### PR TITLE
File upload UI AnnData Datasource Merging

### DIFF
--- a/python/mdvtools/conversions.py
+++ b/python/mdvtools/conversions.py
@@ -8,36 +8,78 @@ from .mdvproject import MDVProject
 import numpy as np
 import json
 import gzip
-
+import copy
 
 def convert_scanpy_to_mdv(
-    folder: str, scanpy_object: AnnData, max_dims=3, delete_existing=False
+    folder: str, scanpy_object: AnnData, max_dims=3, delete_existing=False, label=""
 ) -> MDVProject:
     mdv = MDVProject(folder, delete_existing=delete_existing)
+    
+    # If not deleting existing, preserve current state and views
+    current_state = None
+    current_views = None
+    if not delete_existing:
+        current_state = mdv.state
+        current_views = mdv.views
 
-    # create datasources 'cells'
+    # create datasource 'cells'
     cell_table = scanpy_object.obs
     cell_table["cell_id"] = cell_table.index
     # add any dimension reduction
     _add_dims(cell_table, scanpy_object.obsm, max_dims)
-    mdv.add_datasource("cells", cell_table)
+    mdv.add_datasource(f"{label}cells", cell_table)
 
-    # create two datasources 'genes'
+    # create datasource 'genes'
     gene_table = scanpy_object.var
-    gene_table["name"] = gene_table.index
+    gene_table[f"{label}name"] = gene_table.index
     _add_dims(gene_table, scanpy_object.varm, max_dims)
-    mdv.add_datasource("genes", gene_table)
+    mdv.add_datasource(f"{label}genes", gene_table)
 
     # link the two datasets
-    mdv.add_rows_as_columns_link("cells", "genes", "name", "Gene Expr")
+    mdv.add_rows_as_columns_link(f"{label}cells", f"{label}genes", f"{label}name", "Gene Expr")
 
     # add the gene expression
     mdv.add_rows_as_columns_subgroup(
-        "cells", "genes", "gs", scanpy_object.X, name="gene_scores", label="Gene Scores"
+        f"{label}cells", f"{label}genes", "gs", scanpy_object.X, name="gene_scores", label="Gene Scores"
     )
 
-    # create a default view
-    mdv.set_view("default", {"initialCharts": {"cells": [], "genes": []}}, True)
+    if delete_existing:
+        # If we're deleting existing, create new default view
+        mdv.set_view("default", {"initialCharts": {"cells": [], "genes": []}}, True)
+    else:
+        # If we're not deleting existing, update existing views with new datasources
+        new_views = {}
+        for view_name, view_data in current_views.items():
+            new_view_data = copy.deepcopy(view_data)
+            
+            # Initialize new charts if they don't exist
+            if "initialCharts" not in new_view_data:
+                new_view_data["initialCharts"] = {}
+            
+            # Add new datasources to initialCharts
+            new_view_data["initialCharts"][f"{label}cells"] = []
+            new_view_data["initialCharts"][f"{label}genes"] = []
+            
+            # Initialize dataSources if they don't exist
+            if "dataSources" not in new_view_data:
+                new_view_data["dataSources"] = {}
+            
+            # Add new datasources with panel widths
+            new_view_data["dataSources"][f"{label}cells"] = {"panelWidth": 50}
+            new_view_data["dataSources"][f"{label}genes"] = {"panelWidth": 50}
+            
+            new_views[view_name] = new_view_data
+        
+        # Save updated views
+        mdv.views = new_views
+        
+        # Restore state
+        if current_state:
+            new_state = mdv.state
+            new_state["permission"] = current_state.get("permission", "edit")
+            new_state["all_views"] = current_state.get("all_views", ["default"])
+            mdv.state = new_state
+
     return mdv
 
 

--- a/python/mdvtools/mdvproject.py
+++ b/python/mdvtools/mdvproject.py
@@ -153,6 +153,15 @@ class MDVProject:
         all_cols = set([x["field"] for x in md["columns"]])
         return [x for x in columns if x not in all_cols]
 
+    def get_datasource_names(self) -> list[str]:
+        """
+        Get a list of all datasource names in the project.
+        
+        Returns:
+            list[str]: A list of datasource names
+        """
+        return [ds["name"] for ds in self.datasources]
+    
     def set_interactions(
         self,
         interaction_ds: str,

--- a/python/mdvtools/project_router.py
+++ b/python/mdvtools/project_router.py
@@ -16,9 +16,9 @@ class ProjectBlueprint:
     @staticmethod
     def register_app(app: Flask) -> None:
         @app.route(
-            "/project/<project_id>/", defaults={"subpath": ""}, methods=["GET", "POST"]
+            "/project/<project_id>/", defaults={"subpath": ""}, methods=["GET", "POST", "PATCH"]
         )
-        @app.route("/project/<project_id>/<path:subpath>/", methods=["GET", "POST"])
+        @app.route("/project/<project_id>/<path:subpath>/", methods=["GET", "POST", "PATCH"])
         #incorporated below to resolve issue related to redirecting the request to http
         #@app.route("/project/<project_id>", defaults={'subpath': ''}, methods=["GET", "POST"])
         def project_route(project_id: str, subpath: str):
@@ -89,9 +89,9 @@ class ProjectBlueprint_v2:
     @staticmethod
     def register_app(app: Flask) -> None:
         @app.route(
-            "/project/<project_id>/", defaults={"subpath": ""}, methods=["GET", "POST"]
+            "/project/<project_id>/", defaults={"subpath": ""}, methods=["GET", "POST", "PATCH"]
         )
-        @app.route("/project/<project_id>/<path:subpath>/", methods=["GET", "POST"])
+        @app.route("/project/<project_id>/<path:subpath>/", methods=["GET", "POST", "PATCH"])
         #incorporated below to resolve issue related to redirecting the request to http
         #@app.route("/project/<project_id>", defaults={'subpath': ''}, methods=["GET", "POST"])
         def project_route(project_id: str, subpath: str):

--- a/python/mdvtools/server.py
+++ b/python/mdvtools/server.py
@@ -366,7 +366,7 @@ def create_app(
 
             new_anndata.write(os.path.join(project.dir, "anndata.h5ad"))
             cleanup_folder(temp_folder)
-            return jsonify({'status': 'success', 'message': 'File replaced successfully'}), 200
+            return jsonify({'status': 'success', 'message': 'File merged successfully'}), 200
 
         except ValueError as ve:
             current_app.logger.error(f"Label generation error: {str(ve)}")

--- a/src/charts/dialogs/AnndataConflictDialog.tsx
+++ b/src/charts/dialogs/AnndataConflictDialog.tsx
@@ -1,0 +1,92 @@
+import MergeTypeIcon from "@mui/icons-material/MergeType";
+import {
+    Alert,
+    Box,
+    Button,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogTitle,
+    Paper,
+    Typography,
+} from "@mui/material";
+import type React from "react";
+
+interface AnndataConflictDialogProps {
+    open: boolean;
+    onClose: () => void;
+    onConfirm: () => void;
+}
+
+const AnndataConflictDialog: React.FC<AnndataConflictDialogProps> = ({
+    open,
+    onClose,
+    onConfirm,
+}) => {
+    return (
+        <Dialog
+            open={open}
+            onClose={onClose}
+            PaperComponent={Paper}
+            maxWidth="sm"
+            fullWidth
+            PaperProps={{
+                elevation: 24,
+                className: "rounded-lg",
+            }}
+        >
+            <DialogTitle className="flex items-center gap-3 bg-blue-50 dark:bg-blue-900 border-b px-6 py-4">
+                <Typography
+                    variant="h6"
+                    component="span"
+                    className="font-semibold"
+                >
+                    Existing AnnData File Found
+                </Typography>
+            </DialogTitle>
+
+            <DialogContent className="p-6">
+                <Box className="space-y-4 mt-4">
+                    <Typography variant="body1">
+                        An AnnData file, along with its datasources, already
+                        exists in this project. If you choose to add a new
+                        AnnData file, all datasources will automatically be
+                        assigned unique prefixes to prevent naming conflicts:
+                    </Typography>
+
+                    <Box className="bg-gray-50 dark:bg-gray-900 p-4 rounded-md font-mono text-sm">
+                        <div>existing_cells → A_cells</div>
+                        <div>new_cells → B_cells</div>
+                    </Box>
+
+                    <Alert severity="info" className="mt-4">
+                        This will preserve your existing data while adding the
+                        new sources.
+                    </Alert>
+                </Box>
+            </DialogContent>
+
+            <DialogActions className="bg-gray-50 dark:bg-gray-900 border-t p-4 gap-2">
+                <Button
+                    onClick={onClose}
+                    variant="outlined"
+                    color="inherit"
+                    className="hover:bg-gray-100 dark:hover:bg-gray-800"
+                >
+                    Cancel
+                </Button>
+                <Button
+                    onClick={onConfirm}
+                    variant="contained"
+                    color="primary"
+                    className="bg-blue-600 hover:bg-blue-700"
+                    autoFocus
+                >
+                    Combine Sources
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+export default AnndataConflictDialog;


### PR DESCRIPTION
- This branch introduces a system for handling AnnData file uploads. When an existing AnnData file is detected in the project, the user is presented with a dialog allowing them to either cancel the upload or proceed by adding the new datasources on top of the existing ones. 

- This system implements the label scheme where datasources with identical names are assigned sequential labels to avoid conflicts. For example:
existing_cells → A_cells
new_cells → B_cells

- This feature utilizes temporary server-side storage, which eliminates the need for users to upload the file twice during the merging process. 

- Two endpoints have been implemented:
   - add_anndata: Accepts POST requests for the initial file upload.
   - combine_anndata: Accepts PATCH requests for handling user decisions, such as canceling the upload or merging the datasources.

- A new dialog window, AnndataConflictDialog, has been implemented to guide the user through the process. 
