### PR TITLE
File upload UI h5 visibility improvements

### DIFF
--- a/src/charts/css/charts.css
+++ b/src/charts/css/charts.css
@@ -4,6 +4,7 @@
         --main_panel_color: black;
         --text_color: white;
         --background_color: #f5f5f5;
+        --fade_background_color: rgba(245, 245, 245, 0.4);
         --menu_bar_color: #D6D8DB;
         --border_menu_bar_color: #c9c9c9;
         --primary_background: #ecf0f1;
@@ -23,6 +24,7 @@
         --main_panel_color: #f1f1f1;
         --text_color: black;
         --background_color: #f5f5f5;
+        --fade_background_color: rgba(245, 245, 245, 0.4);
         --menu_bar_color: #D6D8DB;
         --border_menu_bar_color: #c9c9c9;
         --primary_background: #ecf0f1;
@@ -42,6 +44,7 @@
     --main_panel_color: black;
     --text_color: white;
     --background_color: #252525;
+    --fade_background_color: rgba(37, 37, 37, 0.4);
     --menu_bar_color: #404040;
     --border_menu_bar_color: #727272;
     --primary_background: #353536;
@@ -59,6 +62,7 @@
     --main_panel_color: #f1f1f1;
     --text_color: black;
     --background_color: #f5f5f5;
+    --fade_background_color: rgba(245, 245, 245, 0.4);
     --menu_bar_color: #D6D8DB;
     --primary_background: #ecf0f1;
     --shadow_color: #888;

--- a/src/charts/dialogs/AnndataConflictDialog.tsx
+++ b/src/charts/dialogs/AnndataConflictDialog.tsx
@@ -60,11 +60,16 @@ const AnndataConflictDialog: React.FC<AnndataConflictDialogProps> = ({
             open={open}
             onClose={onClose}
             PaperComponent={Paper}
-            maxWidth="sm"
-            fullWidth
+            hideBackdrop={true}
             PaperProps={{
                 elevation: 24,
                 className: "rounded-lg",
+            }}
+            sx={{
+                pointerEvents: "none",
+                "& .MuiPaper-root": {
+                    pointerEvents: "auto",
+                },
             }}
         >
             <DialogTitle className="flex items-center gap-3 bg-blue-50 dark:bg-blue-900 border-b px-6 py-4">

--- a/src/charts/dialogs/ErrorDisplay.tsx
+++ b/src/charts/dialogs/ErrorDisplay.tsx
@@ -44,7 +44,7 @@ const ErrorDisplay = ({
     };
 
     return (
-        <div style={{ maxWidth: 800, margin: "20px auto", width: "90%" }}>
+        <div style={{ maxWidth: 800, minWidth: 500, margin: "20px auto", width: "90%" }}>
             <Paper
                 elevation={3}
                 sx={{
@@ -54,7 +54,13 @@ const ErrorDisplay = ({
             >
                 <Alert
                     severity="error"
-                    icon={<ErrorIcon />}
+                    icon={
+                        <ErrorIcon sx={{ 
+                            fontSize: 25, 
+                            color: "red",
+                            marginTop: "1px", 
+                        }} />
+                    }
                     sx={{
                         "& .MuiAlert-message": {
                             width: "100%",
@@ -98,61 +104,63 @@ const ErrorDisplay = ({
                     </AlertTitle>
 
                     <div style={{ marginTop: "12px" }}>
-                        <p
-                            style={{
-                                margin: "0 0 12px 0",
-                                lineHeight: "1.5",
-                                color: "var(--text_color_error)",
-                                whiteSpace: "pre-wrap",
-                                wordBreak: "break-word",
-                            }}
-                        >
+                    <p
+                        style={{
+                            margin: "0 0 12px 0",
+                            lineHeight: "1.6",
+                            padding: "4px 8px",
+                            color: "var(--text_color_error)",
+                            whiteSpace: "pre-wrap",
+                            wordBreak: "break-word",
+                        }}
+                    >
                             {error.message}
                         </p>
 
                         {error.traceback && (
                             <div>
-                                <IconButton
-                                    size="small"
-                                    onClick={() => setExpanded(!expanded)}
-                                    sx={{
-                                        mb: 1,
-                                        fontSize: "0.875rem",
-                                        display: "flex",
-                                        alignItems: "center",
-                                        gap: "4px",
-                                        color: "var(--icon_color_error)",
-                                        "&:hover": {
-                                            backgroundColor:
-                                                "var(--background_color)",
-                                        },
-                                    }}
-                                >
-                                    {expanded ? <ExpandLess /> : <ExpandMore />}
+                            <IconButton
+                                size="medium"
+                                onClick={() => setExpanded(!expanded)}
+                                sx={{
+                                    mb: 1,
+                                    fontSize: "0.875rem",
+                                    display: "flex",
+                                    alignItems: "center",
+                                    justifyContent: "center",
+                                    padding: "6px 12px",
+                                    borderRadius: "6px",
+                                    color: "var(--icon_color_error)",
+                                    "&:hover": {
+                                        backgroundColor: "var(--background_color_hover)",
+                                    },
+                                }}
+                            >
+                                {expanded ? <ExpandLess /> : <ExpandMore />}
+                                <span style={{ marginLeft: "6px" }}>
                                     {expanded ? "Hide Details" : "Show Details"}
-                                </IconButton>
+                                </span>
+                            </IconButton>
 
                                 <Collapse in={expanded}>
-                                    <pre
-                                        style={{
-                                            backgroundColor:
-                                                "var(--background_color)",
-                                            padding: "16px",
-                                            borderRadius: "4px",
-                                            margin: 0,
-                                            maxHeight: "400px",
-                                            overflowY: "auto",
-                                            overflowX: "hidden",
-                                            fontSize: "0.875rem",
-                                            lineHeight: 1.5,
-                                            fontFamily:
-                                                "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
-                                            border: "1px solid var(--input_border_color)",
-                                            whiteSpace: "pre-wrap",
-                                            wordBreak: "break-word",
-                                            color: "var(--text_color)",
-                                        }}
-                                    >
+                                <pre
+                                    style={{
+                                        backgroundColor: "var(--background_color)",
+                                        padding: "16px",
+                                        borderRadius: "6px",
+                                        margin: "8px 0 0 0",
+                                        maxHeight: "400px",
+                                        overflowY: "auto",
+                                        overflowX: "auto",
+                                        fontSize: "0.9rem",
+                                        lineHeight: "1.5",
+                                        fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+                                        border: "1px solid var(--input_border_color)",
+                                        whiteSpace: "pre-wrap",
+                                        wordBreak: "break-word",
+                                        color: "var(--text_color)",
+                                    }}
+                                >
                                         {error.traceback}
                                     </pre>
                                 </Collapse>

--- a/src/charts/dialogs/FileUploadDialog.tsx
+++ b/src/charts/dialogs/FileUploadDialog.tsx
@@ -960,6 +960,32 @@ const FileUploadDialogComponent: React.FC<FileUploadDialogComponentProps> = obse
         }
     };
 
+    const displayUploadDialog = async () => {
+        if (state.error) {
+            dispatch({ type: "SET_SELECTED_FILES", payload: [] });
+            dispatch({ type: "SET_IS_UPLOADING", payload: false });
+            dispatch({ type: "SET_IS_INSERTING", payload: false });
+            dispatch({ type: "SET_SUCCESS", payload: false });
+            dispatch({ type: "SET_ERROR", payload: null });
+            dispatch({ type: "SET_IS_VALIDATING", payload: false });
+            dispatch({ type: "SET_VALIDATION_RESULT", payload: null });
+            dispatch({ type: "SET_FILE_TYPE", payload: null });
+            dispatch({ type: "SET_TIFF_METADATA", payload: null });
+            dispatch({ type: "SET_H5_METADATA", payload: null });
+            dispatch({ type: "SET_CONFLICT_DATA", payload: null });
+            dispatch({ type: "SET_SHOW_CONFLICT_DIALOG", payload: false });
+            setDatasourceName("");
+            setDatasourceSummary({
+                datasourceName: "",
+                fileName: "",
+                fileSize: "",
+                rowCount: 0,
+                columnCount: 0,
+            });
+            return;
+        }
+    };
+
     const handleCombineCancel = async () => {
         if (!state.conflictData) return;
 
@@ -1034,7 +1060,25 @@ const FileUploadDialogComponent: React.FC<FileUploadDialogComponentProps> = obse
                     </Button>
                 </>
             ) : state.error ? (
-                <ErrorDisplay error={state.error} />
+                <>
+                    <ErrorDisplay error={state.error} />
+                    <div className="flex justify-center items-center gap-6">
+                        <Button
+                            marginTop="mt-1"
+                            onClick={displayUploadDialog}
+                        >
+                            Upload Another File
+                        </Button>
+                        <Button
+                            color="red"
+                            size="px-14 py-2.5"
+                            marginTop="mt-1"
+                            onClick={handleClose}
+                        >
+                            Cancel
+                        </Button>
+                    </div>
+                </> 
             ) : state.showReplaceDialog ? (
                 <AnndataConflictDialog 
                     open={state.showReplaceDialog}

--- a/src/charts/dialogs/FileUploadDialog.tsx
+++ b/src/charts/dialogs/FileUploadDialog.tsx
@@ -1020,6 +1020,9 @@ const FileUploadDialogComponent: React.FC<FileUploadDialogComponentProps> = obse
             dispatch({ type: "SET_H5_METADATA", payload: null });
             dispatch({ type: "SET_SELECTED_FILES", payload: [] });
             dispatch({ type: "SET_FILE_TYPE", payload: null });
+            dispatch({ type: "SET_FILE_SUMMARY", payload: null });
+            onResize(450, 320);
+            onClose();
         }
     };
 

--- a/src/charts/dialogs/FileUploadDialog.tsx
+++ b/src/charts/dialogs/FileUploadDialog.tsx
@@ -27,8 +27,11 @@ import { TiffPreview } from "./TiffPreview";
 import { TiffMetadataTable } from "./TiffMetadataTable";
 import TiffVisualization from "./TiffVisualization";
 import { DatasourceDropdown } from "./DatasourceDropdown";
-import CloudUploadIcon from "@mui/icons-material/CloudUpload";
-import { Dialog, Paper } from "@mui/material";
+import {
+    Close as CloseIcon,
+    CloudUpload as CloudUploadIcon,
+} from "@mui/icons-material";
+import { Dialog, IconButton, Paper } from "@mui/material";
 import { isArray } from "@/lib/utils";
 import processH5File, { CompressionError } from "./utils/h5Processing";
 import H5MetadataPreview from "./H5MetadataPreview";
@@ -1274,9 +1277,36 @@ const Wrapper = (props: FileUploadDialogComponentProps) => {
             window.removeEventListener("keydown", handleKeyDown);
         };
     }, []);
-    //p-4 mt-2 z-50 text-center border-2 border-dashed rounded-lg ${isDragOver ? "bg-gray-300 dark:bg-slate-800" : "bg-white dark:bg-black"} min-w-[90%]
+
+    const handleClose = () => {
+        setOpen(false);
+    };
     return (
-        <Dialog open={open} fullScreen disableEscapeKeyDown={true}>
+        <Dialog
+            open={open}
+            fullScreen
+            disableEscapeKeyDown={true}
+            PaperProps={{
+                style: {
+                    backgroundColor: "var(--fade_background_color)",
+                    backdropFilter: "blur(1px)",
+                },
+            }}
+        >
+            <IconButton
+                onClick={handleClose}
+                className="absolute top-4 right-4"
+                sx={{
+                    position: "absolute",
+                    top: 16,
+                    right: 16,
+                    backgroundColor: "var(--background_color)",
+                    "&:hover": { backgroundColor: "var(--menu_bar_color)" },
+                }}
+            >
+                <CloseIcon />
+            </IconButton>
+
             <div className="h-screen flex items-center justify-center">
                 <Paper elevation={24} sx={{ p: 2 }}>
                     <FileUploadDialogComponent {...props} />
@@ -1284,6 +1314,6 @@ const Wrapper = (props: FileUploadDialogComponentProps) => {
             </div>
         </Dialog>
     );
-}
+};
 
 export default Wrapper;

--- a/src/charts/dialogs/H5MetadataPreview.tsx
+++ b/src/charts/dialogs/H5MetadataPreview.tsx
@@ -123,7 +123,7 @@ const H5MetadataPreview = ({ metadata }: H5MetadataPreviewProps) => {
                         H5 File Metadata
                     </Typography>
 
-                    <Box sx={{ px: 2, pb: 2 }}>
+                    <Box sx={{ px: 2, pb: 2, pt: 2 }}>
                         <select
                             value={selectedMetadata}
                             onChange={(e) =>


### PR DESCRIPTION
- FileUploadDialog no longer overrides the project view with a solid background. Instead, it now features a blurred transparent background, allowing users to maintain context that they are still in the project view while in the file upload process. 

- Added a close button at the top right corner of the overlay, providing users with an explicit way to exit the dialog and improving overall navigation. 

- Added a fade_background_color to the chart.css stylesheet, standardizing the appearance of the new transparent overlay while maintaining readability in both themes. 

- Improved the ErrorDisplay dialog by adding two new buttons: "Upload Another File," which redirects users back to the first step of the file upload process, and "Close," which allows users to exit the dialog without needing to refresh the page. 

- Improved the legibility of error messages and standardized text sizes to ensure consistency across different errors in ErrorDisplay.

- Resolved two issues related to the AnnData Combine dialog.
    - Fixed a problem where this dialog was overriding the File Upload transparent overlay, making it difficult to see and preventing users from closing it via the top-right button. 
    - Addressed an issue where closing the dialog would not correctly redirect the user back to the project view.