### PR TITLE
Implement material-ui components and make theme observable

### DIFF
--- a/src/charts/BaseChart.js
+++ b/src/charts/BaseChart.js
@@ -4,6 +4,7 @@ import {createEl} from "../utilities/Elements.js";
 import SettingsDialog from "../utilities/SettingsDialog";
 import { chartTypes } from "./ChartTypes";
 import DebugJsonDialogReactWrapper from "../react/components/DebugJsonDialogReactWrapper";
+import SettingsDialogReactWrapper from "../react/components/SettingsDialogReactWrapper";
 
 
 class BaseChart{
@@ -605,28 +606,10 @@ class BaseChart{
    
     _openSettingsDialog(e){
         if (!this.settingsDialog) {
-            if (import.meta.env.DEV) {
-                // this.settingsDialog = new SettingsDialogReactWrapper(this);
-                // return;
-            };
-            this.settingsDialog = new SettingsDialog({
-                maxHeight:400,
-                doc:this.__doc__ || document,
-                width:300,
-                title:"Settings",
-                position:[e.pageX,e.pageY],
-                useMobx: this.useMobx,
-                onclose:() => {
-                    this.settingsDialog = null;
-                    this.dialogs.splice(this.dialogs.indexOf(this.settingsDialog), 1);
-                }
-            },this.getSettings());
+            // the dialog will set `this.settingsDialog = null` (and remove itself from this.dialogs) when it closes.
+            this.settingsDialog = new SettingsDialogReactWrapper(this, [e.pageX, e.pageY]);
             this.dialogs.push(this.settingsDialog);
         }
-        //experimenting with making the parent always be contentDiv (not only in fullscreen mode)
-        //doesn't work ATM because of stacking context - may want to review that more generally 
-        //(can be annoying with tooltips...)
-        //this.settingsDialog.setParent(this.contentDiv);
     }
 
   

--- a/src/charts/BaseChart.js
+++ b/src/charts/BaseChart.js
@@ -1,10 +1,10 @@
 import {getRandomString} from "../utilities/Utilities.js";
 import {ContextMenu} from "../utilities/ContextMenu.js";
 import {createEl} from "../utilities/Elements.js";
-import SettingsDialog from "../utilities/SettingsDialog";
 import { chartTypes } from "./ChartTypes";
 import DebugJsonDialogReactWrapper from "../react/components/DebugJsonDialogReactWrapper";
 import SettingsDialogReactWrapper from "../react/components/SettingsDialogReactWrapper";
+import { makeAutoObservable, action } from "mobx";
 
 
 class BaseChart{
@@ -133,22 +133,24 @@ class BaseChart{
         this.legendIcon = this.addMenuIcon("fas fa-info",config.legend || "No description",{size:"medium"});
 
         let oldSize = config.size;
-        this.contentDiv.addEventListener("fullscreenchange", ()=>{
+        this.contentDiv.addEventListener("fullscreenchange", action(()=>{
             //nb, debounced version of setSize also being called by gridstack - doesn't seem to cause any problems
             if (document.fullscreenElement) {
                 if (this.contentDiv !== document.fullscreenElement) console.error('unexpected fullscreen element');
+                this.observable.container = this.contentDiv;
                 const rect = window.screen;
                 this.setSize(rect.width, rect.height);
                 for (const d of this.dialogs) {
                     d.setParent(this.contentDiv);
                 }
             } else {
+                this.observable.container = this.__doc__.body;
                 this.setSize(...oldSize);
                 for (const d of this.dialogs) {
                     d.setParent(null);
                 }
             }
-        });
+        }));
         this.addMenuIcon("fas fa-expand","fullscreen", {
             func: async ()=>{
                 oldSize = this.config.size;
@@ -162,6 +164,10 @@ class BaseChart{
 
         //work out width and height based on container
         this._setDimensions();
+        // provide some observable mobx state for useOuterContainer()
+        this.observable = makeAutoObservable({
+            container: this.__doc__.body
+        });
     }
     dialogs = [];
     _getContentDimensions(){
@@ -679,7 +685,10 @@ class BaseChart{
         //this needs to be reviewed for popout windows
         // - mouse events need to be on the right window ✅
         // - dialogs need to be on the right window ✅ / transferred
+        // - fullscreen... some permutations of dialog behaviour / mouse events on deck are a bit odd
+        //   ^^ that's not a changeBaseDocument() thing, it's a fullscreen thing...
         this.contextMenu.__doc__=doc;
+        action(() => this.observable.container = doc.body)();
         this.__doc__=doc;
         for (const d of this.dialogs){
             // d.close();

--- a/src/charts/ChartManager.js
+++ b/src/charts/ChartManager.js
@@ -49,6 +49,7 @@ import connectIPC from "../utilities/InterProcessCommunication";
 import { addChartLink } from "../links/link_utils";
 import { toPng } from "html-to-image";
 import popoutChart from "@/utilities/Popout";
+import { makeObservable, observable, action } from "mobx";
 
 //order of column data in an array buffer
 //doubles and integers (both represented by float32) and int32 need to be first
@@ -172,6 +173,10 @@ class ChartManager{
         if (listener){
             this.addListener("_default",listener)
         }
+        makeObservable(this, {
+            theme: observable,
+            setTheme: action
+        });
         //we may want to move this, for now I don't think it's doing any harm and avoids changes to multiple index files:
         connectIPC(this);
         this.transactions={};

--- a/src/charts/charts.d.ts
+++ b/src/charts/charts.d.ts
@@ -57,10 +57,16 @@ export type DataSource = {
     regions?: Record<string, any>;
 };
 
-export type DropdownMappedValue<T extends string, V extends string> = { [P in T]: string } & { [P in V]: string };
-export type DropdownMappedValues<T extends string, V extends string> = [
+
+type DropdownMappedValue<T extends string, V extends string> = { [P in T]: string } & { [P in V]: string };
+/** tuple of `[object[], textKey, valueKey]` where `textKey` and `valueKey` are string properties of the object. */
+type DropdownMappedValues<T extends string, V extends string> = [
     Array<DropdownMappedValue<T, V>>, T, V
 ];
+/** `'values'` for a dropdown are either a one-element array (with the element being a string array used for both 'text' and 'value'),
+ * or a tuple of [object[], textKey, valueKey] where `textKey` and `valueKey` are properties of the object that will be used for 'text'
+ * and 'value' respectively.
+ */
 export type DropDownValues = DropdownMappedValues<string, string> | [Array<string>];
 export type GuiValueTypes = { //is the premise of this correct? technically, could we have a dropdown of numbers?
     "dropdown": string;

--- a/src/charts/dialogs/AnnotationDialogReact.tsx
+++ b/src/charts/dialogs/AnnotationDialogReact.tsx
@@ -79,7 +79,7 @@ class AnnotationDialogReact extends BaseDialog {
         this.outer.classList.add('annotationDialog');
         // this.tagModel = new TagModel(dataStore);
         this.tagModel = tagModel;
-        this.root = createMdvPortal(<AnnotationDialogComponent tagModel={this.tagModel} />, this.dialog);
+        this.root = createMdvPortal(<AnnotationDialogComponent tagModel={this.tagModel} />, this.dialog, this);
     }
     close(): void {
         super.close();

--- a/src/charts/dialogs/FileUploadDialogWrapper.tsx
+++ b/src/charts/dialogs/FileUploadDialogWrapper.tsx
@@ -21,7 +21,8 @@ class FileUploadDialogReact extends BaseDialog {
                     onClose={() => this.close()}
                     onResize={(width: number, height: number) => this.resizeDialog(width, height)} // Pass the resize callback
                 />,
-                this.dialog
+                this.dialog,
+                this
             );
         } else {
             console.error("Dialog element not found");

--- a/src/react/components/BaseReactChart.tsx
+++ b/src/react/components/BaseReactChart.tsx
@@ -86,8 +86,8 @@ export abstract class BaseReactChart<T> extends BaseChart implements Chart {
         this.root = createMdvPortal((
             <ChartProvider chart={this}>
                 <ReactComponentFunction />
-            </ChartProvider>                    
-        ), this.reactEl);
+            </ChartProvider>
+        ), this.reactEl, this);
     }
     //todo: implement this
     // getImage(callback: (imgCa: string) => void, type: "svg" | "png" = "png"): void {

--- a/src/react/components/ColorChannelDialogReactWrapper.tsx
+++ b/src/react/components/ColorChannelDialogReactWrapper.tsx
@@ -37,7 +37,7 @@ class ColorDialogReactWrapper extends BaseDialog {
             <ChartProvider chart={parent}>
                 <ColorChannelDialogReact vivStores={parent.vivStores}/>
             </ChartProvider>
-        ), div);
+        ), div, this);
     }
     close() {
         super.close();

--- a/src/react/components/DebugJsonDialogReactWrapper.tsx
+++ b/src/react/components/DebugJsonDialogReactWrapper.tsx
@@ -31,7 +31,7 @@ class DebugChartReactWrapper extends BaseDialog {
         const div = createEl('div', {}, this.dialog);
         this.root = createMdvPortal((
             <DebugChart chart={parent} />
-        ), div);
+        ), div, this);
     }
     close() {
         super.close();

--- a/src/react/components/SettingsDialogComponent.tsx
+++ b/src/react/components/SettingsDialogComponent.tsx
@@ -11,7 +11,6 @@ import {
 } from "@/components/ui/accordion"
 import { v4 as uuid } from 'uuid';
 import { Chip, MenuItem, Select } from "@mui/material";
-// import DropdownSettingsComponent from "./DropdownComponent";
 import Checkbox from '@mui/material/Checkbox';
 import TextField from '@mui/material/TextField';
 import Autocomplete from '@mui/material/Autocomplete';
@@ -81,6 +80,7 @@ function DropdownAutocompleteComponent({ props }: { props: GuiSpec<'dropdown' | 
     // todo review 'virtualization' for large lists 
     const id = useId();
     const multiple = props.type === 'multidropdown';
+    if (!multiple) console.warn('DropdownAutocompleteComoponet with non-multi dropdown is WIP');
     
     // the props.values may be a tuple of [valueObjectArray, textKey, valueKey], or an array of length 1 - [string[]]
     const useObjectKeys = props.values.length === 3;
@@ -222,8 +222,6 @@ const DropdownComponent = ({ props }: { props: GuiSpec<'dropdown' | 'multidropdo
         <>
             <label htmlFor={id}>{props.label}</label>
             <Select
-                // https://github.com/snakesilk/react-fullscreen/issues/44
-                // MenuProps={{container: () => document.getElementById('fullscreen-node')}} //todo maybe a hook to get the fullscreen node or document.body
                 size="small"
                 id={id}
                 multiple={multiple}

--- a/src/react/components/SettingsDialogComponent.tsx
+++ b/src/react/components/SettingsDialogComponent.tsx
@@ -223,7 +223,10 @@ const FolderComponent = ({ props }: { props: GuiSpec<'folder'> }) => {
     ), [props.current_value]);
     if (settings.length === 0) return null;
     return (
-        <Accordion type='single' collapsible className="w-full col-span-2">
+        <Accordion type='single' collapsible className="w-full col-span-2"
+        //expand by default
+        defaultValue={props.label}
+        >
             <AccordionItem value={props.label}>
                 <AccordionTrigger>{props.label}</AccordionTrigger>
                 <AccordionContent>

--- a/src/react/components/SettingsDialogReactWrapper.tsx
+++ b/src/react/components/SettingsDialogReactWrapper.tsx
@@ -36,7 +36,7 @@ class SettingsDialogReactWrapper extends BaseDialog {
         const div = createEl('div', {}, this.dialog);
         this.root = createMdvPortal((
             <SettingsDialog chart={chart} />
-        ), div);
+        ), div, this);
     }
     close() {
         super.close();

--- a/src/react/components/SettingsDialogReactWrapper.tsx
+++ b/src/react/components/SettingsDialogReactWrapper.tsx
@@ -19,13 +19,16 @@ class SettingsDialogReactWrapper extends BaseDialog {
     set root(v) {
         this._root = v;
     }
-    constructor(chart: Chart) {
+    constructor(chart: Chart, position?: [number, number]) {
         // if this is intended to be a drop-in replacement for existing SettingsDialog,
         // it isn't only used by 'charts', but e.g. tracks.
         const name = chart.config.title || `${chart.config.type} ${chart.config.id}`;
-        const config = { //TODO review popout behavior, use `__doc` or whatever here instead of `document` when appropriate
-            width: 500, title: `Settings (${name})`, doc: chart.__doc__ || document,
-            onclose: () => { chart.dialogs.splice(chart.dialogs.indexOf(this), 1) }
+        const config = {
+            width: 500, title: `Settings (${name})`, doc: chart.__doc__ || document, position,
+            onclose: () => { 
+                chart.dialogs.splice(chart.dialogs.indexOf(this), 1);
+                if (chart.settingsDialog === this) chart.settingsDialog = null;
+            }
         };
         super(config, chart);
     }

--- a/src/react/react_utils.tsx
+++ b/src/react/react_utils.tsx
@@ -1,24 +1,33 @@
 import { createRoot } from "react-dom/client";
-import useMediaQuery from '@mui/material/useMediaQuery';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import { type PropsWithChildren, StrictMode, useMemo } from 'react';
 import { ProjectProvider } from "@/modules/ProjectContext";
 import { observer } from "mobx-react-lite";
+import type BaseChart from '@/charts/BaseChart';
+import type { BaseDialog } from '@/utilities/Dialog';
+import { OuterContainerProvider, useOuterContainer } from "./screen_state";
 
-/** This makes sure any material-ui components have an appropriate theme applied.
- * Not clear that we want to use keep using material-ui, but for now it seems not to mix too badly.
+
+/** This makes sure any material-ui components have an appropriate theme applied, including
+ * setting `container` in `defaultProps` of any `<Popper>` and `<Popover>` components 
+ * which should ensure that tooltips / dropdowns etc work correctly without needing to manually
+ * `useOuterContainer`.
  */
 const MaterialWrapper = observer(function MaterialWrapper({ children }: PropsWithChildren) {
-    // todo make this work with user override
-    // const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
     const prefersDarkMode = window.mdv.chartManager.theme === 'dark';
+    const container = useOuterContainer();
+    const defaultProps = useMemo(() => ({ container }), [container]);
 
     const theme = useMemo(() => createTheme({
         palette: {
             mode: prefersDarkMode ? 'dark' : 'light',
         },
-    }), [prefersDarkMode]);
+        components: {
+            MuiPopper: { defaultProps },
+            MuiPopover: { defaultProps },
+        }
+    }), [prefersDarkMode, defaultProps]);
 
     return (
         <ThemeProvider theme={theme}>
@@ -33,16 +42,25 @@ const MaterialWrapper = observer(function MaterialWrapper({ children }: PropsWit
  * It also makes sure that any common global context, styles etc are applied.
  * todo - this is a placeholder for refactoring so that there is a single react root,
  * then charts/dialogs etc will be rendered into it with portals.
+ * 
+ * @param component - the component to render
+ * @param container - the container to render into
+ * @param parent - 'parent' chart or dialog that can be used to determine the container to be used for anything that needs to be rendered outside of the main container.
+ * Currently this will be something that has `{ observable: { container: HTMLElement } }` as a property.
+ * If not provided, the default is document.body.
+ * @returns the root element that was created
  */
-const createMdvPortal = (component: JSX.Element, container: HTMLElement) => {
+const createMdvPortal = (component: JSX.Element, container: HTMLElement, parent?: BaseChart | BaseDialog) => {
     const root = createRoot(container);
     root.render((
         <StrictMode>
-            <MaterialWrapper>
-                <ProjectProvider>
-                    {component}
-                </ProjectProvider>
-            </MaterialWrapper>
+            <OuterContainerProvider parent={parent}>
+                <MaterialWrapper>
+                    <ProjectProvider>
+                        {component}
+                    </ProjectProvider>
+                </MaterialWrapper>
+            </OuterContainerProvider>
         </StrictMode>
     ));
     return root;

--- a/src/react/react_utils.tsx
+++ b/src/react/react_utils.tsx
@@ -2,15 +2,17 @@ import { createRoot } from "react-dom/client";
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
-import { StrictMode, useMemo } from 'react';
+import { type PropsWithChildren, StrictMode, useMemo } from 'react';
 import { ProjectProvider } from "@/modules/ProjectContext";
+import { observer } from "mobx-react-lite";
 
 /** This makes sure any material-ui components have an appropriate theme applied.
  * Not clear that we want to use keep using material-ui, but for now it seems not to mix too badly.
  */
-function MaterialWrapper({ children }) {
+const MaterialWrapper = observer(function MaterialWrapper({ children }: PropsWithChildren) {
     // todo make this work with user override
-    const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
+    // const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
+    const prefersDarkMode = window.mdv.chartManager.theme === 'dark';
 
     const theme = useMemo(() => createTheme({
         palette: {
@@ -25,7 +27,7 @@ function MaterialWrapper({ children }) {
             </CssBaseline>
         </ThemeProvider>
     )
-}
+});
 
 /**
  * It also makes sure that any common global context, styles etc are applied.

--- a/src/react/screen_state.tsx
+++ b/src/react/screen_state.tsx
@@ -1,0 +1,38 @@
+import type BaseChart from '@/charts/BaseChart';
+import type { BaseDialog } from '@/utilities/Dialog';
+import { observer } from 'mobx-react-lite';
+import { createContext, useContext, useEffect, useState } from 'react';
+
+/** All charts and dialogs have this as an `observable` property that can be passed to 
+ * {@link react_utils.createMdvPortal} to allow access to the container they should render things like 
+ * which allows {@link mobx-react-lite.observer} components to {@link useOuterContainer} for access to the container they should render things like
+ * tooltips and dropdowns into.
+*/
+export type OuterContainerObservable = { container: HTMLElement };
+const OuterContainerContext = createContext<Element>(null);
+/**
+ * As of now we only ever use react to render charts & dialogs, and they should be mobx observable
+ * in as much as any `changeBaseDocument()` or `setParent()` will cause this to update...
+ * hopefully the implementation will be easy to change if/when necessary.
+ */
+export const OuterContainerProvider = observer(({ children, parent }: { children: JSX.Element, parent?: BaseChart | BaseDialog }) => {
+    
+    return (
+        <OuterContainerContext.Provider value={ parent?.observable?.container || document.body }>
+            {children}
+        </OuterContainerContext.Provider>
+    );
+});
+/**
+ * This should allow any component that may need knowledge of an outer container to render into
+ * (e.g. for displaying a tooltip or dropdown that may not fit inside that part of DOM).
+ * 
+ * This should consistently provide the right result with any permutation of fullscreen & popout.
+ * 
+ * Specification of how this is implemented subject to change, but it should *always* be valid to call this
+ * from any MDV react component (there may be situations in which it doesn't return anything more useful than `document.body`).
+ */
+export const useOuterContainer = () => {
+    const container = useContext(OuterContainerContext);
+    return container || document.body; //this wasn't getting the right default when leaving fullscreen (d.setParent(null))
+}

--- a/src/utilities/Dialog.js
+++ b/src/utilities/Dialog.js
@@ -1,3 +1,4 @@
+import { action, makeAutoObservable } from "mobx";
 import {createEl,makeResizable,makeDraggable, removeResizable, removeDraggable} from "./Elements.js";
 
 class BaseDialog{
@@ -24,7 +25,7 @@ class BaseDialog{
   * @param {object} content The object passed to the init method
   */
 
-constructor (config,content) {
+  constructor (config,content) {
     config.doc=config.doc || document;
     this.config=config;
     this.buttons={};
@@ -125,22 +126,27 @@ constructor (config,content) {
     this.outer.style.left =`${pos[0]}px`;
     this.outer.style.top =`${pos[1]}px`
     
-
+    // provide some observable mobx state for useOuterContainer()
+    this.observable = makeAutoObservable({
+      container: config.doc.body
+    });
   }
   setParent(parent) {
+    // this.__doc__ = parent || document;
+    action(() => this.observable.container = parent || document.body)();
     // need to makeResizable and makeDraggable work with this
     removeResizable(this.outer);
     removeDraggable(this.outer);
     if (parent) {
       parent.append(this.outer);
       makeResizable(this.outer, {
-        doc: parent.ownerDocument,
+        doc: parent.ownerDocument, //is ownerDocument a safe bet? What if we're fullscreen? then we can't resize anyway.
         onresizeend:(x,y) => {
         this.onResize(x,y)
       }});
       makeDraggable(this.outer, {
         doc: parent.ownerDocument,
-        handle:".ciview-dlg-header"    
+        handle:".ciview-dlg-header"
       });
     } else {
       this.config.doc.body.append(this.outer);
@@ -238,7 +244,7 @@ constructor (config,content) {
         this.outer.style.width = `${x}px`;
         this.outer.style.height = `${y}px`;
     }
-}
+  }
 
 
 }

--- a/src/utilities/Popout.ts
+++ b/src/utilities/Popout.ts
@@ -44,6 +44,9 @@ export default function popoutChart(chart: Chart) {
         chartManager.charts[chart.config.id].win = mainWindow;
         chart.changeBaseDocument(document);
     });
+    mainWindow.addEventListener('unload', () => {
+        popoutWindow.close();
+    });
     return popoutWindow;
 }
 


### PR DESCRIPTION
More use of material-ui components, such as Select and Autocomplete, in the codebase. Use react SettingsDialog by default (apart from in genome tracks).

Also makes the theme observable, allowing for dynamic updates to the material-ui theme to adapt to popout/fullscreen as well as light/dark changes.