### PR TITLE
devcontainer/Dockerfile changes for local development

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,8 +7,10 @@
         "vscode": {
             "extensions": [
                 "ms-python.python",
-                "ms-azuretools.vscode-docker"
+                "ms-azuretools.vscode-docker",
+                "biomejs.biome"
             ]
         }
-    }
+    },
+    "postCreateCommand": "npm run dev"
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,25 +4,7 @@
 # not sure if there's a way of pinning a more specific build of the base image. May want to see if we can reproduce this issue outside of docker.
 FROM nikolaik/python-nodejs:python3.12-nodejs20 AS frontend-builder
 
-# Set the working directory inside the container
-WORKDIR /app
-
-# Copy the entire project to the working directory
-COPY . .
-
-
-## Install npm dependencies & start dev server (should only happen in dev - but other yml configs won't expose the port)
-RUN npm install
-# RUN npm run dev # run manually in container
-
-## Run the npm build script for Flask and Vite
-RUN npm run build-flask-dockerjs
-
-# RUN ln -s /app/python/dist_hotfix /app/dist
-
-# bootstrap project folder - this won't be necessary in future
-#RUN mkdir -p /app/mdv/pbmc3k /app/mdv/pbmc3k_project2
-
+# this layer will change less frequently than the others, so it's good to have it first
 # Install HDF5 library, for some reason poetry can't install it in this context as of now
 # see https://github.com/h5py/h5py/issues/2146 for similar-ish issue
 RUN apt-get update && apt-get install -y libhdf5-dev || (cat /var/log/apt/term.log && exit 1)
@@ -30,9 +12,40 @@ RUN apt-get install -y netcat-openbsd || (cat /var/log/apt/term.log && exit 1)
 RUN apt-get install -y telnet || (cat /var/log/apt/term.log && exit 1)
 RUN apt-get install -y iputils-ping || (cat /var/log/apt/term.log && exit 1)
 
-#RUN pip install gunicorn
 # Install Python dependencies using Poetry
+# this should be early in the process because it's less likely to change
+WORKDIR /app
+# copy poetry files first to cache the install step
+COPY python/pyproject.toml ./python/
+COPY python/poetry.lock ./python/
 WORKDIR /app/python
+# trouble with this is that it doesn't have the mdvtools code yet...
+# still worth installing heavy dependencies here
+RUN poetry install --with dev,backend 
+
+WORKDIR /app
+# copy the package.json and package-lock.json as a separate step so npm install can be cached
+COPY package*.json ./
+## Install npm dependencies
+RUN npm install
+
+
+# Copy the entire project to the working directory
+COPY . .
+
+
+# & start dev server (should only happen in dev - but other yml configs won't expose the port)
+# RUN npm run dev # run manually in container
+
+## Run the npm build script for Flask and Vite
+# this will often change, so it's good to have it last... doesn't seem to be cached
+RUN npm run build-flask-dockerjs
+
+
+WORKDIR /app/python
+# installing again so we have mdvtools as a module, on top of the previous install layer with dependencies
+# this step should be very fast
+# if we don't have this, the server itself runs, but anything that doesn't run from this workdir will fail to import mdvtools
 RUN poetry install --with dev,backend 
 
 # Expose the port that Flask will run on

--- a/docker-secrets.yml
+++ b/docker-secrets.yml
@@ -14,6 +14,8 @@ services:
       - /app/node_modules/
       - ~/mdv:/app/mdv
       - ./app_logs:/app/logs
+      - ~/.gitconfig:/root/.gitconfig:ro  # Mount your global Git config as read-only
+      - ~/.ssh:/root/.ssh:ro  # Mount your SSH keys as read-only
     environment:
       - FLASK_ENV=production  # Set environment to production
       - PYTHONUNBUFFERED=1  


### PR DESCRIPTION
Dockerfile has been re-arranged so that the layer cache can avoid repeated install of python/node dependencies etc. when rebuilding image.

In future, we may make the version for deployment combine `npm install \ build \ rm node_modules` in a single step so that the layer doesn't need to include `node_modules`.

Vite dev-server is started as a `postCreateCommand`.