### PR TITLE
revert 3d scatter plot

### DIFF
--- a/src/react/components/DeckScatterReactWrapper.tsx
+++ b/src/react/components/DeckScatterReactWrapper.tsx
@@ -233,7 +233,8 @@ BaseChart.types["wgl_scatter_plot_dev"] = {
     ]
 };
 BaseChart.types["wgl_3d_scatter_plot_dev"] = {
-    name: "3D Scatter Plot",
+    // todo: remove (Deck) later, added to differentiate it with the existing 3d scatter plot
+    name: "3D Scatter Plot (Deck)",
     class: DeckScatterReact,
     allow_user_add: false,
     params: [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the display name of the "3D Scatter Plot" chart type to "3D Scatter Plot (Deck)" for clearer differentiation in the chart selection interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->