### PR TITLE
useScatterRadius hook

### DIFF
--- a/src/react/components/VivScatterComponent.tsx
+++ b/src/react/components/VivScatterComponent.tsx
@@ -80,8 +80,7 @@ const Main = observer(() => {
     const detailId = `${id}detail-react`;
     const outerContainer = useOuterContainer();
 
-    // what I want to come out of here... n-JSON layers, scatterplot, editable geojson layer, etc.
-    // perhaps as a CompositeLayer.
+    // this isn't updating when we tweak the config...
     const { scatterProps, selectionLayer } = useSpatialLayers();
     const { scatterplotLayer, getTooltip } = scatterProps;
     const jsonLayer = useJsonLayer();
@@ -173,7 +172,7 @@ const Main = observer(() => {
             contrast,
         ],
     );
-    //@ts-expect-error Partial<DeckGLProps> should be fixed
+    //@ts-expect-error tooltip content should be fixed
     const deckProps: Partial<DeckGLProps> = useMemo(
         () => ({
             getTooltip,

--- a/src/react/scatter_state.ts
+++ b/src/react/scatter_state.ts
@@ -202,12 +202,12 @@ export function useScatterRadius() {
     //todo more clarity on radius units - but large radius was causing big problems after deck upgrade
     // this is reasonably ok looking, but even for abstract data it should really relate to axis labels
     // (which implies that if we have a warped aspect ratio but making circles circular, they will be based on one or other axis)
-    const radiusScale = (radius * course_radius * 0.1)/scale;
+    const radiusScale = (radius * course_radius)/scale;
     return useMemo(() => {
         if (cx.minMax && cy.minMax) {
             const xRange = cx.minMax[1] - cx.minMax[0];
             const yRange = cy.minMax[1] - cy.minMax[0];
-            const r = 100 / Math.max(xRange, yRange);
+            const r = 10000 / Math.max(xRange, yRange);
             return radiusScale / r;
         }
         return radiusScale;

--- a/src/react/scatter_state.ts
+++ b/src/react/scatter_state.ts
@@ -194,19 +194,10 @@ function useZoomOnFilter(modelMatrix: Matrix4) {
  * based on some property of the data - but for now we just return a number.
  */
 export function useScatterRadius() {
-    const chart = useChart();
-    const [radiusScale, setRadiusScale] = useState(0);
     const config = useConfig<ScatterPlotConfig>();
-    useEffect(() => {
-        // does this help? 
-        // ! it does - but this is not a good pattern.
-        return chart.mobxAutorun(() => {
-            const { radius, course_radius } = config;
-            //todo more clarity on radius units - but large radius was causing big problems after deck upgrade
-            const radiusScale = radius * course_radius * 0.01;// * (is2d ? 1 : 0.01);
-            setRadiusScale(radiusScale);
-        });
-    });
+    const { radius, course_radius } = config;
+    //todo more clarity on radius units - but large radius was causing big problems after deck upgrade
+    const radiusScale = radius * course_radius * 0.01;// * (is2d ? 1 : 0.01);
     return radiusScale;
 }
 

--- a/src/react/spatial_context.tsx
+++ b/src/react/spatial_context.tsx
@@ -152,6 +152,7 @@ function useCreateSpatialAnnotationState(chart: BaseChart<any>) {
     // consider for project-wide annotation stuff as opposed to ephemeral selections
     const rectRange = useCreateRange(chart);
     const measure = useCreateMeasure();
+    // this doesn't update when props change, need to fix that
     const scatterProps = useScatterplotLayer(rectRange.modelMatrix);
     return { rectRange, measure, scatterProps };
 }


### PR DESCRIPTION
@coderabbitai the intention here is to have more sane control of point size, as per comments on `useScatterRadius()`... but I've realised I recently introduced a bug meaning that `useScatterplotLayer()` is not reacting to changes in the mobx `config`. I'm using `autorun` in a `useEffect` and now it does re-render when I tweak those settings - but other related config things are not working correctly since I moved the call to `useScatterplotLayer()` inside `useCreateSpatialAnnotationState()`.