### PR TITLE
File upload UI h5 support

### DIFF
--- a/src/charts/dialogs/FileUploadDialog.tsx
+++ b/src/charts/dialogs/FileUploadDialog.tsx
@@ -30,6 +30,8 @@ import { DatasourceDropdown } from "./DatasourceDropdown";
 import CloudUploadIcon from "@mui/icons-material/CloudUpload";
 import { Dialog, Paper } from "@mui/material";
 import { isArray } from "@/lib/utils";
+import processH5File from "./utils/h5Processing";
+import H5MetadataPreview from "./H5MetadataPreview";
 
 // Use dynamic import for the worker
 const DatasourceWorker = new Worker(new URL("./datasourceWorker.ts", import.meta.url), {
@@ -235,7 +237,8 @@ const DatasourceNameInput = ({ value, onChange, isDisabled }) => (
 
 type UploadActionType = "SET_SELECTED_FILES" | "SET_IS_UPLOADING" 
 | "SET_IS_INSERTING" | "SET_SUCCESS" | "SET_ERROR" | "SET_IS_VALIDATING" 
-| "SET_VALIDATION_RESULT" | "SET_FILE_TYPE" | "SET_TIFF_METADATA" | "SET_FILE_SUMMARY";
+| "SET_VALIDATION_RESULT" | "SET_FILE_TYPE" | "SET_TIFF_METADATA"
+| "SET_H5_METADATA" | "SET_FILE_SUMMARY";
 // Reducer function
 const DEFAULT_REDUCER_STATE = {
     selectedFiles: [] as File[],
@@ -245,8 +248,9 @@ const DEFAULT_REDUCER_STATE = {
     validationResult: null as unknown,
     success: false,
     error: null as unknown,
-    fileType: null as "csv" | "tiff" | "tsv" | null,
+    fileType: null as "csv" | "tiff" | "tsv" | "h5" | null,
     tiffMetadata: null as unknown,
+    h5Metadata: null as H5Metadata | unknown,
 } as const;
 type ReducerState = typeof DEFAULT_REDUCER_STATE;
 // TODO - would be good to type this, this is not how I should be spending my weekend.
@@ -282,6 +286,8 @@ const reducer = <T extends UploadActionType,>(state: ReducerState, action: { typ
             return { ...state, fileType: action.payload };
         case "SET_TIFF_METADATA":
             return { ...state, tiffMetadata: action.payload };
+        case "SET_H5_METADATA":
+            return { ...state, h5Metadata: action.payload };
         default:
             return state;
     }
@@ -347,8 +353,26 @@ const FILE_TYPES: Record<string, FileTypeConfig> = {
             requiresMetadata: true,
             endpoint: 'add_or_update_image_datasource'
         }
+    },
+    H5: {
+        type: 'h5',
+        extensions: ['.h5', '.h5ad'],
+        mimeTypes: ['application/x-hdf5', 'application/x-hdf'],
+        maxSize: 10000 * 1024 * 1024,
+        processingConfig: {
+            defaultWidth: 1000,
+            defaultHeight: 800,
+            requiresMetadata: true,
+            endpoint: 'add_anndata'
+        }
     }
 };
+
+interface H5Metadata {
+    uns: Record<string, any>;
+    obs: Record<string, any>;
+    var: Record<string, any>;
+}
 
 // Helper functions for file type checking
 const getFileTypeFromExtension = (fileName: string): FileTypeConfig | null => {
@@ -445,7 +469,7 @@ const FileUploadDialogComponent: React.FC<FileUploadDialogComponentProps> = obse
     const { progress, resetProgress, setProgress } = useFileUploadProgress();
 
     const onDrop = useCallback(
-        (acceptedFiles: File[]) => {
+        async (acceptedFiles: File[]) => {
             if (acceptedFiles.length > 0) {
                 const file = acceptedFiles[0];
                 const fileConfig = getFileTypeFromExtension(file.name);
@@ -556,6 +580,34 @@ const FileUploadDialogComponent: React.FC<FileUploadDialogComponentProps> = obse
                             type: "SET_VALIDATION_RESULT",
                             payload: { columnNames, columnTypes },
                         });
+                        break;
+                    }
+
+                    case 'h5': {
+                        try {
+                            const h5Metadata = await processH5File(file);
+                            dispatch({ type: "SET_H5_METADATA", payload: h5Metadata });
+                            
+                            const newDatasourceName = file.name;
+                            setDatasourceName(newDatasourceName);
+                            
+                            onResize(fileConfig.processingConfig.defaultWidth, fileConfig.processingConfig.defaultHeight);
+                            dispatch({ type: "SET_IS_VALIDATING", payload: false });
+                            dispatch({
+                                type: "SET_VALIDATION_RESULT",
+                                payload: { metadata: h5Metadata }
+                            });
+                        } catch (error) {
+                            console.error('H5 processing error:', error);
+                            dispatch({
+                                type: "SET_ERROR",
+                                payload: {
+                                    message: "Error processing H5 file",
+                                    traceback: error instanceof Error ? error.message : String(error),
+                                },
+                            });
+                            dispatch({ type: "SET_IS_VALIDATING", payload: false });
+                        }
                         break;
                     }
     
@@ -789,7 +841,10 @@ const FileUploadDialogComponent: React.FC<FileUploadDialogComponentProps> = obse
                         }
                     }
                     break;
-            }
+                case 'h5':
+                    // Payload content depends on backend implementation
+                    break;
+        }
 
             const response = await axios.post(
                 `${root}/${fileConfig.processingConfig.endpoint}`,
@@ -1032,6 +1087,36 @@ const FileUploadDialogComponent: React.FC<FileUploadDialogComponentProps> = obse
                                         </div>
                                     </div>
                                 </div>
+                            </div>
+                        </>
+                    )}
+
+                    {state.fileType === "h5" && state.h5Metadata && (
+                        <>
+                            <FileSummary>
+                                <FileSummaryHeading>H5 File Summary</FileSummaryHeading>
+                                <FileSummaryText>
+                                    <strong>File name:</strong> {state.selectedFiles[0].name}
+                                </FileSummaryText>
+                                <FileSummaryText>
+                                    <strong>File size:</strong> {(state.selectedFiles[0].size / (1024 * 1024)).toFixed(2)} MB
+                                </FileSummaryText>
+                            </FileSummary>
+                            
+                            <H5MetadataPreview metadata={state.h5Metadata} />
+
+                            <div className="flex justify-center items-center gap-6 mt-4">
+                                <Button marginTop="mt-1" onClick={handleUploadClick}>
+                                    Upload
+                                </Button>
+                                <Button
+                                    color="red"
+                                    size="px-6 py-2.5"
+                                    marginTop="mt-1"
+                                    onClick={handleClose}
+                                >
+                                    Cancel
+                                </Button>
                             </div>
                         </>
                     )}

--- a/src/charts/dialogs/H5JsonViewer.tsx
+++ b/src/charts/dialogs/H5JsonViewer.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+import DebugJsonDialogComponent from '@/react/components/DebugJsonDialogComponent';
+
+interface JsonViewerProps {
+  data: Record<string, any>;
+  title?: string;
+  initiallyExpanded?: boolean;
+  maxHeight?: string;
+}
+
+const H5JsonViewer = ({ 
+  data, 
+  title, 
+  initiallyExpanded = false,
+  maxHeight = "max-h-96"
+}: JsonViewerProps) => {
+  const [isExpanded, setIsExpanded] = useState(initiallyExpanded);
+
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700">
+      {title && (
+        <div 
+          className="flex items-center p-3 cursor-pointer border-b border-gray-200 dark:border-gray-700"
+          onClick={() => setIsExpanded(!isExpanded)}
+        >
+          <h3 className="text-sm font-medium">{title}</h3>
+        </div>
+      )}
+      {isExpanded && (
+        <div className={`overflow-auto ${maxHeight}`}>
+          <DebugJsonDialogComponent json={data} header={undefined} />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default H5JsonViewer;

--- a/src/charts/dialogs/H5MetadataPreview.tsx
+++ b/src/charts/dialogs/H5MetadataPreview.tsx
@@ -1,0 +1,126 @@
+import { Box, Typography, Grid, Paper } from '@mui/material';
+import H5JsonViewer from './H5JsonViewer';
+
+interface H5MetadataPreviewProps {
+  metadata: {
+    uns: Record<string, any>;
+    obs: Record<string, any>;
+    var: Record<string, any>;
+  };
+}
+
+const H5MetadataPreview = ({ metadata }: H5MetadataPreviewProps) => {
+  return (
+    <Box sx={{ width: '100%', px: 2 }}>
+      <Paper 
+        elevation={4}
+        sx={{ 
+          overflowX: 'auto',
+          border: '1px solid',
+          borderColor: 'var(--main_panel_color)',
+          position: 'relative'  // Added to establish stacking context
+        }}
+      >
+        <Paper
+          elevation={1}
+          sx={{
+            position: 'sticky',
+            zIndex: 1,
+            borderColor: 'var(--main_panel_color)',
+          }}
+        >
+          <Typography 
+            variant="h6" 
+            sx={{ 
+              p: 2, 
+              textAlign: 'center',
+              backgroundColor: 'var(--background_color)'
+            }}
+          >
+            H5 File Metadata
+          </Typography>
+        </Paper>
+        
+        <Box sx={{ 
+          minWidth: 'fit-content',
+          maxWidth: '100%',
+          p: 2,
+          backgroundColor: 'var(--primary_background)',
+          position: 'relative',  // For proper stacking
+          zIndex: 0  // Below the header
+        }}>
+          <Grid 
+            container 
+            spacing={2}
+            sx={{
+              flexWrap: 'nowrap',
+              width: 'auto'
+            }}
+          >
+            <Grid item sx={{ minWidth: '350px' }}>
+              <Paper 
+                elevation={0} 
+                sx={{ 
+                  p: 2,
+                  backgroundColor: 'white',
+                  height: '100%',
+                  overflowX: 'auto',
+                  border: '1px solid',
+                  borderColor: 'rgb(209, 213, 219)'
+                }}
+              >
+                <H5JsonViewer
+                  data={metadata.uns}
+                  title="Unstructured Data (uns)"
+                  initiallyExpanded={true}
+                />
+              </Paper>
+            </Grid>
+
+            <Grid item sx={{ minWidth: '350px' }}>
+              <Paper 
+                elevation={0} 
+                sx={{ 
+                  p: 2,
+                  backgroundColor: 'white',
+                  height: '100%',
+                  overflowX: 'auto',
+                  border: '1px solid',
+                  borderColor: 'rgb(209, 213, 219)'
+                }}
+              >
+                <H5JsonViewer
+                  data={metadata.obs}
+                  title="Observation Data (obs)"
+                  initiallyExpanded={true}
+                />
+              </Paper>
+            </Grid>
+
+            <Grid item sx={{ minWidth: '350px' }}>
+              <Paper 
+                elevation={0} 
+                sx={{ 
+                  p: 2,
+                  backgroundColor: 'white',
+                  height: '100%',
+                  overflowX: 'auto',
+                  border: '1px solid',
+                  borderColor: 'rgb(209, 213, 219)'
+                }}
+              >
+                <H5JsonViewer
+                  data={metadata.var}
+                  title="Variable Data (var)"
+                  initiallyExpanded={true}
+                />
+              </Paper>
+            </Grid>
+          </Grid>
+        </Box>
+      </Paper>
+    </Box>
+  );
+};
+
+export default H5MetadataPreview;

--- a/src/charts/dialogs/utils/h5Processing.ts
+++ b/src/charts/dialogs/utils/h5Processing.ts
@@ -1,0 +1,251 @@
+import * as hdf5 from 'h5wasm';
+
+type GroupName = keyof H5Metadata;
+type H5DataType = number | string | boolean;
+type DatasetValue = H5DataType[] | null;
+type TypedArray = Int8Array | Uint8Array | Int16Array | Uint16Array | Int32Array | Uint32Array | Float32Array | Float64Array | BigInt64Array | BigUint64Array;
+
+interface H5Metadata {
+  uns: Record<string, DatasetValue>;
+  obs: Record<string, DatasetValue>;
+  var: Record<string, DatasetValue>;
+}
+
+interface ProcessOptions {
+  onProgress?: (progress: number) => void;
+  chunkSize?: number;
+  memoryThreshold?: number;
+}
+
+interface H5Entity {
+  close: () => void;
+}
+
+interface H5Dataset extends H5Entity {
+  shape: number[];
+  value: TypedArray | H5DataType[];
+}
+
+interface ProgressTracker {
+  current: number;
+  weight: number;
+  onProgress?: (progress: number) => void;
+}
+
+const CHUNK_SIZES = {
+  SMALL: 1024,
+  MEDIUM: 4096,
+  LARGE: 16384
+} as const;
+
+const getOptimalChunkSize = (dataSize: number): number => {
+  if (dataSize < 1e6) return CHUNK_SIZES.SMALL;
+  if (dataSize < 1e8) return CHUNK_SIZES.MEDIUM;
+  return CHUNK_SIZES.LARGE;
+};
+
+interface ExtendedPerformance extends Performance {
+  memory?: {
+    usedJSHeapSize: number;
+    jsHeapSizeLimit: number;
+  };
+}
+
+const checkMemoryUsage = (threshold: number): void => {
+  const performance = window.performance as ExtendedPerformance;
+  if (performance?.memory) {
+    const usage = performance.memory.usedJSHeapSize / performance.memory.jsHeapSizeLimit;
+    if (usage > threshold) {
+      throw new Error(`Memory usage exceeded threshold: ${Math.round(usage * 100)}%`);
+    }
+  }
+};
+
+const withErrorContext = <T>(
+  operation: () => Promise<T>,
+  context: string
+): Promise<T> => {
+  return operation().catch(error => {
+    throw new Error(`${context}: ${error.message}`);
+  });
+};
+
+const isCloseable = (entity: unknown): entity is H5Entity => {
+  return typeof entity === 'object' && 
+         entity !== null && 
+         'close' in entity && 
+         typeof (entity as any).close === 'function';
+};
+
+const readDatasetChunked = async (
+  dataset: H5Dataset,
+  chunkSize: number,
+  tracker?: ProgressTracker
+): Promise<DatasetValue> => {
+  return withErrorContext(async () => {
+    if (!dataset.shape || dataset.shape.length === 0) {
+      return coerceToDatasetValue(dataset.value);
+    }
+
+    const value = dataset.value;
+    
+    if (value instanceof BigInt64Array || value instanceof BigUint64Array) {
+      const result = Array.from(value).map(Number);
+      tracker?.onProgress?.(1);
+      return result;
+    }
+    
+    if (ArrayBuffer.isView(value)) {
+      const result = Array.from(new Float64Array(value.buffer));
+      tracker?.onProgress?.(1);
+      return result;
+    }
+    
+    return coerceToDatasetValue(value);
+  }, 'Failed to read dataset');
+};
+
+function coerceToDatasetValue(value: unknown): DatasetValue {
+  if (Array.isArray(value) && value.every(item => 
+    typeof item === 'number' || 
+    typeof item === 'string' || 
+    typeof item === 'boolean'
+  )) {
+    return value as DatasetValue;
+  }
+  return null;
+}
+
+const cleanup = async (
+  entities: H5Entity[], 
+  virtualPath?: string, 
+  FS?: typeof hdf5.FS
+): Promise<void> => {
+  return withErrorContext(async () => {
+    const errors: Error[] = [];
+
+    for (const entity of entities) {
+      try {
+        entity.close();
+      } catch (error) {
+        errors.push(new Error(`Failed to close entity: ${error}`));
+      }
+    }
+
+    if (virtualPath && FS) {
+      try {
+        FS.unlink(virtualPath);
+      } catch (error) {
+        errors.push(new Error(`Failed to clean up virtual file: ${error}`));
+      }
+    }
+
+    if (errors.length > 0) {
+      throw new Error(`Cleanup failed: ${errors.join(', ')}`);
+    }
+  }, 'Cleanup failed');
+};
+
+const processH5File = async (
+  file: File, 
+  options: ProcessOptions = {}
+): Promise<H5Metadata> => {
+  const {
+    onProgress,
+    memoryThreshold = 0.8
+  } = options;
+
+  const chunkSize = getOptimalChunkSize(file.size);
+  const entities: H5Entity[] = [];
+  const virtualPath = '/uploaded.h5';
+  
+  try {
+    await hdf5.ready;
+    const FS = await hdf5.FS;
+    
+    if (!FS) {
+      throw new Error('Failed to initialize h5wasm filesystem');
+    }
+
+    const arrayBuffer = await file.arrayBuffer();
+    const uint8Array = new Uint8Array(arrayBuffer);
+    FS.writeFile(virtualPath, uint8Array);
+    
+    const h5File = new hdf5.File(virtualPath, 'r');
+    entities.push(h5File);
+
+    const metadata: H5Metadata = {
+      uns: {},
+      obs: {},
+      var: {},
+    };
+
+    const readGroup = async (
+      groupName: GroupName,
+      target: Record<string, DatasetValue>,
+      tracker: ProgressTracker
+    ): Promise<void> => {
+      return withErrorContext(async () => {
+        const groupEntity = h5File.get(groupName);
+        if (!groupEntity) return;
+
+        if (isCloseable(groupEntity)) {
+          entities.push(groupEntity);
+        }
+
+        if (!(groupEntity instanceof hdf5.Group)) {
+          throw new Error(`${groupName} is not a group`);
+        }
+
+        const keys = Array.from(groupEntity.keys());
+        const keyProgress = 1 / keys.length;
+        
+        await Promise.all(keys.map(async (key, index) => {
+          if (typeof key !== 'string') return;
+
+          checkMemoryUsage(memoryThreshold);
+
+          const dataset = groupEntity.get(key);
+          if (!dataset || !(dataset instanceof hdf5.Dataset)) return;
+
+          if (isCloseable(dataset)) {
+            entities.push(dataset);
+          }
+          
+          const datasetTracker: ProgressTracker = {
+            current: tracker.current + (index * keyProgress),
+            weight: keyProgress,
+            onProgress: tracker.onProgress
+          };
+          
+          target[key] = await readDatasetChunked(
+            dataset as unknown as H5Dataset,
+            chunkSize,
+            datasetTracker
+          );
+        }));
+      }, `Failed to read group ${groupName}`);
+    };
+
+    const progressTrackers = {
+      uns: { current: 0, weight: 0.33, onProgress },
+      obs: { current: 0.33, weight: 0.33, onProgress },
+      var: { current: 0.66, weight: 0.34, onProgress }
+    };
+
+    await Promise.all([
+      readGroup('uns', metadata.uns, progressTrackers.uns),
+      readGroup('obs', metadata.obs, progressTrackers.obs),
+      readGroup('var', metadata.var, progressTrackers.var)
+    ]);
+
+    onProgress?.(1);
+    return metadata;
+  } catch (error) {
+    throw new Error(`Failed to process H5 file: ${error}`);
+  } finally {
+    await cleanup(entities, virtualPath, await hdf5.FS);
+  }
+};
+
+export default processH5File;

--- a/src/react/components/DebugJsonDialogComponent.tsx
+++ b/src/react/components/DebugJsonDialogComponent.tsx
@@ -5,6 +5,7 @@ import "react18-json-view/src/style.css";
 import "react18-json-view/src/dark.css";
 import { useMemo, useState } from "react";
 import { useDebounce } from "use-debounce";
+import "../../utilities/css/JsonDialogStyles.css";
 
 type JSONObject = { [key: string]: any };
 
@@ -65,16 +66,25 @@ export default function ({ json, header }: { json: any; header?: string }) {
         () => filterJSON(json, debouncedFilter),
         [json, debouncedFilter]
     );
+
     return (
-        <div className="max-h-[90vh] overflow-auto">
-            {header && <h2>{header}</h2>}
+        <div className="max-h-[90vh] overflow-auto p-4">
+            {header && <h2 className="text-lg font-semibold mb-4">{header}</h2>}
             <input
                 type="text"
                 value={filter}
                 onChange={(e) => setFilter(e.target.value)}
                 placeholder="Filter..."
+                className="w-full mb-4 p-2 border rounded-md dark:bg-gray-700 dark:border-gray-600"
             />
-            <JsonView src={filteredJson} />
+            <JsonView 
+                src={filteredJson} 
+                style={{
+                    backgroundColor: 'transparent',
+                    fontSize: '0.875rem',
+                    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace'
+                }}
+            />
         </div>
     );
 }

--- a/src/utilities/css/JsonDialogStyles.css
+++ b/src/utilities/css/JsonDialogStyles.css
@@ -1,0 +1,51 @@
+.json-view {
+    font-size: 1.0rem;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    color: #d4d4d4;
+    background-color: #1e1e1e;
+    --json-property: #569cd6;
+    --json-string: #ce9178;
+    --json-number: #b5cea8;
+    --json-boolean: #d16969;
+    --json-null: #808080;
+  }
+  
+  .json-view .json-view--property { 
+    color: var(--json-property); 
+  }
+  
+  .json-view .json-view--string { 
+    color: var(--json-string); 
+  }
+  
+  .json-view .json-view--number { 
+    color: var(--json-number); 
+  }
+  
+  .json-view .json-view--boolean { 
+    color: var(--json-boolean); 
+  }
+  
+  .json-view .json-view--null { 
+    color: var(--json-null); 
+  }
+  
+  .json-view .json-view--line:hover {
+    background-color: #2d2d2d;
+  }
+  
+  @media (prefers-color-scheme: light) {
+    .json-view {
+      color: #333333;
+      background-color: #ffffff;
+      --json-property: #007acc;
+      --json-string: #a31515;
+      --json-number: #098658;
+      --json-boolean: #d16969;
+      --json-null: #646464;
+    }
+  
+    .json-view .json-view--line:hover {
+      background-color: #f0f0f0;
+    }
+  }


### PR DESCRIPTION
This update adds support for processing .`h5 `and `.h5ad` AnnData files in the FileUpload component. Testing was conducted using the PBMC3k data HDF5 file, as described in the feature requirements. The module was built using the `h5wasm `library and processes the AnnData file by extracting three key groups within the HDF5 structure: `uns `(unstructured data), `obs `(observations), and `var `(variables). It uses a virtual filesystem to load the file, and datasets are read in chunks to prevent memory overload. The implementation includes a simple memory check to prevent crashes and optimizes chunk sizes automatically based on file size. Additionally, a cleanup system ensures all resources are properly released to avoid potential memory leaks.

As discussed, the module now utilizes the `DebugJsonDialogComponent `for JSON visualization. I’ve included updates to improve the visibility and legibility of the displayed JSON files. A custom color scheme, defined in `JsonDialogStyles.css,` now aligns with Visual Studio Code’s themes for both light and dark modes. 

For the frontend implementation, the module currently sends a POST request containing the AnnData file to a temporary backend endpoint `add_anndata`. Space has been left open for the backend implementation.