### PR TITLE
Don't make devcontainer mount ~/mdv multiple times

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,6 +15,10 @@
         }
     },
     "postStartCommand": "git config --global --add safe.directory /app"
+    //Note: when setting up a new user's development environment, first we had to install
+    // a new WSL distro to clone the code into. Then we had some strange behaviour when
+    // first building the container, not sure how to reproduce it as it got resolved itself.
+    
     //"postCreateCommand": "npm run dev"
     //running a command that doesn't return will cause other issues
     //subsequent devcontainer steps like copying .gitconfig end up not happening...

--- a/docker-secrets.yml
+++ b/docker-secrets.yml
@@ -6,7 +6,7 @@ services:
     # image: jayeshire/mdv-frontend:latest
     ports:
       - "5055:5055"
-      - "5170:5170"
+      # - "5170:5170" # vscode will automatically forward locally opened ports
     volumes:
       # https://stackoverflow.com/questions/29181032/add-a-volume-to-docker-but-exclude-a-sub-folder
       - .:/app

--- a/docker-secrets.yml
+++ b/docker-secrets.yml
@@ -13,8 +13,7 @@ services:
       - /app/venv/
       - /app/node_modules/
       - /app/dist/
-      - ~/mdv:/app/mdv
-      - ~/mdv:/root/mdv # XXX: so that scripts referring to '~/mdv/...' work - may still be issues with db integration etc...
+      - ~/mdv:/root/mdv # no longer using /app/mdv - multiple volumes pointing to the same directory seems to cause issues
       - ./app_logs:/app/logs
       # - ~/data:/app/data # thinking about allowing symlinked data folder...
     environment:

--- a/docker/docker-compose-stack.yml
+++ b/docker/docker-compose-stack.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - "5055:5055"
     volumes:
-      - mdv-data:/app/mdv 
+      - mdv-data:/root/mdv 
     depends_on:
       - mdv_db
     secrets:

--- a/python/mdvtools/dbutils/config.json
+++ b/python/mdvtools/dbutils/config.json
@@ -3,5 +3,5 @@
   "db_container": "mdv_db",
   "db_track_modifications": false,
   "upload_folder": "/python",
-  "projects_base_dir": "/app/mdv"
+  "projects_base_dir": "/root/mdv"
 }


### PR DESCRIPTION
I had added a `volumes` entry in `docker-secrets.yml` (used for configuring local development environment), so that certain scripts and tests using the `~/mdv` convention for project paths would still be able to work in this environment.

I suspect that by having both

```
- ~/mdv:/app/mdv
- ~/mdv:/root/mdv
```

it was leading to files being corrupted.

As such, I have changed the configuration to use `/root/mdv` in the container more consistently. In order for the `mdv_server_app.py` to work, this just required a simple change of `python/mdvtools/config.json` - **however** I'm pretty sure that other places where the container is used will require an equivalent change to their configuration that is not under source control in this repo.

If this is the case, we should review that, as while it should be easy to change the configuration if necessary in order to work with this particular change, it means that it may create friction in general to rollback to different versions / bisect issues etc.