### PR TITLE
Removed key shortcut for y and n in save as dialog

### DIFF
--- a/src/charts/dialogs/SaveAsViewDialog.tsx
+++ b/src/charts/dialogs/SaveAsViewDialog.tsx
@@ -17,28 +17,6 @@ const SaveAsViewDialogComponent = (props: {
         props.onClose();
     }, [viewManager, viewName, props]);
 
-    useEffect(() => {
-        const handleKeyDown = (event: KeyboardEvent) => {
-            if (!props.open) return; //probably doesn't happen, but no harm to check
-            if (event.key === "y") {
-                event.preventDefault();
-                onSaveAs();
-                props.onClose();
-            }
-            if (event.key === "n") {
-                event.preventDefault();
-                props.onClose();
-            }            
-        };
-
-        // seems ok to use window here since this is a modal dialog
-        // saves faffing about with refs
-        window.addEventListener("keydown", handleKeyDown);
-        return () => {
-            window.removeEventListener("keydown", handleKeyDown);
-        };
-    }, [props, onSaveAs, props.open]);
-
     return (
         <Dialog open={props.open} onClose={props.onClose} fullWidth maxWidth="xs">
             <DialogTitle>Save View As...</DialogTitle>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed global keyboard shortcuts ("y" to save, "n" to close) from the save dialog. Keyboard shortcuts are no longer available for this dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->