### PR TITLE
Updated chart.css for consistency between ciview-chart-panel definitions

### DIFF
--- a/src/charts/css/charts.css
+++ b/src/charts/css/charts.css
@@ -135,7 +135,7 @@ select, input, textarea {
 }
 
 .grid-stack  .ciview-chart-panel {
-    box-shadow: none;
+    box-shadow: 0 0 1em var(--shadow_color);
     /* nb changing box-sizing,  adjusted width in _getContentDimensions()...
     otherwise VolumeView was overflowing.
     Left 'overflow: hidden' for now anyway.


### PR DESCRIPTION
In this issue, when creating a new chart, the CSS definition of ciview-chart-panel was being overridden, causing shadows on all charts within the chart panel to be removed. I have included a tweak to the CSS definition to ensure consistency in how shadows are applied, so they remain visible when new charts are created.