### PR TITLE
Basic "Add view" dialog name validation

### DIFF
--- a/src/charts/ChartManager.js
+++ b/src/charts/ChartManager.js
@@ -1026,6 +1026,9 @@ class ChartManager {
                 type: "text",
                 id: "name",
                 label: "name",
+                // todo have some better reusability for this kind of validation
+                // (also probably refactor this dialog into react)
+                validate: (v) => !this.viewSelect.childNodes.values().some(e => e.value === v),
             },
         ];
         if (this.dataSources.length > 1) {

--- a/src/charts/ChartManager.js
+++ b/src/charts/ChartManager.js
@@ -1028,6 +1028,8 @@ class ChartManager {
                 label: "name",
                 // todo have some better reusability for this kind of validation
                 // (also probably refactor this dialog into react)
+                // considered returning a string to set a tooltip or something, parked that idea for now pending more thought/refactoring
+                // validate: (v) => this.viewSelect.childNodes.values().some(e => e.value === v) ? "Name already exists" : null,
                 validate: (v) => !this.viewSelect.childNodes.values().some(e => e.value === v),
             },
         ];

--- a/src/charts/css/charts.css
+++ b/src/charts/css/charts.css
@@ -423,3 +423,7 @@ select, input, textarea {
     bottom: 0 !important;
     right: 0 !important;
 }
+.invalid {
+    background-color: var(--background_color_error);
+    color: var(--text_color_error);
+}

--- a/src/charts/dialogs/CustomDialog.js
+++ b/src/charts/dialogs/CustomDialog.js
@@ -241,6 +241,16 @@ class CustomDialog extends BaseDialog {
         this.controls[s.id] = ch;
     }
 
+    /**
+     * Create a text input field
+     * @param {object} s - settings object
+     * @param {string} s.id - id of the control
+     * @param {string} s.defaultValue - default value (optional)
+     * @param {function} s.validate - function to validate the input (optional).
+     *  current implementation will check strict equality with true to determine if the input is valid,
+     *  returning a boolean. This value will be used to add or remove the 'invalid' class from the input field.
+     *  We may want to change this to allow for more complex behavior in the future (i.e. give the user some information).
+     */
     text(s, d) {
         const v = s.defaultValue || "";
         const t = createEl(

--- a/src/charts/dialogs/CustomDialog.js
+++ b/src/charts/dialogs/CustomDialog.js
@@ -254,6 +254,14 @@ class CustomDialog extends BaseDialog {
         this.controlValues[s.id] = v;
         t.addEventListener("keyup", () => {
             this.controlValues[s.id] = t.value;
+            if (s.validate) {
+                const valid = s.validate(t.value);
+                if (valid === true) {
+                    t.classList.remove("invalid");
+                } else {
+                    t.classList.add("invalid");
+                }
+            }
         });
         this.controls[s.id] = t;
     }


### PR DESCRIPTION
It is possible to add new views with a name which already exists...

This leads to the project state as represented to the user being inconsistent, and also will mean that the previous view will be quietly overwritten without warning.

This PR partially addresses the issue, in that as the user enters the view name, if there is a clash it will highlight the input element as a hint to them that this could be a problem.