### PR TITLE
Md 485 tooltips for deck.gl scatterplot, hook for fields in config

### DIFF
--- a/src/charts/ChartManager.js
+++ b/src/charts/ChartManager.js
@@ -948,7 +948,13 @@ export class ChartManager {
         }
         if (config.tooltip) {
             if (config.tooltip.column) {
-                set.add(config.tooltip.column);
+                if (Array.isArray(config.tooltip.column)) {
+                    for (const i of config.tooltip.column) {
+                        set.add(i);
+                    }
+                } else {
+                    set.add(config.tooltip.column);
+                }
             }
         }
         if (config.background_filter) {

--- a/src/charts/chartConfigUtils.ts
+++ b/src/charts/chartConfigUtils.ts
@@ -1,12 +1,13 @@
 import { getRandomString } from "@/utilities/Utilities";
 import type BaseChart from "./BaseChart";
-import { action, type IReactionDisposer, makeAutoObservable } from "mobx";
-import type { FieldSpec } from "@/lib/columnTypeHelpers";
+import { action, makeAutoObservable } from "mobx";
+import type { FieldSpec, FieldSpecs } from "@/lib/columnTypeHelpers";
 import { RowsAsColsQuery, type RowsAsColsQuerySerialized } from "@/links/link_utils";
-import type { DataSource, FieldName } from "./charts";
+import type { FieldName } from "./charts";
 import type DataStore from "@/datastore/DataStore";
 import { isArray } from "@/lib/utils";
 import type { BaseConfig } from "./BaseChart";
+import type { TooltipConfig } from "@/react/scatter_state";
 
 /**
  * This is a utility module for handling the serialisation and deserialisation of chart configurations.
@@ -51,9 +52,10 @@ export function deserialiseParam(ds: DataStore, param: SerialisedColumnParam) {
     return result;
 }
 
-export function getConcreteFieldNames(fieldSpec: FieldSpec) {
+export function getConcreteFieldNames(fieldSpec: FieldSpec | FieldSpecs) {
     if (isArray(fieldSpec)) {
-        throw new Error("Not implemented");
+        // throw new Error("Not implemented");
+        return fieldSpec.flatMap((f) => typeof f === "string" ? f : f.fields);
     }
     //! nb, previously unused, now changing the signature to return string array
     //(I've had it with checking for array or string)
@@ -160,12 +162,25 @@ export function initialiseChartConfig<C extends BaseConfig, T extends BaseChart<
             chart.colorByColumn?.(colorBy);
         })
     }
-    if ((originalConfig as any).tooltip?.column) {
-        const tooltipColumn = deserialiseParam(chart.dataStore, (originalConfig as any).tooltip.column);
-        (config as any).tooltip.column = getConcreteFieldNames(tooltipColumn)[0];
-        chart.deferredInit(() => {
-            if (chart.setToolTipColumn) chart.setToolTipColumn(tooltipColumn);
-        })
+    const configWithTooltip = config as unknown as TooltipConfig;
+    const serialisedTooltipColumn = configWithTooltip.tooltip?.column;
+    if (serialisedTooltipColumn) {
+        if (isArray(serialisedTooltipColumn)) {
+            //@ts-expect-error type FieldSpec isn't serialised form, so deserialise complains
+            const tooltipColumn = serialisedTooltipColumn.map((c) => deserialiseParam(chart.dataStore, c));
+            (config as any).tooltip.column = getConcreteFieldNames(tooltipColumn);
+            // we're not using this method with multi-column, only react charts which aren't so method-based have this(?)
+            // chart.deferredInit(() => {
+            //     if (chart.setToolTipColumn) chart.setToolTipColumn(tooltipColumn);
+            // })            
+        } else {
+            //@ts-expect-error type FieldSpec isn't serialised form, so deserialise complains
+            const tooltipColumn = deserialiseParam(chart.dataStore, serialisedTooltipColumn);
+            (config as any).tooltip.column = getConcreteFieldNames(tooltipColumn)[0];
+            chart.deferredInit(() => {
+                if (chart.setToolTipColumn) chart.setToolTipColumn(tooltipColumn);
+            });
+        }
     }
     console.log(config.type, 'processed config:', config);
     //temporary way of prototyping query

--- a/src/charts/dialogs/utils/TooltipSettingsGui.ts
+++ b/src/charts/dialogs/utils/TooltipSettingsGui.ts
@@ -22,7 +22,6 @@ export default function getTooltipSettings(config: ScatterPlotConfig, callback?:
                 //@ts-expect-error - need a way of dealing with optional column...
                 current_value: config.tooltip.column,
                 func: async (x) => {
-                    //@ts-expect-error pending tooltip column being FieldSpec(s)
                     config.tooltip.column = x;
                     callback?.();
                 }

--- a/src/charts/dialogs/utils/TooltipSettingsGui.ts
+++ b/src/charts/dialogs/utils/TooltipSettingsGui.ts
@@ -1,55 +1,8 @@
-import BaseChart from "@/charts/BaseChart";
-import { DataColumn, DataType } from "@/charts/charts";
-import { loadColumn } from "@/dataloaders/DataLoaderUtil";
 import { g } from "@/lib/utils";
 import type { ScatterPlotConfig } from "@/react/scatter_state";
 
 // this will be for more general tooltip settings rather than just scatterplot
-export default function getTooltipSettings(config: ScatterPlotConfig, chart: BaseChart<any>) {
-    return getTooltipSettings2(config);
-    // really don't want to be messing around with dataStore and such here...
-    // first step is to separate out the tooltip settings from the chart config
-    // and then we can sort out the implementation details
-    const { tooltip } = config;
-    const { dataStore } = chart;
-    const cols = dataStore.getColumnList() as DataColumn<DataType>[];
-    return g({
-        type: "folder",
-        label: "Tooltip",
-        current_value: [
-            g({
-                type: "check",
-                label: "Show Tooltip",
-                current_value: tooltip.show,
-                func: async (x: boolean) => {
-                    tooltip.show = x;
-                    if (!tooltip.column) {
-                        const columnName = cols[0].field;
-                        console.log(
-                            "No tooltip column set, using first column:",
-                            columnName,
-                        );
-                        await loadColumn(dataStore.name, cols[0].field);
-                        tooltip.column = cols[0].field;
-                    }
-                },
-            }),
-            g({
-                type: "dropdown",
-                label: "Tooltip value",
-                current_value: tooltip.column || cols[0].field,
-                //@ts-expect-error - should be using "column" for the GiuSpecType rather than "dropdown"
-                values: [cols, "name", "field"],
-                func: async (c) => {
-                    await loadColumn(dataStore.name, c);
-                    tooltip.column = c;
-                },
-            }),
-        ]
-    });
-}
-
-function getTooltipSettings2(config: ScatterPlotConfig, callback?: () => void) {
+export default function getTooltipSettings(config: ScatterPlotConfig, callback?: () => void) {
     return g({
         type: "folder",
         label: "Tooltip",

--- a/src/charts/dialogs/utils/TooltipSettingsGui.ts
+++ b/src/charts/dialogs/utils/TooltipSettingsGui.ts
@@ -17,7 +17,7 @@ export default function getTooltipSettings(config: ScatterPlotConfig, callback?:
                 },
             }),
             g({
-                type: "column",
+                type: "multicolumn",
                 label: "Tooltip value",
                 //@ts-expect-error - need a way of dealing with optional column...
                 current_value: config.tooltip.column,

--- a/src/charts/dialogs/utils/TooltipSettingsGui.ts
+++ b/src/charts/dialogs/utils/TooltipSettingsGui.ts
@@ -1,0 +1,78 @@
+import BaseChart from "@/charts/BaseChart";
+import { DataColumn, DataType } from "@/charts/charts";
+import { loadColumn } from "@/dataloaders/DataLoaderUtil";
+import { g } from "@/lib/utils";
+import type { ScatterPlotConfig } from "@/react/scatter_state";
+
+// this will be for more general tooltip settings rather than just scatterplot
+export default function getTooltipSettings(config: ScatterPlotConfig, chart: BaseChart<any>) {
+    // really don't want to be messing around with dataStore and such here...
+    // first step is to separate out the tooltip settings from the chart config
+    // and then we can sort out the implementation details
+    const { tooltip } = config;
+    const { dataStore } = chart;
+    const cols = dataStore.getColumnList() as DataColumn<DataType>[];
+    return g({
+        type: "folder",
+        label: "Tooltip",
+        current_value: [
+            g({
+                type: "check",
+                label: "Show Tooltip",
+                current_value: tooltip.show,
+                func: async (x: boolean) => {
+                    tooltip.show = x;
+                    if (!tooltip.column) {
+                        const columnName = cols[0].field;
+                        console.log(
+                            "No tooltip column set, using first column:",
+                            columnName,
+                        );
+                        await loadColumn(dataStore.name, cols[0].field);
+                        tooltip.column = cols[0].field;
+                    }
+                },
+            }),
+            g({
+                type: "dropdown",
+                label: "Tooltip value",
+                current_value: tooltip.column || cols[0].field,
+                //@ts-expect-error - should be using "column" for the GiuSpecType rather than "dropdown"
+                values: [cols, "name", "field"],
+                func: async (c) => {
+                    await loadColumn(dataStore.name, c);
+                    tooltip.column = c;
+                },
+            }),
+        ]
+    });
+}
+
+function getTooltipSettings2(config: ScatterPlotConfig, callback?: () => void) {
+    return g({
+        type: "folder",
+        label: "Tooltip",
+        current_value: [
+            g({
+                type: "check",
+                label: "Show tooltip",
+                current_value: config.tooltip.show,
+                func: (x) => {
+                    config.tooltip.show = x;
+                    callback?.();
+                },
+            }),
+            g({
+                type: "column",
+                label: "Tooltip value",
+                //@ts-expect-error - need a way of dealing with optional column...
+                current_value: config.tooltip.column,
+                func: async (x) => {
+                    //@ts-expect-error pending tooltip column being FieldSpec(s)
+                    config.tooltip.column = x;
+                    callback?.();
+                }
+            }),
+        ]
+    });
+}

--- a/src/charts/dialogs/utils/TooltipSettingsGui.ts
+++ b/src/charts/dialogs/utils/TooltipSettingsGui.ts
@@ -6,6 +6,7 @@ import type { ScatterPlotConfig } from "@/react/scatter_state";
 
 // this will be for more general tooltip settings rather than just scatterplot
 export default function getTooltipSettings(config: ScatterPlotConfig, chart: BaseChart<any>) {
+    return getTooltipSettings2(config);
     // really don't want to be messing around with dataStore and such here...
     // first step is to separate out the tooltip settings from the chart config
     // and then we can sort out the implementation details

--- a/src/react/components/AxisComponent.tsx
+++ b/src/react/components/AxisComponent.tsx
@@ -1,5 +1,5 @@
 import { observer } from "mobx-react-lite";
-import { AxisConfig, ScatterPlotConfig2D, ScatterPlotConfig3D } from "../scatter_state";
+import type { AxisConfig, ScatterPlotConfig2D, ScatterPlotConfig3D } from "../scatter_state";
 import type { DataColumn } from "@/charts/charts";
 import { useChartSize, useParamColumns } from "../hooks";
 import { useEffect, useMemo, type PropsWithChildren } from "react";
@@ -61,6 +61,7 @@ export default observer(function AxisComponent({ config, unproject, children }: 
             const domainY = [p2[1], p[1]];
             return { domainX, domainY };
         } catch (e) {
+            // console.warn("AxisComponent: unproject failed", e);
             return { domainX: cx.minMax, domainY: cy.minMax };
         }
     }, [cx.minMax, cy.minMax, viewState, chartWidth, chartHeight, unproject]);
@@ -69,11 +70,11 @@ export default observer(function AxisComponent({ config, unproject, children }: 
     const scaleX = useMemo(() => Scale.scaleLinear({
         domain: ranges.domainX, // e.g. [min, max]
         range: [margin.left, chartWidth + margin.left],
-    }), [chartWidth, ranges]);
+    }), [chartWidth, ranges, margin.left]);
     const scaleY = useMemo(() => Scale.scaleLinear({
         domain: ranges.domainY, // e.g. [min, max]
         range: [chartHeight + margin.top, margin.top],
-    }), [chartHeight, ranges]);
+    }), [chartHeight, ranges, margin.top]);
 
     const deckStyle = useMemo(() => ({
         position: "absolute",
@@ -81,7 +82,7 @@ export default observer(function AxisComponent({ config, unproject, children }: 
         left: margin.left,
         width: chartWidth,
         height: chartHeight,
-    } as const), [chartWidth, chartHeight]);
+    } as const), [chartWidth, chartHeight, margin.top, margin.left]);
     // useEffect(() => {
     //     if (is2d && (config.axis.x.rotate_labels || config.axis.y.rotate_labels)) {
     //         console.warn("Axis rotation not implemented for react charts");

--- a/src/react/components/DeckScatterComponent.tsx
+++ b/src/react/components/DeckScatterComponent.tsx
@@ -221,6 +221,7 @@ const DeckScatter = observer(function DeckScatterComponent() {
                     // initialViewState={viewState} //consider not using react state for this        
                     views={view}
                     onViewStateChange={v => { action(() => config.viewState = v.viewState)() }}
+                    getTooltip={getTooltip}
                 />
             </AxisComponent>
         </>

--- a/src/react/components/DeckScatterReactWrapper.tsx
+++ b/src/react/components/DeckScatterReactWrapper.tsx
@@ -10,6 +10,7 @@ import type { OrthographicViewState, OrbitViewState } from "deck.gl";
 import { g } from "@/lib/utils";
 import type DataStore from "@/datastore/DataStore";
 import getAxisGuiSpec from "@/charts/dialogs/utils/AxisSettingsGui";
+import getTooltipSettings from "@/charts/dialogs/utils/TooltipSettingsGui";
 
 const MainChart = observer(() => {
     return <DeckScatterComponent />;
@@ -90,11 +91,8 @@ class DeckScatterReact extends BaseReactChart<DeckScatterConfig> {
 
     getSettings() {
         const c = this.config;
-        const { tooltip } = c;
-        const cols = this.dataStore.getColumnList() as DataColumn<DataType>[];
-        //const catCols = cols.filter((c) => c.datatype.match(/text/i));
+        
         const settings = super.getSettings();
-
 
         if (c.dimension === "2d") {
             const axisSettings = getAxisGuiSpec(c);
@@ -102,34 +100,7 @@ class DeckScatterReact extends BaseReactChart<DeckScatterConfig> {
         }
         return settings.concat([
             //todo standard tooltip setting (with multi-choice)
-            g({
-                type: "check",
-                label: "Show Tooltip",
-                current_value: tooltip.show,
-                func: async (x: boolean) => {
-                    tooltip.show = x;
-                    if (!tooltip.column) {
-                        const columnName = cols[0].field;
-                        console.log(
-                            "No tooltip column set, using first column:",
-                            columnName,
-                        );
-                        await loadColumn(this.dataStore.name, cols[0].field);
-                        tooltip.column = cols[0].field;
-                    }
-                },
-            }),
-            g({
-                type: "dropdown",
-                label: "Tooltip value",
-                current_value: c.tooltip.column || cols[0].field,
-                //@ts-expect-error - should be using "column" for the GiuSpecType rather than "dropdown"
-                values: [cols, "name", "field"],
-                func: async (c) => {
-                    await loadColumn(this.dataStore.name, c);
-                    tooltip.column = c;
-                },
-            }),
+            getTooltipSettings(c, this),
             g({
                 type: "radiobuttons",
                 label: "course radius",

--- a/src/react/components/DeckScatterReactWrapper.tsx
+++ b/src/react/components/DeckScatterReactWrapper.tsx
@@ -91,7 +91,6 @@ class DeckScatterReact extends BaseReactChart<DeckScatterConfig> {
 
     getSettings() {
         const c = this.config;
-        
         const settings = super.getSettings();
 
         if (c.dimension === "2d") {
@@ -99,8 +98,7 @@ class DeckScatterReact extends BaseReactChart<DeckScatterConfig> {
             settings.push(axisSettings);
         }
         return settings.concat([
-            //todo standard tooltip setting (with multi-choice)
-            getTooltipSettings(c, this),
+            getTooltipSettings(c),
             g({
                 type: "radiobuttons",
                 label: "course radius",

--- a/src/react/components/VivMDVReact.tsx
+++ b/src/react/components/VivMDVReact.tsx
@@ -24,6 +24,7 @@ import { useChart } from "../context";
 import type DataStore from "@/datastore/DataStore";
 import { g, isArray, toArray } from "@/lib/utils";
 import { scatterDefaults, type ScatterPlotConfig } from "../scatter_state";
+import getTooltipSettings from "@/charts/dialogs/utils/TooltipSettingsGui";
 
 function VivScatterChartRoot() {
     // to make this look like Avivator...
@@ -237,33 +238,7 @@ class VivMdvReact extends BaseReactChart<VivMdvReactConfig> {
                     c.background_filter.category = v;
                 },
             }),
-            g({
-                type: "check",
-                label: "Show Tooltip",
-                current_value: tooltip.show,
-                func: async (x: boolean) => {
-                    tooltip.show = x;
-                    if (!tooltip.column) {
-                        const columnName = cols[0].field;
-                        console.log(
-                            "No tooltip column set, using first column:",
-                            columnName
-                        );
-                        await loadColumn(this.dataStore.name, cols[0].field);
-                        tooltip.column = cols[0].field;
-                    }
-                },
-            }),
-            g({
-                type: "dropdown",
-                label: "Tooltip value",
-                current_value: c.tooltip.column || cols[0].field,
-                values: [cols, "name", "field"],
-                func: async (c) => {
-                    await loadColumn(this.dataStore.name, c);
-                    tooltip.column = c;
-                },
-            }),
+            getTooltipSettings(c, this),
             g({
                 type: "dropdown",
                 label: "Shape",

--- a/src/react/components/VivMDVReact.tsx
+++ b/src/react/components/VivMDVReact.tsx
@@ -238,7 +238,7 @@ class VivMdvReact extends BaseReactChart<VivMdvReactConfig> {
                     c.background_filter.category = v;
                 },
             }),
-            getTooltipSettings(c, this),
+            getTooltipSettings(c),
             g({
                 type: "dropdown",
                 label: "Shape",

--- a/src/react/components/VivScatterComponent.tsx
+++ b/src/react/components/VivScatterComponent.tsx
@@ -172,7 +172,6 @@ const Main = observer(() => {
             contrast,
         ],
     );
-    //@ts-expect-error tooltip content should be fixed
     const deckProps: Partial<DeckGLProps> = useMemo(
         () => ({
             getTooltip,

--- a/src/react/contour_state.ts
+++ b/src/react/contour_state.ts
@@ -98,7 +98,7 @@ export function useContour(props: ContourProps) {
     // there's a possiblity that in future different layers of the same chart might draw from different data sources...
     // so encapsulating things like getPosition might be useful.
     const [cx, cy] = useParamColumns();
-    const { column: contourParameter } = useFieldSpec(parameter) || { column: undefined };
+    const contourParameter = useFieldSpec(parameter);
     if (!contourParameter) {
         console.error(`Contour parameter '${parameter}' not found`);
         return undefined;

--- a/src/react/contour_state.ts
+++ b/src/react/contour_state.ts
@@ -3,7 +3,7 @@ import { useMemo } from "react";
 import {
     useCategoryFilterIndices,
     useConfig,
-    useNamedColumn,
+    useFieldSpec,
     useParamColumns,
 } from "./hooks";
 import { useDataStore } from "./context";
@@ -98,7 +98,7 @@ export function useContour(props: ContourProps) {
     // there's a possiblity that in future different layers of the same chart might draw from different data sources...
     // so encapsulating things like getPosition might be useful.
     const [cx, cy] = useParamColumns();
-    const { column: contourParameter } = useNamedColumn(parameter) || { column: undefined };
+    const { column: contourParameter } = useFieldSpec(parameter) || { column: undefined };
     if (!contourParameter) {
         console.error(`Contour parameter '${parameter}' not found`);
         return undefined;

--- a/src/react/hooks.ts
+++ b/src/react/hooks.ts
@@ -129,13 +129,12 @@ export function useParamColumns(): LoadedDataColumn<DataType>[] {
  * If the spec is for some active column that changes at runtime, this will set up appropriate
  * (re)loading.
  */
-export function useFieldSpecs(specs: FieldSpecs) {
+export function useFieldSpecs(specs?: FieldSpecs | FieldSpec) {
     const chart = useChart();
     // consider different loading strategies, lazy vs eager column data
     //todo generic type with corresponding check when loaded
     const [columns, setColumns] = useState<DataColumn<any>[]>([]);
     //I'm dubious about this...
-    // biome-ignore lint/correctness/useExhaustiveDependencies: specs is the same mobx observable, and re-runs effect if included in deps
     useEffect(() => {
         if (!specs) {
             setColumns([]);
@@ -158,7 +157,7 @@ export function useFieldSpecs(specs: FieldSpecs) {
                 setColumns(columns);
             });
         });
-    }, []);
+    }, [specs, chart.dataStore]);
     return columns;
 }
 export function useFieldSpec(spec?: FieldSpec) {

--- a/src/react/hooks.ts
+++ b/src/react/hooks.ts
@@ -131,17 +131,19 @@ export function useParamColumns(): LoadedDataColumn<DataType>[] {
  */
 export function useFieldSpecs(specs: FieldSpecs) {
     const chart = useChart();
-    // may consider different loading strategies later
-    // const [isLoaded, setIsLoaded] = useState(false);
+    // consider different loading strategies, lazy vs eager column data
+    //todo generic type with corresponding check when loaded
     const [columns, setColumns] = useState<DataColumn<any>[]>([]);
+    //I'm dubious about this...
+    // biome-ignore lint/correctness/useExhaustiveDependencies: specs is the same mobx observable, and re-runs effect if included in deps
     useEffect(() => {
         if (!specs) {
             setColumns([]);
             return;
         }
         return autorun(() => {
-            const fieldName = flattenFields(specs);
-            if (!fieldName) {
+            const fieldNames = flattenFields(specs);
+            if (!fieldNames) {
                 setColumns([]);
                 return;
             }
@@ -149,16 +151,14 @@ export function useFieldSpecs(specs: FieldSpecs) {
             // if this is less efficient than it could be with already loaded columns,
             // we could fix it upstream - although there'll always be some async...
             // but then that's generally the case with setState etc
-            cm.loadColumnSet(fieldName, chart.dataStore.name, () => {
+            // console.log("loading columns", fieldNames);
+            cm.loadColumnSet(fieldNames, chart.dataStore.name, () => {
                 const { columnIndex } = chart.dataStore;
-                const columns = fieldName.map((f) => columnIndex[f]).filter(notEmpty);
-                if (columns.length !== fieldName.length) {
-                    throw `some columns are not loaded?`;
-                }
+                const columns = fieldNames.map((f) => columnIndex[f]).filter(notEmpty);
                 setColumns(columns);
             });
         });
-    }, [specs, chart.dataStore]);
+    }, []);
     return columns;
 }
 export function useFieldSpec(spec?: FieldSpec) {

--- a/src/react/scatter_state.ts
+++ b/src/react/scatter_state.ts
@@ -291,7 +291,10 @@ export function useScatterplotLayer(modelMatrix: Matrix4) {
     );
     const contourLayers = useLegacyDualContour();
 
-    const tooltipCol = useFieldSpec(config.tooltip.column)?.column;
+    // would rather not even need to call a hook here, but just have some
+    // `state.tooltip.column` which would have a column object...
+    // but this isn't really all that bad, so maybe we can stick with it.
+    const tooltipCol = useFieldSpec(config.tooltip.column);
     const getTooltipVal = useCallback(
         (i: number) => {
             // if (!tooltipCol?.data) return '#'+i;

--- a/src/react/scatter_state.ts
+++ b/src/react/scatter_state.ts
@@ -24,7 +24,8 @@ import type { ColumnName } from "@/charts/charts";
 import type { FeatureCollection } from "@turf/helpers";
 import { getEmptyFeatureCollection } from "./spatial_context";
 import type { BaseConfig } from "@/charts/BaseChart";
-import { type FieldSpec, type FieldSpecs, flattenFields } from "@/lib/columnTypeHelpers";
+import type { FieldSpec, FieldSpecs } from "@/lib/columnTypeHelpers";
+import type { TooltipContent } from "@deck.gl/core/dist/lib/tooltip";
 
 export type TooltipConfig = {
     tooltip: {
@@ -300,23 +301,28 @@ export function useScatterplotLayer(modelMatrix: Matrix4) {
             if (!tooltipCols) return null;
             // return tooltipCols.getValue(data[i]);
             return tooltipCols.map((col) => {
-                    return `${col.name}: ${col.data ? col.getValue(data[i]) : "loading..."}`;
-            }).join("\n");
+                    return `<strong>${col.name}:</strong> ${col.data ? col.getValue(data[i]) : "loading..."}`;
+            });
         },
         [tooltipCols, data],
     );
     const getTooltip = useCallback(
         //todo nicer tooltip interface (and review how this hook works)
-        //allow multicolumn with nice formatting
         () => {
             if (!config.tooltip.show) return null;
             if (!config.tooltip.column) return null;
-            // testing reading object properties --- pending further development
+            // testing reading object properties --- pending further development (for GeoJSON layer in particular)
+            // also consider some other things like transcripts / stats heatmap etc...
             // (not hardcoding DN property etc)
             // if (object && object?.properties?.DN) return `DN: ${object.properties.DN}`;
             const hoverInfo = hoverInfoRef.current;
             if (!hoverInfo || hoverInfo.index === -1) return null;
-            return getTooltipVal(hoverInfo.index);
+            const tooltipVal = getTooltipVal(hoverInfo.index);
+            if (!tooltipVal) return null;
+            const tooltip: TooltipContent = {
+                html: `<div>${tooltipVal.join("<br/>")}</div>`,
+            }
+            return tooltip;
         },
         [getTooltipVal, config.tooltip.show, config.tooltip.column],
     );

--- a/src/react/scatter_state.ts
+++ b/src/react/scatter_state.ts
@@ -24,14 +24,14 @@ import type { ColumnName } from "@/charts/charts";
 import type { FeatureCollection } from "@turf/helpers";
 import { getEmptyFeatureCollection } from "./spatial_context";
 import type { BaseConfig } from "@/charts/BaseChart";
-import { flattenFields } from "@/lib/columnTypeHelpers";
+import { type FieldSpec, flattenFields } from "@/lib/columnTypeHelpers";
 
 export type TooltipConfig = {
     tooltip: {
         show: boolean;
         // would like to be able to have multiple columns
         // sticking to version that should be compatible with old config
-        column?: ColumnName;
+        column?: FieldSpec;
     };
 };
 export type AxisConfig = {


### PR DESCRIPTION
Both deck scatterplots & react-viv charts now use common code for tooltips, and associated settings dialog entries.

`useFieldSpecs(specs)` hook has been added, which is generally useful any time a chart config object has some arbitrary property representing column data, rather than requiring that fields either be listed in `param` or have `configEntriesUsingColumns` (which is only useful for non-nested properties) etc.

New tooltips accept multi-column, so that users can get a bit more useful insight from them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced tooltip functionality in scatterplots to support displaying multiple columns simultaneously.
  - Tooltip settings now provide a multiselect interface for choosing multiple columns to display in tooltips.

- **Bug Fixes**
  - Tooltips now correctly display all selected columns, resolving previous issues with array handling.

- **Refactor**
  - Consolidated tooltip settings UI into a reusable utility for consistency across components.
  - Improved hooks for loading and managing multiple data columns dynamically.

- **Chores**
  - Cleaned up unused imports and improved dependency tracking in memoized React hooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->