### PR TITLE
Md 484 axis settings

### DIFF
--- a/src/charts/dialogs/utils/AxisSettingsGui.ts
+++ b/src/charts/dialogs/utils/AxisSettingsGui.ts
@@ -18,15 +18,18 @@ const sizeLabel = (label: string) => {
 
 function axisGui(axis: AxisConfig, label: string, callback?: () => void) {
     return [
-        g({
-            type: "check",
-            label: `Rotate ${label} labels`,
-            current_value: axis.rotate_labels,
-            func: (x) => {
-                axis.rotate_labels = x;
-                callback?.();
-            }
-        }),
+        // rotate_labels is a bit of a pain to get working
+        // and not so useful for scatterplots - numbers tend to look ok
+        // will want to review axis settings for other charts
+        // g({
+        //     type: "check",
+        //     label: `Rotate ${label} labels`,
+        //     current_value: axis.rotate_labels,
+        //     func: (x) => {
+        //         axis.rotate_labels = x;
+        //         callback?.();
+        //     }
+        // }),
         g({
             type: "slider",
             max: 20,

--- a/src/charts/dialogs/utils/AxisSettingsGui.ts
+++ b/src/charts/dialogs/utils/AxisSettingsGui.ts
@@ -1,0 +1,72 @@
+import { g } from "@/lib/utils";
+import { AxisConfig, ScatterPlotConfig2D } from "@/react/scatter_state";
+
+// premature abstraction?
+const axisNames = {
+    x: "X Axis",
+    y: "Y Axis",
+    z: "Z Axis",
+    ry: "Right Y Axis",
+    tx: "Top X Axis",
+}
+const sizeLabel = (label: string) => {
+    // 🙄 this is a bit dumb
+    if (label.toLowerCase().includes("y")) return "Width";
+    if (label.toLowerCase().includes("x")) return "Height";
+    return "Size";
+};
+
+function axisGui(axis: AxisConfig, label: string, callback?: () => void) {
+    return [
+        g({
+            type: "check",
+            label: `Rotate ${label} labels`,
+            current_value: axis.rotate_labels,
+            func: (x) => {
+                axis.rotate_labels = x;
+                callback?.();
+            }
+        }),
+        g({
+            type: "slider",
+            max: 20,
+            min: 4,
+            step: 1,
+            label: `${label} text size`,
+            current_value: axis.tickfont,
+            func: (x) => {
+                axis.tickfont = x;
+                callback?.();
+            }
+        }),
+        g({
+            type: "slider",
+            label: `${label} ${sizeLabel(label)}`,
+            max: 200,
+            min: 20,
+            current_value: axis.size,
+            func: (x) => {
+                axis.size = x;
+                callback?.();
+            }
+        }),
+    ];
+}
+
+export default function getAxisGuiSpec(config: ScatterPlotConfig2D, callback?: () => void) {
+    if (!config.axis) {
+        throw new Error("No axis config found");
+    }
+    const { axis } = config;
+    // mobx doesn't like this Object.entries?
+    // const arr = Object.entries(axis).flatMap(([key, value]) => axisGui(value, key, callback));
+    const arr = [
+        ...axisGui(axis.x, axisNames.x, callback),
+        ...axisGui(axis.y, axisNames.y, callback),
+    ];
+    return g({
+        type: "folder",
+        label: "Axis Controls",
+        current_value: arr,
+    });
+};

--- a/src/react/components/AxisComponent.tsx
+++ b/src/react/components/AxisComponent.tsx
@@ -1,0 +1,111 @@
+import { observer } from "mobx-react-lite";
+import { ScatterPlotConfig2D, ScatterPlotConfig3D } from "../scatter_state";
+import type { DataColumn } from "@/charts/charts";
+import { useChartSize, useParamColumns } from "../hooks";
+import { useMemo, type PropsWithChildren } from "react";
+import { Axis, Scale } from "@visx/visx";
+
+type AxisComponentProps = {
+    config: ScatterPlotConfig2D | ScatterPlotConfig3D
+    unproject: (xy: [number, number]) => number[];
+} & PropsWithChildren;
+
+export default observer(function AxisComponent({ config, unproject, children }: AxisComponentProps) {
+    const [cx, cy] = useParamColumns() as DataColumn<"double">[];
+    const { dimension, viewState } = config;
+    const is2d = dimension === "2d";
+    const margin = useMemo(() => (
+        //todo better Axis encapsulation in another component
+        is2d ? {
+            top: 10,
+            right: 10,
+            bottom: config.axis.x.size + 20,
+            left: config.axis.y.size + 20,
+        } : {
+            top: 0,
+            right: 0,
+            bottom: 0,
+            left: 0,
+        }
+    ), [is2d, is2d && config.axis.x.size, is2d && config.axis.y.size]);
+    const [width, height] = useChartSize();
+    const chartWidth = width - margin.left - margin.right;
+    //there could be a potential off-by-one/two error somewhere down the line
+    //if we don't fully understand reasons for `- 2` here.
+    //prevents overlapping with x-axis.
+    const chartHeight = height - margin.top - margin.bottom - 2;
+
+    // axes need to respond to the viewState... (make sure there isn't a regression here when refactoring etc).
+    const ranges = useMemo(() => {
+        viewState;
+        // first time around, we get an exception because scatterplotLayer hasn't been rendered yet
+        try {
+            const p = unproject([0, 0]);
+            const p2 = unproject([chartWidth, chartHeight]);
+            const domainX = [p[0], p2[0]];
+            const domainY = [p2[1], p[1]];
+            return { domainX, domainY };
+        } catch (e) {
+            return { domainX: cx.minMax, domainY: cy.minMax };
+        }
+    }, [cx.minMax, cy.minMax, viewState, chartWidth, chartHeight, unproject]);
+    // * as of now, we only use these scales for the axes,
+    // but we should consider how they might relate to data transformation
+    const scaleX = useMemo(() => Scale.scaleLinear({
+        domain: ranges.domainX, // e.g. [min, max]
+        range: [margin.left, chartWidth + margin.left],
+    }), [chartWidth, ranges]);
+    const scaleY = useMemo(() => Scale.scaleLinear({
+        domain: ranges.domainY, // e.g. [min, max]
+        range: [chartHeight + margin.top, margin.top],
+    }), [chartHeight, ranges]);
+
+    const deckStyle = useMemo(() => ({
+        position: "absolute",
+        top: margin.top,
+        left: margin.left,
+        width: chartWidth,
+        height: chartHeight,
+    } as const), [chartWidth, chartHeight]);
+    return (
+        <>
+            <div style={deckStyle}>{children}</div>
+            {is2d && <svg width={width} height={height}>
+                <Axis.AxisBottom
+                    top={chartHeight + margin.top}
+                    scale={scaleX}
+                    stroke={"var(--text_color)"}
+                    tickStroke={"var(--text_color)"}
+                    tickLabelProps={() => ({
+                        fill: "var(--text_color)",
+                        fontSize: config.axis.x.tickfont,
+                        textAnchor: "middle",
+                    })}
+                    labelProps={{
+                        fill: "var(--text_color)",
+                        fontSize: config.axis.x.tickfont,
+                        textAnchor: "middle",
+                    }}
+                    label={cx.name}
+                />
+                <Axis.AxisLeft
+                    left={margin.left}
+                    scale={scaleY}
+                    stroke={"var(--text_color)"}
+                    tickStroke={"var(--text_color)"}
+                    tickLabelProps={() => ({
+                        fill: "var(--text_color)",
+                        fontSize: config.axis.y.tickfont,
+                        textAnchor: "end",
+                    })}
+                    labelProps={{
+                        fill: "var(--text_color)",
+                        fontSize: config.axis.y.tickfont,
+                        // dx: config.axis.x.rotate_labels ? 
+                    }}
+                    label={cy.name}
+                />
+            </svg>}        
+        </>
+    )
+});

--- a/src/react/components/AxisComponent.tsx
+++ b/src/react/components/AxisComponent.tsx
@@ -1,14 +1,29 @@
 import { observer } from "mobx-react-lite";
-import { ScatterPlotConfig2D, ScatterPlotConfig3D } from "../scatter_state";
+import { AxisConfig, ScatterPlotConfig2D, ScatterPlotConfig3D } from "../scatter_state";
 import type { DataColumn } from "@/charts/charts";
 import { useChartSize, useParamColumns } from "../hooks";
-import { useMemo, type PropsWithChildren } from "react";
+import { useEffect, useMemo, type PropsWithChildren } from "react";
 import { Axis, Scale } from "@visx/visx";
 
 type AxisComponentProps = {
     config: ScatterPlotConfig2D | ScatterPlotConfig3D
     unproject: (xy: [number, number]) => number[];
 } & PropsWithChildren;
+
+//! todo - get label options working... for now, we ignore rotate_labels
+// not generally relevant to scatterplot, but will be for other charts
+function getLabelProps(axisConfig?: AxisConfig) {
+    if (!axisConfig) return {};
+    const { tickfont, rotate_labels } = axisConfig;
+    return () => ({
+        fill: "var(--text_color)",
+        fontSize: tickfont,
+        textAnchor: rotate_labels ? "end" : "middle",
+        dx: rotate_labels ? "-.8em" : undefined,
+        dy: rotate_labels ? "-.10em" : ".71em",
+        transform: rotate_labels ? "rotate(-45)" : undefined,
+    });
+}
 
 export default observer(function AxisComponent({ config, unproject, children }: AxisComponentProps) {
     const [cx, cy] = useParamColumns() as DataColumn<"double">[];
@@ -67,6 +82,11 @@ export default observer(function AxisComponent({ config, unproject, children }: 
         width: chartWidth,
         height: chartHeight,
     } as const), [chartWidth, chartHeight]);
+    // useEffect(() => {
+    //     if (is2d && (config.axis.x.rotate_labels || config.axis.y.rotate_labels)) {
+    //         console.warn("Axis rotation not implemented for react charts");
+    //     }
+    // }, [is2d]);
     return (
         <>
             <div style={deckStyle}>{children}</div>
@@ -101,7 +121,6 @@ export default observer(function AxisComponent({ config, unproject, children }: 
                     labelProps={{
                         fill: "var(--text_color)",
                         fontSize: config.axis.y.tickfont,
-                        // dx: config.axis.x.rotate_labels ? 
                     }}
                     label={cy.name}
                 />

--- a/src/react/components/DeckScatterComponent.tsx
+++ b/src/react/components/DeckScatterComponent.tsx
@@ -4,7 +4,7 @@ import { observer } from "mobx-react-lite";
 import { useChartSize, useConfig, useFilterArray, useFilteredIndices, useParamColumns, useSimplerFilteredIndices } from "../hooks";
 import { ScatterplotLayer } from "@deck.gl/layers";
 import { DataFilterExtension } from "@deck.gl/extensions";
-import { useEffect, useId, useMemo, useState } from "react";
+import { useCallback, useEffect, useId, useMemo, useState } from "react";
 import { useChart, useDataStore } from "../context";
 import type { DeckScatterConfig } from "./DeckScatterReactWrapper";
 import { action } from "mobx";
@@ -15,6 +15,7 @@ import "../../charts/css/charts.css";
 import { SpatialAnnotationProvider, useSpatialLayers } from "../spatial_context";
 import SelectionOverlay from "./SelectionOverlay";
 import { useScatterRadius } from "../scatter_state";
+import AxisComponent from "./AxisComponent";
 
 // const margin = { top: 10, right: 10, bottom: 40, left: 60 };
 /** todo this should be common for viv / scatter_state, pending refactor
@@ -102,19 +103,16 @@ const DeckScatter = observer(function DeckScatterComponent() {
     const id = useId();
     const [width, height] = useChartSize();
     const [cx, cy, cz] = useParamColumns() as LoadedDataColumn<"double">[];
-    // const data = useSimplerFilteredIndices();
     const data = useFilteredIndices(); //changed to fallback to simplerFilteredIndices when filterColumn is not set
     const config = useConfig<DeckScatterConfig>();
     const { opacity, viewState, on_filter, dimension } = config;
     const is2d = dimension === "2d";
     //todo more clarity on radius units - but large radius was causing big problems after deck upgrade
     const radiusScale = useScatterRadius();
-    const chart = useChart();
     //todo colorBy should be done differently (also bearing in mind multiple layers)
-    const colorBy = (chart as any).colorBy;
-    // const colorBy = color_by;
     const margin = useMemo(() => (
-        //todo better Axis encapsulation in another component
+        //todo better Axis/margin encapsulation - new hook
+        //currently this is duplicated so that we have chartWidth/Height for the view
         is2d ? {
             top: 10,
             right: 10,
@@ -138,7 +136,8 @@ const DeckScatter = observer(function DeckScatterComponent() {
 
     const { scatterProps, selectionLayer } = useSpatialLayers();
     // this is now somewhat able to render for "2d", pending further tweaks
-    const { scatterplotLayer, getTooltip, unproject } = scatterProps;
+    //! beware unproject from here is not what we want, should review
+    const { scatterplotLayer, getTooltip } = scatterProps;
 
     const filterValue = useFilterArray();
 
@@ -205,40 +204,15 @@ const DeckScatter = observer(function DeckScatterComponent() {
     }, [chartWidth, chartHeight, config.dimension, id]);
     //! deck doesn't like it if we change the layers array - better to toggle visibility
     const layers = [scatterplotLayer, greyScatterplotLayer, selectionLayer];
-    // todo - encapsulate better
-    // axes need to respond to the viewState... (make sure there isn't a regression here when refactoring etc).
-    const ranges = useMemo(() => {
-        viewState;
-        // first time around, we get an exception because scatterplotLayer hasn't been rendered yet
-        try {
-            const p = scatterplotLayer.unproject([0, 0]);
-            const p2 = scatterplotLayer.unproject([chartWidth, chartHeight]);
-            const domainX = [p[0], p2[0]];
-            const domainY = [p2[1], p[1]];
-            return { domainX, domainY };
-        } catch (e) {
-            return { domainX: cx.minMax, domainY: cy.minMax };
-        }
-    }, [cx.minMax, cy.minMax, viewState, chartWidth, chartHeight, scatterplotLayer]);
-    const scaleX = useMemo(() => Scale.scaleLinear({
-        domain: ranges.domainX, // e.g. [min, max]
-        range: [margin.left, chartWidth + margin.left],
-    }), [chartWidth, ranges]);
-    const scaleY = useMemo(() => Scale.scaleLinear({
-        domain: ranges.domainY, // e.g. [min, max]
-        range: [chartHeight + margin.top, margin.top],
-    }), [chartHeight, ranges]);
-
-    const deckStyle = useMemo(() => ({
-        position: "absolute",
-        top: margin.top,
-        left: margin.left,
-        width: chartWidth,
-        height: chartHeight,
-    } as const), [chartWidth, chartHeight]);
+    
+    // unproject used for updating ranges - may refactor hooks around this
+    const unproject = useCallback((coords: [number, number]) => {
+        // make sure it applies to the right `this`
+        return scatterplotLayer.unproject(coords);
+    }, [scatterplotLayer]);
     return (
         <>
-            <div style={deckStyle}>
+            <AxisComponent config={config} unproject={unproject}>
                 <DeckGL
                     layers={layers}
                     useDevicePixels={true}
@@ -248,43 +222,7 @@ const DeckScatter = observer(function DeckScatterComponent() {
                     views={view}
                     onViewStateChange={v => { action(() => config.viewState = v.viewState)() }}
                 />
-            </div>
-            {is2d && <svg width={width} height={height}>
-                <Axis.AxisBottom
-                    top={chartHeight + margin.top}
-                    scale={scaleX}
-                    stroke={"var(--text_color)"}
-                    tickStroke={"var(--text_color)"}
-                    tickLabelProps={() => ({
-                        fill: "var(--text_color)",
-                        fontSize: config.axis.x.tickfont,
-                        textAnchor: "middle",
-                    })}
-                    labelProps={{
-                        fill: "var(--text_color)",
-                        fontSize: config.axis.x.tickfont,
-                        textAnchor: "middle",
-                    }}
-                    label={cx.name}
-                />
-                <Axis.AxisLeft
-                    left={margin.left}
-                    scale={scaleY}
-                    stroke={"var(--text_color)"}
-                    tickStroke={"var(--text_color)"}
-                    tickLabelProps={() => ({
-                        fill: "var(--text_color)",
-                        fontSize: config.axis.y.tickfont,
-                        textAnchor: "end",
-                    })}
-                    labelProps={{
-                        fill: "var(--text_color)",
-                        fontSize: config.axis.y.tickfont,
-                        // dx: config.axis.x.rotate_labels ? 
-                    }}
-                    label={cy.name}
-                />
-            </svg>}
+            </AxisComponent>
         </>
     );
 });

--- a/src/react/scatter_state.ts
+++ b/src/react/scatter_state.ts
@@ -1,5 +1,5 @@
 import type { Matrix4 } from "@math.gl/core";
-import type { PickingInfo } from "@deck.gl/core";
+import type { OrbitViewState, OrthographicViewState, PickingInfo } from "@deck.gl/core";
 import { useChart } from "./context";
 import {
     useChartID,
@@ -30,6 +30,15 @@ export type TooltipConfig = {
         column?: ColumnName;
     };
 };
+export type AxisConfig = {
+    size: number;
+    tickfont: number;
+    rotate_labels: boolean;
+};
+export type AxisConfig2D = {
+    x: AxisConfig;
+    y: AxisConfig;
+};
 export type CategoryFilter = {
     column: ColumnName;
     category: string | string[];
@@ -52,8 +61,18 @@ export type ScatterPlotConfig = {
     point_shape: "circle" | "square" | "gaussian";
     dimension: "2d" | "3d";
     selectionFeatureCollection: FeatureCollection;
-} & TooltipConfig &
-    DualContourLegacyConfig & BaseConfig;
+} & TooltipConfig & DualContourLegacyConfig & BaseConfig;
+
+export type ScatterPlotConfig2D = ScatterPlotConfig & {
+    dimension: "2d";
+    axis: AxisConfig2D;
+    viewState: OrthographicViewState;
+};
+export type ScatterPlotConfig3D = ScatterPlotConfig & {
+    dimension: "3d";
+    viewState: OrbitViewState;
+};
+
 export const scatterDefaults: Omit<ScatterPlotConfig, "id" | "legend" | "size" | "title" | "type" | "param"> = {
     course_radius: 1,
     radius: 10,
@@ -77,7 +96,18 @@ export const scatterDefaults: Omit<ScatterPlotConfig, "id" | "legend" | "size" |
     selectionFeatureCollection: getEmptyFeatureCollection(),
 };
 
-
+export const scatterAxisDefaults: AxisConfig2D = {
+    x: {
+        rotate_labels: false,
+        size: 10,
+        tickfont: 10,
+    },
+    y: {
+        rotate_labels: false,
+        size: 10,
+        tickfont: 10,
+    },
+}
 
 export function useRegionScale() {
     const metadata = useMetadata();


### PR DESCRIPTION
Makes axis controls for deck-based 2D scatterplot controllable through settings GUI, and refactor axis-related code.

Axis config settings should be broadly compatible with the previous version - although for now we don't handle `rotate_labels` which would not translate directly from the original code, and are not considered relevant in the case of numerical labels for scatterplots. In future, we will want to more extensively review the props of axes for other chart types where labels often become crowded etc.

We may also consider in future implementing more direct interaction on the axis elements - dragging to resize etc.

For now, this should at least be broadly functionally equivalent to the previous versions of these charts.