### PR TITLE
Tweaks to Dockerfile, deploy action and devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,8 @@
                 "ms-python.python",
                 "ms-azuretools.vscode-docker",
                 "biomejs.biome",
-                "ms-toolsai.jupyter"
+                "ms-toolsai.jupyter",
+                "github.vscode-github-actions"
             ]
         }
     }

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,16 +10,10 @@ on:
   push:
     branches:
       - dev
-    # testing with all dev pushes triggering the workflow - including this one.
-    # paths-ignore:
-    #   - '**.github/workflows/**' # Ignore changes to workflow files
-    # this was highlighted as an error:
-    # if: "contains(github.event.head_commit.message, '[deploy]')"
 
 jobs:
   build-and-push:
-    # testing with all dev pushes triggering the workflow - including this one.
-    # if: ${{ github.event.pull_request.merged || contains(github.event.head_commit.message, '[deploy]') }} # Only run for PR merge or push with "[deploy]"
+    if: ${{ github.event.pull_request.merged || contains(github.event.head_commit.message, '[deploy]') }} # Only run for PR merge or push with "[deploy]"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,16 @@ WORKDIR /app/python
 RUN poetry config virtualenvs.create false
 # trouble with this is that it doesn't have the mdvtools code yet...
 # still worth installing heavy dependencies here
-RUN poetry install --with dev,backend 
+# BUT - 
+#16 20.81 Installing the current project: mdvtools (0.0.1)
+#16 20.81 
+#16 20.81 Warning: The current project could not be installed: [Errno 2] No such file or directory: '/app/python/README.md'
+#16 20.81 If you do not want to install the current project use --no-root.
+#16 20.81 If you want to use Poetry only for dependency management but not for packaging, you can disable package mode by setting package-mode = false in your pyproject.toml file.
+#16 20.81 In a future version of Poetry this warning will become an error!
+# seems to be ok to first install with --no-root for dependencies, then install the root package later
+# we don't want to set package-mode = false in pyproject.toml
+RUN poetry install --with dev,backend --no-root
 
 WORKDIR /app
 # copy the package.json and package-lock.json as a separate step so npm install can be cached


### PR DESCRIPTION
This PR should re-instate the previous logic for triggering the action to rebuild container in dockerhub - but with an `on: pull_request: if: ...` that was showing as an error removed.

The "Github Actions" extension that highlighted this error in `deploy.yml` has been added to the devcontainer configuration.

There was also a warning in the initial

```
RUN poetry install --with dev,backend
```

which occurs when only `pyproject.toml` and `dependencies.lock` have been added to the Python folder.

```
#16 20.81 Installing the current project: mdvtools (0.0.1)
#16 20.81 
#16 20.81 Warning: The current project could not be installed: [Errno 2] No such file or directory: '/app/python/README.md'
#16 20.81 If you do not want to install the current project use --no-root.
#16 20.81 If you want to use Poetry only for dependency management but not for packaging, you can disable package mode by setting package-mode = false in your pyproject.toml file.
#16 20.81 In a future version of Poetry this warning will become an error!
# seems to be ok to first install with --no-root for dependencies, then install the root package later
# we don't want to set package-mode = false in pyproject.toml
```

We work-around this by adding a `--no-root` flag, which seems reasonable but may be subject to review.