### PR TITLE
Add keyboard shortcuts to Save View dialog

### DIFF
--- a/src/charts/dialogs/SaveViewDialog.tsx
+++ b/src/charts/dialogs/SaveViewDialog.tsx
@@ -1,4 +1,5 @@
 import { Button, Dialog, DialogActions, DialogContent, DialogTitle, Typography } from "@mui/material";
+import { useEffect, useCallback } from "react";
 
 const SaveViewDialogComponent = (props: {
     open: boolean;
@@ -8,9 +9,30 @@ const SaveViewDialogComponent = (props: {
 }) => {
     const { viewManager } = window.mdv.chartManager;
 
-    const onSave = () => {
+    const onSave = useCallback(() => {
         viewManager.saveView();
-    };
+    }, [viewManager]);
+
+    useEffect(() => {
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === "y") {
+                event.preventDefault();
+                onSave();
+                props?.action?.();
+                props.onClose();
+            }
+            if (event.key === "n") {
+                event.preventDefault();
+                props?.action?.();
+                props.onClose();
+            }            
+        };
+
+        window.addEventListener("keydown", handleKeyDown);
+        return () => {
+            window.removeEventListener("keydown", handleKeyDown);
+        };
+    }, [props, onSave]);
 
     return (
         <Dialog open={props.open} onClose={props.onClose} fullWidth maxWidth="xs">

--- a/src/charts/dialogs/SaveViewDialog.tsx
+++ b/src/charts/dialogs/SaveViewDialog.tsx
@@ -15,6 +15,7 @@ const SaveViewDialogComponent = (props: {
 
     useEffect(() => {
         const handleKeyDown = (event: KeyboardEvent) => {
+            if (!props.open) return; //probably doesn't happen, but no harm to check
             if (event.key === "y") {
                 event.preventDefault();
                 onSave();
@@ -28,11 +29,13 @@ const SaveViewDialogComponent = (props: {
             }            
         };
 
+        // seems ok to use window here since this is a modal dialog
+        // saves faffing about with refs
         window.addEventListener("keydown", handleKeyDown);
         return () => {
             window.removeEventListener("keydown", handleKeyDown);
         };
-    }, [props, onSave]);
+    }, [props, onSave, props.open]);
 
     return (
         <Dialog open={props.open} onClose={props.onClose} fullWidth maxWidth="xs">


### PR DESCRIPTION
I think this is a reasonably sound way to do this and don't see any particular issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The save view dialog now supports keyboard shortcuts for quick actions. Users can press designated keys to either save or dismiss the dialog, enhancing the overall user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->