### PR TITLE
Fix problems with popout charts in gridstack layout

### DIFF
--- a/src/charts/ChartManager.js
+++ b/src/charts/ChartManager.js
@@ -714,15 +714,16 @@ export class ChartManager {
                 removeDraggable(div);
             });
         }
-        //add new ones
+        
         view.layout = type;
-        if (type === "absolute") {
-            this.getAllCharts(ds.name).forEach((x) => this._makeChartRD(x, ds));
-        } else if (type === "gridstack") {
-            this.getAllCharts(ds.name).forEach((chart) => {
-                this.gridStack.manageChart(chart, ds, this._inInit);
-            });
-        }
+        //will add the appropriate layout depending on the current layout type
+        this.getAllCharts(ds.name).forEach((x) => {
+            //the chart is popped out so not subject to the layout manager
+            if (x.__doc__ !== document){
+                return;
+            }
+            this._makeChartRD(x, ds)
+        });
     }
 
     _setupThemeContextMenu() {
@@ -1250,24 +1251,15 @@ export class ChartManager {
         }
         for (const chid in this.charts) {
             const chInfo = this.charts[chid];
-
             const chart = chInfo.chart;
             const config = chart.getConfig();
             const div = chart.getDiv();
             const d = this.viewData.dataSources[chInfo.dataSource.name];
             if (d.layout === "gridstack") {
-                config.gsposition = [
-                    Number.parseInt(div.getAttribute("gs-x")),
-                    Number.parseInt(div.getAttribute("gs-y")),
-                ];
-                config.gssize = [
-                    Number.parseInt(div.getAttribute("gs-w")),
-                    Number.parseInt(div.getAttribute("gs-h")),
-                ];
+               //this is handled by gridstack now
             } else {
                 config.position = [div.offsetLeft, div.offsetTop];
             }
-
             initialCharts[chInfo.dataSource.name].push(config);
         }
 

--- a/src/charts/GridstackManager.ts
+++ b/src/charts/GridstackManager.ts
@@ -278,8 +278,8 @@ export default class GridStackManager {
                 locked = !locked;
                 lockIcon.classList.toggle("fa-lock", locked);
                 lockIcon.classList.toggle("fa-unlock", !locked);
-                grid.update(div, { locked });
-                div.classList.toggle("gridLock", locked);
+                grid.update(outer, { locked });
+                outer.classList.toggle("gridLock", locked);
             });
             return lockButton;
         }

--- a/src/charts/GridstackManager.ts
+++ b/src/charts/GridstackManager.ts
@@ -179,6 +179,7 @@ export default class GridStackManager {
         const inner = document.createElement("div");
         inner.classList.add("grid-stack-item-content");
         inner.style.overflow = "visible"; // able to see shadow
+        const origHeight = div.style.height;;
         div.style.height="100%";
         outer.appendChild(inner);
         inner.appendChild(div);
@@ -197,7 +198,11 @@ export default class GridStackManager {
         const ro = new ResizeObserver(
             debounce(() => {
                 try {
-                    // this leads to a condition in which initial chart.config.size is not stable
+                    //this is causing 'No data for row chart' error
+                    //when loading as saved view
+                    //it redraws chart before the data is processed
+
+                    // also leads to a condition in which initial chart.config.size is not stable
                     // immediately after adding it... and also if the window is resized, 
                     // or the view is opened on a different screen... we need to think about how
                     // we serialize the layout information.
@@ -315,6 +320,7 @@ export default class GridStackManager {
         chart.removeLayout = () => {
             //remove the chart from the gridstack
             grid.removeWidget(outer, false);
+            div.style.height = origHeight;
             //take the chart out of the containers
             grid.el.append(div);
             //destroy the containers
@@ -327,6 +333,7 @@ export default class GridStackManager {
             if (handle) {
                 handle.style.cursor = ""; // Reset to default cursor
             }
+
             ro.disconnect();
             mo.disconnect();
         };

--- a/src/charts/GridstackManager.ts
+++ b/src/charts/GridstackManager.ts
@@ -220,6 +220,9 @@ export default class GridStackManager {
                     //this is causing 'No data for row chart' error
                     //when loading as saved view
                     //it redraws chart before the data is processed
+                    //^ perhaps we could use something related to chart.deferredInit if this is a problem
+                    //would possibly need to improve the design of that mechanism, 
+                    //we could possibly move `ro` creation to after that promise resolves.
 
                     // also leads to a condition in which initial chart.config.size is not stable
                     // immediately after adding it... and also if the window is resized, 

--- a/src/utilities/Popout.ts
+++ b/src/utilities/Popout.ts
@@ -5,8 +5,6 @@ export default function popoutChart(chart: BaseChart<any>) {
     const { chartManager } = window.mdv;
     const mainWindow = window;
     const div = chart.getDiv();
-    const originalParent = div.parentElement;
-    if (!originalParent) throw "Chart div has no parent element";
     const wtop = window.screenTop ? window.screenTop : window.screenY;
     const wleft = window.screenLeft ? window.screenLeft : window.screenX;
     const { width, height, left, top } = div.getBoundingClientRect();
@@ -15,6 +13,10 @@ export default function popoutChart(chart: BaseChart<any>) {
     const l = Math.floor(left + wleft);
     const t = Math.floor(top + wtop);
     if (div.gridstackPopoutCallback) div.gridstackPopoutCallback();
+    //moved this to after the callback as this will ensure the 
+    //parent element is correct
+    const originalParent = div.parentElement;
+    if (!originalParent) throw "Chart div has no parent element";
     removeResizable(div);
     removeDraggable(div);
     const popoutWindow = window.open(

--- a/src/utilities/Popout.ts
+++ b/src/utilities/Popout.ts
@@ -104,7 +104,9 @@ export default function popoutChart(chart: BaseChart<any>) {
     popoutWindow.addEventListener("beforeunload", () => {
         popStyles();
         originalParent.appendChild(div);
-        chartManager._makeChartRD(chart);
+        //this will enable the chart position, size to be manipulated 
+        //in the current layout manager (absolute or gridstack)
+        chartManager._makeChartRD(chart,chart.dataSource);
         //@ts-ignore
         chartManager.charts[chart.config.id].win = mainWindow;
         chart.changeBaseDocument(document);


### PR DESCRIPTION
**Problems**
When charts were added back to a gridstack layout they reverted to absolute positioning
In gridstack there were no margins and the charts were slightly overlapping

**Fixes**
Overhauled gridstack manager adding outer and inner containers to ensure it works correctly e.g. correct margins
Also ensured charts can be added and removed from the gridstack  without errors  - however it has not been extensively tested
Ensure layout can be changed even when some charts are popped out
