### PR TITLE
Selection Dialog improvements

### DIFF
--- a/src/react/components/SelectionDialogComponent.tsx
+++ b/src/react/components/SelectionDialogComponent.tsx
@@ -590,7 +590,7 @@ const SelectionDialogComponent = () => {
     const cols = useParamColumnsExperimental();
     useResetButton();
     return (
-        <div className="p-3 absolute w-[100%] h-[100%] overflow-auto">
+        <div className="p-3 absolute w-[100%] h-[100%] overflow-x-hidden overflow-y-auto">
             {cols.map((col) => <AbstractComponent key={col.field} column={col} />)}
             <AddRowComponent />
             <ForeignRows />

--- a/src/react/components/SelectionDialogComponent.tsx
+++ b/src/react/components/SelectionDialogComponent.tsx
@@ -20,6 +20,8 @@ import type RangeDimension from "@/datastore/RangeDimension";
 import { useDebounce } from "use-debounce";
 import { useHighlightedForeignRowsAsColumns, useRowsAsColumnsLinks } from "../chartLinkHooks";
 import * as d3 from 'd3';
+import { ErrorBoundary } from "react-error-boundary";
+import ErrorDisplay from "@/charts/dialogs/ErrorDisplay";
 
 const icon = <CheckBoxOutlineBlankIcon fontSize="small" />;
 const checkedIcon = <CheckBoxIcon fontSize="small" />;
@@ -341,6 +343,7 @@ const useBrushX = (
         const svg = d3.select(ref.current);
 
         if (!v) {
+            // throw new Error("this is actually ok, but I want to test the error handling");
             //@ts-ignore life is too short
             svg.select(".brush").call(brushRef.current.move, null);
             return;
@@ -519,7 +522,11 @@ const AbstractComponent = observer(function AbstractComponent<K extends DataType
                 </div>
             </AccordionSummary>
             <AccordionDetails>
-                <Component column={column} />
+                <ErrorBoundary FallbackComponent={
+                    ({ error }) => <ErrorDisplay error={error} title="Unexpected Error: please report to developers." />
+                    }>
+                    <Component column={column} />
+                </ErrorBoundary>
             </AccordionDetails>
         </Accordion>
     );

--- a/src/react/components/SelectionDialogComponent.tsx
+++ b/src/react/components/SelectionDialogComponent.tsx
@@ -463,7 +463,6 @@ const AbstractComponent = observer(function AbstractComponent<K extends DataType
     const f = filters[column.field];
     // todo: what about category filters with empty array?
     const hasFilter = (f !== null);
-    const [defaultExpanded] = useState(hasFilter);
     const [isHovered, setIsHovered] = useState(false);
     const clearFilter = useCallback(
         action((e: MouseEvent) => {
@@ -482,7 +481,7 @@ const AbstractComponent = observer(function AbstractComponent<K extends DataType
         console.log('Delete item');
     }, [filters, column.field, config]);
     return (
-        <Accordion defaultExpanded={defaultExpanded}
+        <Accordion defaultExpanded={true}
             onMouseEnter={() => setIsHovered(true)}
             onMouseLeave={() => setIsHovered(false)}
         >

--- a/src/react/components/SelectionDialogComponent.tsx
+++ b/src/react/components/SelectionDialogComponent.tsx
@@ -337,7 +337,7 @@ const useBrushX = (
         if (!brushRef.current || !ref.current) return;
         const svg = d3.select(ref.current);
 
-        if (v === null) {
+        if (!v) {
             //@ts-ignore life is too short
             svg.select(".brush").call(brushRef.current.move, null);
             return;


### PR DESCRIPTION
There was an issue with how we explicitly tested for `=== null` in `useBrushX`'s `setBrushValue`, which could cause it to fail in circumstances such as when linked "foreign rows" are highlighted.

The way in which this failed was unhelpful; any such internal error lead to the entire chart being blank.

We now use an `<ErrorBoundary>` around the internal content the component for each `param` rendered in the interface and display a nicer error to the user.

Other changes are to make the accordion elements for each of these components be expanded by default, and hiding the unwanted horizontal scroll-bar at the bottom of the chart.