### PR TITLE
UI catalog navigation tweaks

### DIFF
--- a/src/catalog/Dashboard.tsx
+++ b/src/catalog/Dashboard.tsx
@@ -68,19 +68,13 @@ const Dashboard: React.FC = () => {
     }, [fetchProjects]);
 
     const handleCreateProject = async () => {
-        // in future we should change the signature of createProject to not need the project name...
-        // mdv_server_app will ignore it anyway... but for now I'm making it so in dev server we can enter the project name with a prompt...
-        const newProjectName = import.meta.env.DEV ? prompt("Enter project name") : "<<UNUSED>>";
-        if (newProjectName.trim()) {
-            try {
-                const newProject = await createProject(newProjectName.trim());
-                // Redirect to the new project page
-                // note that we may not be hosted in the root of the domain, so we should use relative paths
-                window.location.href = `project/${newProject.id}`;
-            } catch (error) {
-                console.error("Failed to create project:", error);
-                alert("Failed to create project. Please try again.");
-            }
+        try {
+            const newProject = await createProject();
+            const base = import.meta.env.DEV ? "http://localhost:5170?dir=/" : "";
+            window.location.href = `${base}project/${newProject.id}`;
+        } catch (error) {
+            console.error("Failed to create project:", error);
+            alert("Failed to create project. Please try again.");
         }
     };
 

--- a/src/catalog/ProjectAccessModal.tsx
+++ b/src/catalog/ProjectAccessModal.tsx
@@ -1,0 +1,96 @@
+import type React from "react";
+import { useState } from "react";
+import {
+    Dialog,
+    DialogTitle,
+    DialogContent,
+    DialogActions,
+    Select,
+    MenuItem,
+    Button,
+    IconButton,
+    FormControl,
+    InputLabel,
+    Box,
+} from "@mui/material";
+import { Close as CloseIcon, Edit as EditIcon } from "@mui/icons-material";
+
+interface ProjectAccessModalProps {
+    id: string;
+    type: "Editable" | "Read-Only";
+    open: boolean;
+    onChangeType: (id: string, newType: "Editable" | "Read-Only") => Promise<void>;
+    onClose: () => void;
+}
+
+const ProjectAccessModal: React.FC<ProjectAccessModalProps> = ({
+    id,
+    type,
+    open,
+    onChangeType,
+    onClose,
+}) => {
+    const [newType, setNewType] = useState(type);
+
+    const handleSave = () => {
+        if (newType !== type) {
+            onChangeType(id, newType);
+        }
+        onClose();
+    };
+
+    return (
+        <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+            <DialogTitle>
+                Edit Project Access Level
+                <IconButton
+                    aria-label="close"
+                    onClick={onClose}
+                    sx={{
+                        position: "absolute",
+                        right: 8,
+                        top: 8,
+                        color: (theme) => theme.palette.grey[500],
+                    }}
+                >
+                    <CloseIcon />
+                </IconButton>
+            </DialogTitle>
+            <DialogContent dividers>
+                <FormControl fullWidth variant="outlined" margin="normal">
+                    <InputLabel>Project Type</InputLabel>
+                    <Select
+                        value={newType}
+                        onChange={(e) =>
+                            setNewType(
+                                e.target.value as "Editable" | "Read-Only",
+                            )
+                        }
+                        label="Project Type"
+                    >
+                        <MenuItem value="Editable">Editable</MenuItem>
+                        <MenuItem value="Read-Only">Read-Only</MenuItem>
+                    </Select>
+                </FormControl>
+            </DialogContent>
+            <DialogActions>
+                <Box
+                    sx={{
+                        display: "flex",
+                        justifyContent: "flex-end",
+                        width: "100%",
+                    }}
+                >
+                    <Button onClick={onClose} color="primary" sx={{ mr: 2 }}>
+                        Cancel
+                    </Button>
+                    <Button onClick={handleSave} color="primary">
+                        Save Changes
+                    </Button>
+                </Box>
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+export default ProjectAccessModal;

--- a/src/catalog/ProjectCard.tsx
+++ b/src/catalog/ProjectCard.tsx
@@ -1,6 +1,7 @@
 import type React from "react";
 import { useEffect, useState } from "react";
 import {
+    DriveFileRenameOutline,
     MoreVert,
     Info,
     Settings,
@@ -21,6 +22,7 @@ import {
 import ProjectInfoModal from "./ProjectInfoModal";
 import ProjectSettingsModal from "./ProjectSettingsModal";
 import ProjectShareModal from "./ProjectShareModal";
+import ProjectRenameModal from "./ProjectRenameModal"
 
 interface ProjectCardProps {
     id: string;
@@ -57,6 +59,7 @@ const ProjectCard: React.FC<ProjectCardProps> = ({
     const [isInfoModalOpen, setIsInfoModalOpen] = useState(false);
     const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false);
     const [isShareModalOpen, setIsShareModalOpen] = useState(false);
+    const [isRenameModalOpen, setisRenameModalOpen] = useState(false);
     const [shouldNavigate, setShouldNavigate] = useState(false);
 
     useEffect(() => {
@@ -175,6 +178,17 @@ const ProjectCard: React.FC<ProjectCardProps> = ({
                 </MenuItem>
                 <MenuItem
                     onClick={() => {
+                        setisRenameModalOpen(true);
+                        handleMenuClose();
+                    }}
+                >
+                    <ListItemIcon>
+                        <DriveFileRenameOutline fontSize="small" />
+                    </ListItemIcon>
+                    <ListItemText>Rename Project</ListItemText>
+                </MenuItem>
+                {/* <MenuItem
+                    onClick={() => {
                         setIsSettingsModalOpen(true);
                         handleMenuClose();
                     }}
@@ -183,7 +197,7 @@ const ProjectCard: React.FC<ProjectCardProps> = ({
                         <Settings fontSize="small" />
                     </ListItemIcon>
                     <ListItemText>Project Settings</ListItemText>
-                </MenuItem>
+                </MenuItem> */}
                 {/* <MenuItem
                     onClick={() => {
                         setIsShareModalOpen(true);
@@ -225,6 +239,14 @@ const ProjectCard: React.FC<ProjectCardProps> = ({
                 onClose={() => setIsShareModalOpen(false)}
                 onAddCollaborator={onAddCollaborator}
                 projectId={id}
+            />
+
+            <ProjectRenameModal
+                id={id}
+                name={name}
+                open={isRenameModalOpen}
+                onRename={onRename}
+                onClose={() => setisRenameModalOpen(false)}
             />
         </Card>
     );

--- a/src/catalog/ProjectCard.tsx
+++ b/src/catalog/ProjectCard.tsx
@@ -184,7 +184,7 @@ const ProjectCard: React.FC<ProjectCardProps> = ({
                     </ListItemIcon>
                     <ListItemText>Project Settings</ListItemText>
                 </MenuItem>
-                <MenuItem
+                {/* <MenuItem
                     onClick={() => {
                         setIsShareModalOpen(true);
                         handleMenuClose();
@@ -194,7 +194,7 @@ const ProjectCard: React.FC<ProjectCardProps> = ({
                         <Share fontSize="small" />
                     </ListItemIcon>
                     <ListItemText>Share Project</ListItemText>
-                </MenuItem>
+                </MenuItem> */}
             </Menu>
 
             <ProjectInfoModal

--- a/src/catalog/ProjectCard.tsx
+++ b/src/catalog/ProjectCard.tsx
@@ -63,8 +63,8 @@ const ProjectCard: React.FC<ProjectCardProps> = ({
     const [isInfoModalOpen, setIsInfoModalOpen] = useState(false);
     const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false);
     const [isShareModalOpen, setIsShareModalOpen] = useState(false);
-    const [isRenameModalOpen, setisRenameModalOpen] = useState(false);
-    const [isDeleteModalOpen, setisDeleteModalOpen] = useState(false);
+    const [isRenameModalOpen, setIsRenameModalOpen] = useState(false);
+    const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
     const [isAccessModalOpen, setIsAccessModalOpen] = useState(false);
     const [shouldNavigate, setShouldNavigate] = useState(false);
 
@@ -184,7 +184,7 @@ const ProjectCard: React.FC<ProjectCardProps> = ({
                 </MenuItem>
                 <MenuItem
                     onClick={() => {
-                        setisRenameModalOpen(true);
+                        setIsRenameModalOpen(true);
                         handleMenuClose();
                     }}
                 >
@@ -195,7 +195,7 @@ const ProjectCard: React.FC<ProjectCardProps> = ({
                 </MenuItem>
                 <MenuItem
                     onClick={() => {
-                        setisDeleteModalOpen(true);
+                        setIsDeleteModalOpen(true);
                         handleMenuClose();
                     }}
                 >
@@ -274,14 +274,14 @@ const ProjectCard: React.FC<ProjectCardProps> = ({
                 name={name}
                 open={isRenameModalOpen}
                 onRename={onRename}
-                onClose={() => setisRenameModalOpen(false)}
+                onClose={() => setIsRenameModalOpen(false)}
             />
 
             <ProjectDeleteModal
                 id={id}
                 open={isDeleteModalOpen}
                 onDelete={onDelete}
-                onClose={() => setisDeleteModalOpen(false)}
+                onClose={() => setIsDeleteModalOpen(false)}
             />
 
             <ProjectAccessModal

--- a/src/catalog/ProjectCard.tsx
+++ b/src/catalog/ProjectCard.tsx
@@ -8,6 +8,7 @@ import {
     Settings,
     Share,
     Image as ImageIcon,
+    LockPerson as LockPersonIcon
 } from "@mui/icons-material";
 import {
     Card,
@@ -25,6 +26,7 @@ import ProjectSettingsModal from "./ProjectSettingsModal";
 import ProjectShareModal from "./ProjectShareModal";
 import ProjectRenameModal from "./ProjectRenameModal"
 import ProjectDeleteModal from "./ProjectDeleteModal"
+import ProjectAccessModal from "./ProjectAccessModal"
 
 interface ProjectCardProps {
     id: string;
@@ -63,6 +65,7 @@ const ProjectCard: React.FC<ProjectCardProps> = ({
     const [isShareModalOpen, setIsShareModalOpen] = useState(false);
     const [isRenameModalOpen, setisRenameModalOpen] = useState(false);
     const [isDeleteModalOpen, setisDeleteModalOpen] = useState(false);
+    const [isAccessModalOpen, setIsAccessModalOpen] = useState(false);
     const [shouldNavigate, setShouldNavigate] = useState(false);
 
     useEffect(() => {
@@ -201,6 +204,17 @@ const ProjectCard: React.FC<ProjectCardProps> = ({
                     </ListItemIcon>
                     <ListItemText>Delete Project</ListItemText>
                 </MenuItem>
+                <MenuItem
+                    onClick={() => {
+                        setIsAccessModalOpen(true);
+                        handleMenuClose();
+                    }}
+                >
+                    <ListItemIcon>
+                        <LockPersonIcon fontSize="small" />
+                    </ListItemIcon>
+                    <ListItemText>Project Access</ListItemText>
+                </MenuItem>
                 {/* <MenuItem
                     onClick={() => {
                         setIsSettingsModalOpen(true);
@@ -268,6 +282,14 @@ const ProjectCard: React.FC<ProjectCardProps> = ({
                 open={isDeleteModalOpen}
                 onDelete={onDelete}
                 onClose={() => setisDeleteModalOpen(false)}
+            />
+
+            <ProjectAccessModal
+                id={id}
+                type={type}
+                open={isAccessModalOpen}
+                onChangeType={onChangeType}
+                onClose={() => setIsAccessModalOpen(false)}
             />
         </Card>
     );

--- a/src/catalog/ProjectCard.tsx
+++ b/src/catalog/ProjectCard.tsx
@@ -1,6 +1,7 @@
 import type React from "react";
 import { useEffect, useState } from "react";
 import {
+    Delete as DeleteIcon,
     DriveFileRenameOutline,
     MoreVert,
     Info,
@@ -23,6 +24,7 @@ import ProjectInfoModal from "./ProjectInfoModal";
 import ProjectSettingsModal from "./ProjectSettingsModal";
 import ProjectShareModal from "./ProjectShareModal";
 import ProjectRenameModal from "./ProjectRenameModal"
+import ProjectDeleteModal from "./ProjectDeleteModal"
 
 interface ProjectCardProps {
     id: string;
@@ -60,6 +62,7 @@ const ProjectCard: React.FC<ProjectCardProps> = ({
     const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false);
     const [isShareModalOpen, setIsShareModalOpen] = useState(false);
     const [isRenameModalOpen, setisRenameModalOpen] = useState(false);
+    const [isDeleteModalOpen, setisDeleteModalOpen] = useState(false);
     const [shouldNavigate, setShouldNavigate] = useState(false);
 
     useEffect(() => {
@@ -187,6 +190,17 @@ const ProjectCard: React.FC<ProjectCardProps> = ({
                     </ListItemIcon>
                     <ListItemText>Rename Project</ListItemText>
                 </MenuItem>
+                <MenuItem
+                    onClick={() => {
+                        setisDeleteModalOpen(true);
+                        handleMenuClose();
+                    }}
+                >
+                    <ListItemIcon>
+                        <DeleteIcon fontSize="small" />
+                    </ListItemIcon>
+                    <ListItemText>Delete Project</ListItemText>
+                </MenuItem>
                 {/* <MenuItem
                     onClick={() => {
                         setIsSettingsModalOpen(true);
@@ -247,6 +261,13 @@ const ProjectCard: React.FC<ProjectCardProps> = ({
                 open={isRenameModalOpen}
                 onRename={onRename}
                 onClose={() => setisRenameModalOpen(false)}
+            />
+
+            <ProjectDeleteModal
+                id={id}
+                open={isDeleteModalOpen}
+                onDelete={onDelete}
+                onClose={() => setisDeleteModalOpen(false)}
             />
         </Card>
     );

--- a/src/catalog/ProjectDeleteModal.tsx
+++ b/src/catalog/ProjectDeleteModal.tsx
@@ -1,0 +1,75 @@
+import type React from "react";
+import {
+    Dialog,
+    DialogTitle,
+    DialogContent,
+    DialogActions,
+    Button,
+    IconButton,
+    Box,
+    Typography,
+} from "@mui/material";
+import { Close as CloseIcon, Edit as EditIcon } from "@mui/icons-material";
+
+interface ProjectDeleteModalProps {
+    id: string;
+    open: boolean;
+    onDelete: (id: string) => Promise<void>;
+    onClose: () => void;
+}
+
+const ProjectDeleteModal: React.FC<ProjectDeleteModalProps> = ({
+    id,
+    open,
+    onDelete,
+    onClose,
+}) => {
+    const handleDelete = async () => {
+        await onDelete(id);
+        onClose();
+    };
+
+    return (
+        <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+            <DialogTitle>
+                Delete Project
+                <IconButton
+                    aria-label="close"
+                    onClick={onClose}
+                    sx={{
+                        position: "absolute",
+                        right: 8,
+                        top: 8,
+                        color: (theme) => theme.palette.grey[500],
+                    }}
+                >
+                    <CloseIcon />
+                </IconButton>
+            </DialogTitle>
+            <DialogContent dividers>
+                <Typography variant="body1" align="center">
+                    Are you sure you want to permanently <strong>delete this project</strong>? 
+                    This action is <strong>irreversible</strong> and cannot be <strong>undone</strong>.
+                </Typography>
+            </DialogContent>
+            <DialogActions>
+                <Box
+                    sx={{
+                        display: "flex",
+                        justifyContent: "flex-end",
+                        width: "100%",
+                    }}
+                >
+                    <Button onClick={onClose} color="primary" sx={{ mr: 2 }}>
+                        Cancel
+                    </Button>
+                    <Button onClick={handleDelete} color="error">
+                        Delete Project
+                    </Button>
+                </Box>
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+export default ProjectDeleteModal;

--- a/src/catalog/ProjectRenameModal.tsx
+++ b/src/catalog/ProjectRenameModal.tsx
@@ -86,6 +86,9 @@ const ProjectRenameModal: React.FC<ProjectRenameModalProps> = ({
                         width: "100%",
                     }}
                 >
+                    <Button onClick={onClose} color="primary" sx={{ mr: 2 }}>
+                        Cancel
+                    </Button>
                     <Button onClick={handleSave} color="primary">
                         Save Changes
                     </Button>

--- a/src/catalog/ProjectRenameModal.tsx
+++ b/src/catalog/ProjectRenameModal.tsx
@@ -1,0 +1,98 @@
+import type React from "react";
+import { useState } from "react";
+import {
+    Dialog,
+    DialogTitle,
+    DialogContent,
+    DialogActions,
+    TextField,
+    Button,
+    IconButton,
+    Box,
+} from "@mui/material";
+import { Close as CloseIcon, Edit as EditIcon } from "@mui/icons-material";
+
+interface ProjectRenameModalProps {
+    id: string;
+    name: string;
+    open: boolean;
+    onRename: (id: string, newName: string) => Promise<void>;
+    onClose: () => void;
+}
+
+const ProjectRenameModal: React.FC<ProjectRenameModalProps> = ({
+    id,
+    name,
+    open,
+    onRename,
+    onClose,
+}) => {
+    const [newName, setNewName] = useState(name);
+    const [isEditingName, setIsEditingName] = useState(false);
+
+    const handleSave = () => {
+        if (newName !== name) {
+            onRename(id, newName);
+        }
+        onClose();
+    };
+
+    const toggleEditName = () => {
+        setIsEditingName((prev) => !prev);
+    };
+
+    return (
+        <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+            <DialogTitle>
+                Rename Project
+                <IconButton
+                    aria-label="close"
+                    onClick={onClose}
+                    sx={{
+                        position: "absolute",
+                        right: 8,
+                        top: 8,
+                        color: (theme) => theme.palette.grey[500],
+                    }}
+                >
+                    <CloseIcon />
+                </IconButton>
+            </DialogTitle>
+            <DialogContent dividers>
+                <Box sx={{ mb: 2 }}>
+                    <TextField
+                        label="Project Name"
+                        value={newName}
+                        onChange={(e) => setNewName(e.target.value)}
+                        fullWidth
+                        variant="outlined"
+                        margin="normal"
+                        InputProps={{
+                            readOnly: !isEditingName,
+                            endAdornment: (
+                                <IconButton onClick={toggleEditName} edge="end">
+                                    <EditIcon />
+                                </IconButton>
+                            ),
+                        }}
+                    />
+                </Box>
+            </DialogContent>
+            <DialogActions>
+                <Box
+                    sx={{
+                        display: "flex",
+                        justifyContent: "flex-end",
+                        width: "100%",
+                    }}
+                >
+                    <Button onClick={handleSave} color="primary">
+                        Save Changes
+                    </Button>
+                </Box>
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+export default ProjectRenameModal;

--- a/src/charts/ChartManager.js
+++ b/src/charts/ChartManager.js
@@ -227,6 +227,24 @@ class ChartManager {
 
         createEl("span", { classes: ["mdv-divider"] }, this.menuBar);
 
+        
+        const homeButton = createMenuIcon(
+            "fas fa-home",
+            {
+                tooltip: {
+                    text: "Back to Catalog",
+                    position: "bottom-right",
+                },
+                func: () => {
+                    const state = this.getState();
+                    this._callListeners("state_saved", state);
+                    window.location.href = `${window.location.origin}/catalog_dev`;
+                },
+            },
+            this.menuBar,
+        );
+        homeButton.style.marginRight = "20px";
+
         if (config.all_views) {
             this.viewSelect = createEl(
                 "select",


### PR DESCRIPTION
Changes on this PR:
- The settings menu has been replaced with three separate modal menus, each handling one of the functionalities previously available in the settings menu:
    - Rename Menu
    - Delete Menu
    - Change Project Access Menu
- A home button has been added to the top-left corner of the project view, allowing users to return to the catalog view.
- The create new project button has been updated with new backend calls and a refined flow. The Dashboard now correctly utilizes the createProject method from the related custom hook. Users are immediately redirected to the new project without needing to provide a name first.