### PR TITLE
Md 466 axes syncing with view state

### DIFF
--- a/src/react/components/DeckScatterComponent.tsx
+++ b/src/react/components/DeckScatterComponent.tsx
@@ -242,27 +242,15 @@ const DeckScatter = observer(function DeckScatterComponent() {
         viewState;
         // first time around, we get an exception because scatterplotLayer hasn't been rendered yet
         try {
-            // this unproject is not getting the right values.
-            // we have another `unproject` from our useSpatialLayers hook - we should use that
-            // it is also currently not correct, but we should still switch to that, and then fix it.
-            // that should also fix issues with mouse events being in wrong coordinates.
-            //! this version of unproject currently expects coordinates in 'client space',
-            // as in `getBoundingClientRect` - we potentially want to change this...
-            // Really, we want to refactor more of this stuff.
-            //! the other problem is that it currently always throws internally because of scatterplotLayer.lifecycle
-            // which is always "Awaiting state".
-            // Are we always referring to the same layer?
-            // ^^ no, we should use context or some other way to keep the same state...
-            // using selectionLayer instead as a workaround pending refactor
-            const p = selectionLayer.unproject([0, 0]);
-            const p2 = selectionLayer.unproject([chartWidth, chartHeight]);
+            const p = scatterplotLayer.unproject([0, 0]);
+            const p2 = scatterplotLayer.unproject([chartWidth, chartHeight]);
             const domainX = [p[0], p2[0]];
             const domainY = [p2[1], p[1]];
             return { domainX, domainY };
         } catch (e) {
             return { domainX: cx.minMax, domainY: cy.minMax };
         }
-    }, [cx.minMax, cy.minMax, viewState, chartWidth, chartHeight, selectionLayer]);
+    }, [cx.minMax, cy.minMax, viewState, chartWidth, chartHeight, scatterplotLayer]);
     const scaleX = useMemo(() => Scale.scaleLinear({
         domain: ranges.domainX, // e.g. [min, max]
         range: [margin.left, chartWidth + margin.left],

--- a/src/react/scatter_state.ts
+++ b/src/react/scatter_state.ts
@@ -343,6 +343,7 @@ export function useScatterplotLayer(modelMatrix: Matrix4) {
     const boundingClientRect = useMemo(() => {
         return chart.contentDiv.getBoundingClientRect();
     }, [chart.contentDiv.getBoundingClientRect]);
+    // maybe we should rename this `unprojectMouse` or something
     const unproject = useCallback(
         (e: MouseEvent | React.MouseEvent | P) => {
             // never liked this... and then it was actually causing an infinite loop

--- a/src/react/scatter_state.ts
+++ b/src/react/scatter_state.ts
@@ -184,6 +184,13 @@ function useZoomOnFilter(modelMatrix: Matrix4) {
 
 // type Tooltip = (PickingInfo) => string;
 export type P = [number, number];
+/**
+ * ! in its current form, this hook is only called by `useCreateSpatialAnnotationState`
+ * in future we may want to be able to have different arrangement of layers & rework this.
+ * 
+ * As of now, charts with appropriate spatial context can call `useSpatialLayers()` at any point
+ * to access the scatterplot layer, and the tooltip function.
+ */
 export function useScatterplotLayer(modelMatrix: Matrix4) {
     const id = useChartID();
     const chart = useChart();

--- a/src/react/spatial_context.tsx
+++ b/src/react/spatial_context.tsx
@@ -180,8 +180,13 @@ export function useMeasure() {
     return measure;
 }
 
-/** work in progress... very much unstable return type etc, but starting to make use
- * and hopefully refactor into something coherent soon.
+/** 
+ * useSpatialLayers is a hook that provides access to the spatial layers and their properties.
+ * 
+ * This includes the selection layer, scatterplot layer (which is actually an instance
+ * of a more complex `SpatialLayer` with custom density/contour rendering), etc.
+ * 
+ * work in progress... unstable return type etc, and subject to future changes.
  */
 export function useSpatialLayers() {
     const { rectRange, scatterProps } = useContext(SpatialAnnotationState);

--- a/src/react/spatial_context.tsx
+++ b/src/react/spatial_context.tsx
@@ -32,6 +32,7 @@ export type MeasureState = {
 export type SpatialAnnotationState = {
     rectRange: RangeState;
     measure: MeasureState;
+    scatterProps: ReturnType<typeof useScatterplotLayer>;
 };
 
 // Could more usefully be thought of as SpatialContext?
@@ -150,7 +151,8 @@ function useCreateSpatialAnnotationState(chart: BaseChart<any>) {
     // consider for project-wide annotation stuff as opposed to ephemeral selections
     const rectRange = useCreateRange(chart);
     const measure = useCreateMeasure();
-    return { rectRange, measure };
+    const scatterProps = useScatterplotLayer(rectRange.modelMatrix);
+    return { rectRange, measure, scatterProps };
 }
 
 export function SpatialAnnotationProvider({
@@ -182,8 +184,10 @@ export function useMeasure() {
  * and hopefully refactor into something coherent soon.
  */
 export function useSpatialLayers() {
-    const { rectRange } = useContext(SpatialAnnotationState);
-    const scatterProps = useScatterplotLayer(rectRange.modelMatrix);
+    const { rectRange, scatterProps } = useContext(SpatialAnnotationState);
+    // this should be in the context, useScatterplotLayer currently called *only* from there...
+    // if we want to use it in other places we need to refactor
+    // const scatterProps = useScatterplotLayer(rectRange.modelMatrix);
     const { getTooltip } = scatterProps;
     // const layers = [rectRange.polygonLayer, scatterplotLayer]; /// should probably be in a CompositeLayer?
     return {


### PR DESCRIPTION
This fixes bugs 

- with mouse coordinates used for making selections
- updating axis ranges (there were multiple copies of `scatterplotLayer` meaning that the one being referred to was never in a usable state for `unproject`)

Also hopefully makes things marginally neater and clearer.