### PR TITLE
Md 235 persist selection

### DIFF
--- a/src/react/components/VivMDVReact.tsx
+++ b/src/react/components/VivMDVReact.tsx
@@ -1,4 +1,4 @@
-import BaseChart, { type BaseConfig } from "../../charts/BaseChart";
+import BaseChart from "../../charts/BaseChart";
 import { BaseReactChart } from "./BaseReactChart";
 import { action, makeObservable, observable } from "mobx";
 import {
@@ -13,19 +13,17 @@ import {
 } from "./avivatorish/state";
 import "../../charts/VivScatterPlot"; //because we use the BaseChart.types object, make sure it's loaded.
 import { useEffect } from "react";
-import type { ColumnName, GuiSpec } from "../../charts/charts";
+import type { ColumnName } from "../../charts/charts";
 import { useImage } from "./avivatorish/hooks";
 import { VivScatter } from "./VivScatterComponent";
 import { useImgUrl } from "../hooks";
 import ColorChannelDialogReactWrapper from "./ColorChannelDialogReactWrapper";
-import type { DualContourLegacyConfig } from "../contour_state";
 import { loadColumn } from "@/dataloaders/DataLoaderUtil";
 import { observer } from "mobx-react-lite";
 import { useChart } from "../context";
 import type DataStore from "@/datastore/DataStore";
 import { g, isArray, toArray } from "@/lib/utils";
-import type { FeatureCollection } from "@turf/helpers";
-import { getEmptyFeatureCollection } from "../spatial_context";
+import { scatterDefaults, type ScatterPlotConfig } from "../scatter_state";
 
 function VivScatterChartRoot() {
     // to make this look like Avivator...
@@ -70,47 +68,6 @@ export type CategoryFilter = {
     column: ColumnName;
     category: string | string[];
     // consider properties like 'invert' or 'exclude', or 'color'...
-};
-//viewState should be persisted... maybe a way of saving different snapshots?
-//could we infer or something to avoid having to repeat this?
-//! need to only use the other version of this...
-export type ScatterPlotConfig = {
-    course_radius: number;
-    radius: number;
-    opacity: number;
-    // part of ColorConfig
-    // color_by?: ColumnName; 
-    // color_legend: {
-    //     display: boolean;
-    //     // todo: add more options here...
-    // };
-    category_filters: Array<CategoryFilter>;
-    //on_filter: "hide" | "grey", //todo
-    zoom_on_filter: boolean;
-    point_shape: "circle" | "square" | "gaussian";
-    selectionFeatureCollection: FeatureCollection;
-} & TooltipConfig &
-    DualContourLegacyConfig & BaseConfig;
-//@ts- expect-error things like 'id' are expected... subject to review.
-const scatterDefaults: Omit<ScatterPlotConfig, "id" | "legend" | "size" | "title" | "type" | "param"> = {
-    course_radius: 1,
-    radius: 10,
-    opacity: 1,
-    color_by: undefined,
-    color_legend: {
-        display: false,
-    },
-    tooltip: {
-        show: false,
-    },
-    category_filters: [],
-    zoom_on_filter: false,
-    point_shape: "circle",
-    contour_fill: false,
-    contour_bandwidth: 0.1,
-    contour_intensity: 1,
-    contour_opacity: 0.5,
-    selectionFeatureCollection: getEmptyFeatureCollection(),
 };
 export type VivRoiConfig = {
     // making this 'type' very specific will let us infer the rest of the type, i.e.

--- a/src/react/scatter_state.ts
+++ b/src/react/scatter_state.ts
@@ -22,6 +22,7 @@ import { type DualContourLegacyConfig, useLegacyDualContour } from "./contour_st
 import type { ColumnName } from "@/charts/charts";
 import type { FeatureCollection } from "@turf/helpers";
 import { getEmptyFeatureCollection } from "./spatial_context";
+import type { BaseConfig } from "@/charts/BaseChart";
 
 export type TooltipConfig = {
     tooltip: {
@@ -52,8 +53,8 @@ export type ScatterPlotConfig = {
     dimension: "2d" | "3d";
     selectionFeatureCollection: FeatureCollection;
 } & TooltipConfig &
-    DualContourLegacyConfig;
-export const scatterDefaults: ScatterPlotConfig = {
+    DualContourLegacyConfig & BaseConfig;
+export const scatterDefaults: Omit<ScatterPlotConfig, "id" | "legend" | "size" | "title" | "type" | "param"> = {
     course_radius: 1,
     radius: 10,
     opacity: 1,

--- a/src/react/spatial_context.tsx
+++ b/src/react/spatial_context.tsx
@@ -9,8 +9,8 @@ import { useChartID, useRangeDimension2D } from "./hooks";
 import type BaseChart from "@/charts/BaseChart";
 import { observer } from "mobx-react-lite";
 import type { BaseConfig } from "@/charts/BaseChart";
-import { action } from "mobx";
-import { useDebounce } from "use-debounce";
+import { action, toJS } from "mobx";
+
 /*****
  * Persisting some properties related to SelectionOverlay in "SpatialAnnotationProvider"... >>subject to change<<.
  * Not every type of chart will have a range dimension, and not every chart will have a selection overlay etc.
@@ -57,11 +57,11 @@ function useSelectionCoords(selection: FeatureCollection) {
         //^^ need to be careful about managing that property.
         const geometry = feature.geometry as Geometry;
         const raw = geometry.coordinates as Position[][];
-        return raw[0];
+        //! without toJS, this can be orders of magnitude slower than before - careful with that mobx, eugene...
+        // still adds significant overhead - may need a different strategy for critical/hot paths.
+        return toJS(raw[0]);
     }, [feature]);
-    //fast debounce to avoid excessive re-render/re-compute
-    const [debouncedCoords] = useDebounce(coords, 1);
-    return debouncedCoords as [number, number][];
+    return coords as [number, number][];
 }
 
 /** for this to be more useful as a hook will depend on state/context... */
@@ -129,12 +129,13 @@ function useCreateRange(chart: BaseChart<ScatterPlotConfig & BaseConfig>) {
             },
             lineWidthMinPixels: 1,
             selectedFeatureIndexes,
-            onEdit: ({ updatedData }) => {
+            // adding `action` here gets rid of warnings but doesn't help with performance.
+            onEdit: action(({ updatedData }) => {
                 // console.log("onEdit", editType, updatedData);
                 const feature = updatedData.features.pop();
                 updatedData.features = [feature];
                 setSelectionFeatureCollection(updatedData);
-            },
+            }),
             onHover(pickingInfo, event) {
                 if ((pickingInfo as any).featureType === "points") return;
                 // -- try to avoid selecting invisible features etc - refer to notes in aosta prototype

--- a/src/react/spatial_context.tsx
+++ b/src/react/spatial_context.tsx
@@ -10,6 +10,7 @@ import type BaseChart from "@/charts/BaseChart";
 import { observer } from "mobx-react-lite";
 import type { BaseConfig } from "@/charts/BaseChart";
 import { action } from "mobx";
+import { useDebounce } from "use-debounce";
 /*****
  * Persisting some properties related to SelectionOverlay in "SpatialAnnotationProvider"... >>subject to change<<.
  * Not every type of chart will have a range dimension, and not every chart will have a selection overlay etc.
@@ -58,7 +59,9 @@ function useSelectionCoords(selection: FeatureCollection) {
         const raw = geometry.coordinates as Position[][];
         return raw[0];
     }, [feature]);
-    return coords as [number, number][];
+    //fast debounce to avoid excessive re-render/re-compute
+    const [debouncedCoords] = useDebounce(coords, 1);
+    return debouncedCoords as [number, number][];
 }
 
 /** for this to be more useful as a hook will depend on state/context... */

--- a/src/react/spatial_context.tsx
+++ b/src/react/spatial_context.tsx
@@ -9,6 +9,7 @@ import { useChartID, useRangeDimension2D } from "./hooks";
 import type BaseChart from "@/charts/BaseChart";
 import { observer } from "mobx-react-lite";
 import type { BaseConfig } from "@/charts/BaseChart";
+import { action } from "mobx";
 /*****
  * Persisting some properties related to SelectionOverlay in "SpatialAnnotationProvider"... >>subject to change<<.
  * Not every type of chart will have a range dimension, and not every chart will have a selection overlay etc.
@@ -80,10 +81,11 @@ function useCreateRange(chart: BaseChart<ScatterPlotConfig & BaseConfig>) {
     // !nb as of this writing, the scale of these features will be wrong if there is useRegionScale() / modelMatrix that compensates for image being different to 'regions'
     // so when we are persisting editable-geojson in a way that will be used elsewhere we need to address that later.
     //const [selectionFeatureCollection, setSelectionFeatureCollection] = useState<FeatureCollection>(getEmptyFeatureCollection());
+    //! it appears to drastically affect performance having this in mobx config - why?
     const { selectionFeatureCollection } = chart.config;
-    const setSelectionFeatureCollection = useCallback((newSelection: FeatureCollection) => {
+    const setSelectionFeatureCollection = useCallback(action((newSelection: FeatureCollection) => {
         chart.config.selectionFeatureCollection = newSelection;
-    }, [chart]);
+    }), []);
     const [selectionMode, setSelectionMode] = useState<GeoJsonEditMode>(new CompositeMode([]));
     const { filterPoly, removeFilter, rangeDimension } = useRangeDimension2D();
     const coords = useSelectionCoords(selectionFeatureCollection);


### PR DESCRIPTION
The `FeatureCollection` used to represent selection state in scatterplots and spatial/viv chart is persisted via mobx `config`.

A serious performance issue was noticed, which is mostly mitigated by making sure that we use `toJS(coords)` before passing them on to the point-in-polygon `filterPoly` method - although there still appears to be a significant overhead, which suggests that we need to be extremely careful with how `mobx` is used.

The performance of `filterPoly` may in future be improved with changes to how we compute `Dimension`, particularly in cases where other dimensions already filter most of the samples.

@coderabbitai review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined scatter plot configuration settings to simplify customization.
	- Enhanced state management for interactive map features, resulting in smoother performance during user interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->