### PR TITLE
Interactive histogram in Selection Dialog

### DIFF
--- a/src/react/components/SelectionDialogComponent.tsx
+++ b/src/react/components/SelectionDialogComponent.tsx
@@ -331,7 +331,7 @@ const useBrushX = (ref: React.RefObject<SVGSVGElement>, {value, setValue, minMax
     }, [ref, handleMouseMove, handleMouseUp, getX, setValue, minMax, lowFraction, highFraction, doc.addEventListener]);
 }
 const Histogram = observer((props: RangeProps) => {
-    const { histogram: data, lowFraction, highFraction, queryHistogram } = props;
+    const { histogram: data, lowFraction, highFraction, queryHistogram, value } = props;
     const ref = useRef<SVGSVGElement>(null);
     useBrushX(ref, props);
     const prefersDarkMode = window.mdv.chartManager.theme === "dark";
@@ -426,6 +426,7 @@ const Histogram = observer((props: RangeProps) => {
                 opacity={0.5}
             />
         </svg>
+        <p className="flex justify-between"><em>{`${value[0].toFixed(2)}<`}</em> <em>{`<${value[1].toFixed(2)}`}</em></p>
         </>
     );
 });

--- a/src/react/components/SelectionDialogComponent.tsx
+++ b/src/react/components/SelectionDialogComponent.tsx
@@ -260,7 +260,7 @@ const useBrushX = (ref: React.RefObject<SVGSVGElement>, {value, setValue, minMax
     const doc = useOuterContainer();
     const getX = useCallback((e: { clientX: number }) => {
         const { width, left } = ref.current.getBoundingClientRect();
-        const normalizedX = (e.clientX - left) / width;
+        const normalizedX = Math.min(1, Math.max(0, (e.clientX - left) / width));
         const [min, max] = minMax;
         return min + normalizedX * (max - min);
     }, [minMax, ref.current]); //not sure we should need ref.current here... biome says.

--- a/src/react/screen_state.tsx
+++ b/src/react/screen_state.tsx
@@ -9,7 +9,7 @@ import { createContext, useContext, useEffect, useState } from "react";
  * tooltips and dropdowns into.
  */
 export type OuterContainerObservable = { container: HTMLElement };
-const OuterContainerContext = createContext<Element>(null);
+const OuterContainerContext = createContext<HTMLElement>(null);
 /**
  * As of now we only ever use react to render charts & dialogs, and they should be mobx observable
  * in as much as any `changeBaseDocument()` or `setParent()` will cause this to update...


### PR DESCRIPTION
Histogram component is larger, with the previous sliders & text-input no longer shown.

Behaviour is somewhat similar to `brushX` from `d3` as used in `HistogramChart` - user can drag the two ends of the range, dragging in the middle portion moves the range, dragging from outside sets a new range.

There is also a change to the return type of `useOuterContainer` from `Element` to `HTMLElement` so that it is compatible with mouse event listeners.