### PR TITLE
Md 535 multiple links subgroups support

### DIFF
--- a/src/links/link_utils.ts
+++ b/src/links/link_utils.ts
@@ -200,7 +200,10 @@ export type RowsAsColslink = {
             type: string;
         }
     },
-    /** added at runtime, observable array corresponding to currently selected/highlighted items */
+    /** 
+     * added at runtime, observable array corresponding to currently selected/highlighted items.
+     * In order to support multiple subgroups, should this be Map<string, IRowAsColumn[]> (or Record, not important)
+     */
     observableFields: IRowAsColumn[];
     //^^ what if it was iterator instead of Array? and/or `column` can be a computed value?
     // observableColumns: DataColumn<DataType>[]; //computed?
@@ -208,6 +211,7 @@ export type RowsAsColslink = {
      * Added at runtime, given a value appearing in `name_column`, the index of a row corresponding to that value.
      * This can be used in the formation of a {@link FieldName}
      * ! note, we should be able to use 'unique' values in the name_column, and would like to do away with this
+     * ^^ this is essentially a bug
      * It is now optional to reflect that it will not be available until `initPromise` resolves.
      */
     valueToRowIndex?: Map<string, number>;

--- a/src/react/chartLinkHooks.ts
+++ b/src/react/chartLinkHooks.ts
@@ -110,14 +110,14 @@ export function useRowsAsColumnsLinks() {
     return getRowsAsColumnsLinks(dataStore);
 }
 
-/** design of this will need to change to account for n-links
+/** What if the linkIndex might be able to change at runtime?
  * 
  * We could also consider having distinct hooks for highlighted and filtered rows.
  * @returns the text values and indices of the highlighted/filtered rows in a linked dataSource
  */
-export function useHighlightedForeignRows() {
+export function useHighlightedForeignRows(linkIndex = 0) {
     const id = useId();
-    const racLink = useRowsAsColumnsLinks()[0];
+    const racLink = useRowsAsColumnsLinks()[linkIndex];
     const values = racLink?.link.observableFields || [];
     return values; //maybe don't useState version of this but return the mobx observable directly
 }
@@ -136,11 +136,11 @@ export function useHighlightedForeignRows() {
  * @returns an array of DataColumn objects, with loaded data, for virtual columns 
  * corresponding to the highlighted/filtered rows in the linked dataSource.
  */
-export function useHighlightedForeignRowsAsColumns(max = 10, filter = "") {
-    const cols = useHighlightedForeignRows(); //not actual cols
+export function useHighlightedForeignRowsAsColumns(max = 10, filter = "", linkIndex = 0) {
+    const cols = useHighlightedForeignRows(linkIndex); //not actual cols
     //would like not to have this here - might have some more logic in above hook
     //in particular want to redesign the fieldName being what determines the column
-    const racLink = useRowsAsColumnsLinks()[0];
+    const racLink = useRowsAsColumnsLinks()[linkIndex];
     //! this next line may be problematic - useMemo is important
     const { link } = useMemo(() => racLink || { link: null }, [racLink]);
     const [columns, setColumns] = useState<DataColumn<DataType>[]>([]);
@@ -157,6 +157,7 @@ export function useHighlightedForeignRowsAsColumns(max = 10, filter = "") {
         }
         const cm = window.mdv.chartManager;
         // c.value & c.index are from the DataStore listener event, now in cols
+        // this needs to change for multiple subgroups
         const sg = Object.keys(link.subgroups)[0];
         const f = filter.toLowerCase();
         // todo: consider pagination... pass in a page number, return information about total number of columns etc.

--- a/src/react/components/ActiveLinkComponent.tsx
+++ b/src/react/components/ActiveLinkComponent.tsx
@@ -1,37 +1,54 @@
 import type { ColumnSelectionProps, CTypes } from "@/lib/columnTypeHelpers";
 import { observer } from "mobx-react-lite";
-import { useHighlightedForeignRows, useRowsAsColumnsLinks } from "../chartLinkHooks";
+import { useRowsAsColumnsLinks } from "../chartLinkHooks";
 import { useCallback, useMemo, useState } from "react";
 import { isArray } from "@/lib/utils";
 import { RowsAsColsQuery } from "@/links/link_utils";
 import { Button, TextField } from "@mui/material";
 import { action } from "mobx";
 
-function useActiveLink<T extends CTypes, M extends boolean>(props: ColumnSelectionProps<T, M>) {
-    const { link, linkedDs } = useRowsAsColumnsLinks()[0]; //pending multiple link support
+type LocalProps<T extends CTypes, M extends boolean> = ColumnSelectionProps<
+    T,
+    M
+> & {
+    link: ReturnType<typeof useRowsAsColumnsLinks>[0];
+};
+
+function useActiveLink<T extends CTypes, M extends boolean>(
+    props: LocalProps<T, M>,
+) {
+    const { link, linkedDs } = props.link; //pending multiple link support
     const sg = Object.values(link.subgroups)[0]; //pending subgroup support
     // const highlightedForeignRows = useHighlightedForeignRows();
     const isActive = useMemo(() => {
         const ov = props.current_value;
         const v = isArray(ov) ? ov[0] : ov;
-        // for now, if it's not a string, there's only one option - it's an active link...
-        //! but this is not the long-term intention.
-        return typeof v !== "string";
-    }, [props.current_value]);
+        // still needs more understanding of sg etc etc
+        return (
+            typeof v !== "string" &&
+            v instanceof RowsAsColsQuery &&
+            v.link === link
+        ); // && v.subgroup === sg;
+    }, [props.current_value, link, sg]);
     // if we already have a link, we should initialize the maxItems to its current value
     const defaultMaxItems = props.multiple ? 10 : 1;
     // will change when we can actually select different link/sg... but we could just keep one of these around
     // apply it to the app state / mutate whenever... this is very un-functional/react... which is a shame (really).
     const [queryObj] = useState(() => {
         if (props.current_value) {
-            const v = isArray(props.current_value) ? props.current_value[0] : props.current_value;
-            if (v instanceof RowsAsColsQuery) return v;
+            const v = isArray(props.current_value)
+                ? props.current_value[0]
+                : props.current_value;
+            if (v instanceof RowsAsColsQuery && v.link === link) return v;
         }
         return new RowsAsColsQuery(link, linkedDs.name, defaultMaxItems);
     });
-    const setMaxItems = useCallback(action((v: number) => {
-        queryObj.maxItems = v;
-    }), []);
+    const setMaxItems = useCallback(
+        action((v: number) => {
+            queryObj.maxItems = v;
+        }),
+        [],
+    );
     const activateLink = useCallback(() => {
         //@ts-expect-error setSelectedColumn generic not behaving nicely
         props.setSelectedColumn(props.multiple ? [queryObj] : queryObj);
@@ -51,37 +68,58 @@ function useActiveLink<T extends CTypes, M extends boolean>(props: ColumnSelecti
     };
 }
 
-const ActiveLinkComponent = observer(<T extends CTypes, M extends boolean>(props: ColumnSelectionProps<T, M>) => {
-    const {
-        isActive,
-        activateLink,
-        maxItems,
-        setMaxItems,
-        sg,
-        // highlightedForeignRows,
-    } = useActiveLink(props);
-    // maybe something like rowsText can be shown in a little scrollable box...
-    // const rowsText = highlightedForeignRows.slice(0, maxItems).map((r) => r.name).join(", ");
+const ActiveLinkComponent = observer(
+    <T extends CTypes, M extends boolean>(props: LocalProps<T, M>) => {
+        const {
+            isActive,
+            activateLink,
+            maxItems,
+            setMaxItems,
+            sg,
+            // highlightedForeignRows,
+        } = useActiveLink(props);
+        // maybe something like rowsText can be shown in a little scrollable box...
+        // const rowsText = highlightedForeignRows.slice(0, maxItems).map((r) => r.name).join(", ");
 
-    return (
-        <div className="w-full flex justify-around text-xs font-light">
-            <Button onClick={activateLink}>
-                {isActive ? "Using" : "Activate"} '{sg.label}' Link
-            </Button>
-            {props.multiple && (
-                <TextField
-                    size="small"
-                    className="max-w-20 float-right"
-                    type="number"
-                    label="Max"
-                    variant="standard"
-                    value={maxItems}
-                    onChange={(e) => setMaxItems(Number(e.target.value))}
-                />
-            )}
-            {/* {isActive && rowsText} */}
-        </div>
-    );
-});
+        return (
+            <div className="w-full flex justify-around text-xs font-light">
+                <Button onClick={activateLink}>
+                    {isActive ? "Using" : "Activate"} '{sg.label}' Link
+                </Button>
+                {props.multiple && (
+                    <TextField
+                        size="small"
+                        className="max-w-20 float-right"
+                        type="number"
+                        label="Max"
+                        variant="standard"
+                        value={maxItems}
+                        onChange={(e) => setMaxItems(Number(e.target.value))}
+                    />
+                )}
+                {/* {isActive && rowsText} */}
+            </div>
+        );
+    },
+);
 
-export default ActiveLinkComponent;
+const ActiveLinkMultiComponent = observer(
+    <T extends CTypes, M extends boolean>(
+        props: ColumnSelectionProps<T, M>,
+    ) => {
+        const links = useRowsAsColumnsLinks();
+        return (
+            <>
+                {links.map((link) => (
+                    <ActiveLinkComponent
+                        key={link.link.name}
+                        {...props}
+                        link={link}
+                    />
+                ))}
+            </>
+        );
+    },
+);
+
+export default ActiveLinkMultiComponent;

--- a/src/react/components/ActiveLinkComponent.tsx
+++ b/src/react/components/ActiveLinkComponent.tsx
@@ -82,7 +82,7 @@ const ActiveLinkComponent = observer(
         // const rowsText = highlightedForeignRows.slice(0, maxItems).map((r) => r.name).join(", ");
 
         return (
-            <div className="w-full flex justify-around text-xs font-light">
+            <div className="w-full flex justify-end text-xs font-light p-1">
                 <Button onClick={activateLink}>
                     {isActive ? "Using" : "Activate"} '{sg.label}' Link
                 </Button>

--- a/src/react/components/ActiveLinkComponent.tsx
+++ b/src/react/components/ActiveLinkComponent.tsx
@@ -29,7 +29,7 @@ function useActiveLink<T extends CTypes, M extends boolean>(
             v instanceof RowsAsColsQuery &&
             v.link === link
         ); // && v.subgroup === sg;
-    }, [props.current_value, link, sg]);
+    }, [props.current_value, link]);
     // if we already have a link, we should initialize the maxItems to its current value
     const defaultMaxItems = props.multiple ? 10 : 1;
     // will change when we can actually select different link/sg... but we could just keep one of these around

--- a/src/react/components/ColumnDropdownComponent.tsx
+++ b/src/react/components/ColumnDropdownComponent.tsx
@@ -2,9 +2,9 @@ import { columnMatchesType, inferGenericColumnSelectionProps } from "@/lib/colum
 import type { ColumnSelectionProps, CTypes } from "@/lib/columnTypeHelpers";
 import { useDataStore } from "../context";
 import type { DataColumn, DataType } from "@/charts/charts";
-import { type HTMLAttributes, memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { observer } from "mobx-react-lite";
-import { Autocomplete, Box, Button, Checkbox, Chip, Divider, FormControlLabel, Paper, PaperProps } from "@mui/material";
+import { Autocomplete, Box, Button, Checkbox, Chip, Divider, Paper, type PaperProps } from "@mui/material";
 import { isArray } from "@/lib/utils";
 import { TextFieldExtended } from "./TextFieldExtended";
 import Grid from '@mui/material/Grid2';

--- a/src/react/components/ColumnSelectionComponent.tsx
+++ b/src/react/components/ColumnSelectionComponent.tsx
@@ -10,41 +10,13 @@ import { paramAcceptsNumeric } from "@/lib/columnTypeHelpers";
 import ColumnDropdownComponent from "./ColumnDropdownComponent.js";
 import LinkToColumnComponent from "./LinkToColumnComponent.js";
 import ActiveLinkComponent from "./ActiveLinkComponent.js";
-import clsx from "clsx";
 import { ErrorBoundary } from "react-error-boundary";
 import ErrorComponentReactWrapper from "./ErrorComponentReactWrapper.js";
 import { isArray } from "@/lib/utils.js";
-
+import TabHeader from "./TabHeader";
 
 type ColumnMode = "column" | "link" | "active link";
 
-type TabHeaderProps = {
-    activeTab: ColumnMode;
-    setActiveTab: (tab: ColumnMode) => void;
-    tabName: ColumnMode;
-    activeMode?: ColumnMode;
-}
-
-const TabHeader = ({ activeTab, setActiveTab, tabName, activeMode }: TabHeaderProps) => {
-    const theme = useTheme();
-    const isActiveMode = activeMode === tabName;
-    return (
-        <button
-            onClick={() => setActiveTab(tabName)}
-            type="button"
-            className={clsx("p-2 text-center border-b-2 transition-colors w-full", isActiveMode ? "font-bold" : "font-light")}
-            style={{
-                borderColor: activeTab === tabName ? theme.palette.primary.main : theme.palette.divider,
-                color:
-                    activeTab === tabName
-                        ? theme.palette.primary.main
-                        : theme.palette.text.primary,
-            }}
-        >
-            {tabName}
-        </button>
-    );
-}
 
 /**
  * Currently, the only type of 'link' that we are referring to is a `RowsAsCols` link.
@@ -108,11 +80,11 @@ const ColumnSelectionComponent = observer(<T extends CTypes, M extends boolean>(
         <>
             {iIsLinkCompatible ? (
                 <Paper className="mx-auto w-full" variant="outlined" sx={{ backgroundColor: "transparent" }}>
-                    <div className="w-full flex justify-around text-xs font-light">
-                        <TabHeader activeMode={activeMode} activeTab={activeTab} setActiveTab={setActiveTab} tabName="column" />
-                        <TabHeader activeMode={activeMode} activeTab={activeTab} setActiveTab={setActiveTab} tabName="link" />
-                        <TabHeader activeMode={activeMode} activeTab={activeTab} setActiveTab={setActiveTab} tabName="active link" />
-                    </div>
+                    <TabHeader
+                        activeTab={activeTab}
+                        setActiveTab={setActiveTab}
+                        tabs={["column", "link", "active link"]}
+                    />
                     <ErrorBoundary FallbackComponent={({error}) => <ErrorComponentReactWrapper error={error} title={error.toString()} />}>
                         <div className="p-4">
                             {activeTab === "column" && (

--- a/src/react/components/LinkToColumnComponent.tsx
+++ b/src/react/components/LinkToColumnComponent.tsx
@@ -231,9 +231,9 @@ const LinkMulti = observer(
             return 0;
         });
 
-        const handleLinkChange = (index: number) => {
+        const handleLinkChange = useCallback((index: number) => {
             setActiveLinkIndex(index);
-        };
+        }, []);
         // don't show tab ui if we only have one link
         if (links.length === 1) {
             return <LinkToColumnComponentInit {...props} link={links[0]} />;
@@ -245,6 +245,7 @@ const LinkMulti = observer(
                     {links.map((link, index) => (
                         <button
                             key={link.link.name}
+                            type="button"
                             className={`px-4 py-1 border-b-2 ${
                                 index === activeLinkIndex
                                     ? "font-bold"

--- a/src/react/components/LinkToColumnComponent.tsx
+++ b/src/react/components/LinkToColumnComponent.tsx
@@ -134,7 +134,8 @@ function useLinkSpec<T extends CTypes, M extends boolean>(props: LocalProps<T, M
         }
     }, [link.valueToRowIndex, props.multiple, sg]);
     //! there is a bug - when values from a different link are selected, the spec doesn't update
-    // it should be cleared...
+    // we want to be able to set more different combinations of values - which will mean more changes to state management
+    // for now, the UI should better reflect what the user is allowed to select.
     const [initialValue] = useState(() => getSafeInternalValue(props.current_value));
 
     /// we don't want a new spec every time the value changes... we want to give it an observable value
@@ -183,7 +184,7 @@ const LinkToColumnComponent = observer(<T extends CTypes, M extends boolean>(pro
     // at least it feels simple if you ignore everything in the hook...
     const spec = useLinkSpec(props);
     return (
-        <div className="flex flex-col" style={{ textAlign: 'left' }}>
+        <div className="flex flex-col p-1">
             {/* don't want to have this typecast here, slight nuisance. */}
             <DropdownAutocompleteComponent props={spec as GuiSpec<"dropdown"> | GuiSpec<"multidropdown">} />
         </div>

--- a/src/react/components/SelectionDialogComponent.tsx
+++ b/src/react/components/SelectionDialogComponent.tsx
@@ -595,20 +595,17 @@ const AddRowComponent = observer(() => {
             />
         </div>
     )
-})
+});
 
-const ForeignRows = observer(() => {
-    // const rlink = useRowsAsColumnsLinks();
-    // //!breaking rule of hooks here, but in a way that should be ok at runtime as of now
-    // //! (just testing "infinte loop with no link" fix)
-    // if (rlink.length === 0) return null; //todo: 30sec video clip
+type RLink = ReturnType<typeof useRowsAsColumnsLinks>[0];
+
+const LinkComponent = observer(({ rlink, linkIndex }: { rlink: RLink, linkIndex: number }) => {
     const [filter, setFilter] = useState("");
     const [max, setMax] = useState(10);
     const [debouncedFilter] = useDebounce(filter, 300);
-    const rlink = useRowsAsColumnsLinks();
-    const fcols = useHighlightedForeignRowsAsColumns(max, debouncedFilter);
-    if (!rlink[0]) return null;
-    const { linkedDs, link } = rlink[0];
+    // if we re-instate this, perhaps temporarily, it could be a useful way to test showing multiple links and subgroups.
+    const fcols = useHighlightedForeignRowsAsColumns(max, debouncedFilter, linkIndex);
+    const { linkedDs, link } = rlink;
     return (
         <div className="p-3">
             <Typography variant="h6" sx={{ marginBottom: '0.5em' }}>Columns associated with selected '{linkedDs.name}':</Typography>
@@ -618,10 +615,19 @@ const ForeignRows = observer(() => {
                 value={max}
                 onChange={(e) => setMax(Number(e.target.value))}
             />
-
+    
             {fcols.map(col => <AbstractComponent key={col.field} column={col} />)}
         </div>
     );
+});
+
+const ForeignRows = observer(() => {
+    const rlink = useRowsAsColumnsLinks();
+    return (
+        <>
+        {rlink.map((link, i) => <LinkComponent key={link.link.name} rlink={link} linkIndex={i} />)}
+        </>
+    )
 });
 
 /**
@@ -662,7 +668,7 @@ const SelectionDialogComponent = () => {
     //we could consider returning some kind of `Result` object from this hook...
     const cols = useParamColumnsExperimental();
     useResetButton();
-    const showAddRow = false;
+    const showAddRow = true;
     return (
         <div className="p-3 absolute w-[100%] h-[100%] overflow-x-hidden overflow-y-auto">
             {cols.map((col) => <AbstractComponent key={col.field} column={col} />)}
@@ -680,6 +686,7 @@ const SelectionDialogComponent = () => {
                         )
             }>
                 <AddRowComponent />
+                <ForeignRows />
             </ErrorBoundary>}
         </div>
     );

--- a/src/react/components/SelectionDialogComponent.tsx
+++ b/src/react/components/SelectionDialogComponent.tsx
@@ -1,15 +1,13 @@
 import { useCloseOnIntersection, useConfig, useDimensionFilter, useParamColumnsExperimental } from "../hooks";
 import type { CategoricalDataType, NumberDataType, DataColumn, DataType } from "../../charts/charts";
-import { Accordion, AccordionDetails, AccordionSummary, Autocomplete, Box, Button, Checkbox, Chip, Divider, FormControlLabel, IconButton, Paper, PaperProps, TextField, Typography } from "@mui/material";
+import { Accordion, AccordionDetails, AccordionSummary, Autocomplete, Box, Button, Checkbox, Chip, Divider, IconButton, Paper, type PaperProps, TextField, Typography } from "@mui/material";
 import { createFilterOptions } from '@mui/material/Autocomplete';
-import { type MouseEvent, useCallback, useEffect, useState, useMemo, useRef, useId, type HTMLAttributes } from "react";
+import { type MouseEvent, useCallback, useEffect, useState, useMemo, useRef, useId } from "react";
 
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
-import DoneAllIcon from '@mui/icons-material/DoneAll';
 import CachedIcon from '@mui/icons-material/Cached';
 import CheckBoxOutlineBlankIcon from "@mui/icons-material/CheckBoxOutlineBlank";
 import CheckBoxIcon from "@mui/icons-material/CheckBox";
-import SwapHorizIcon from '@mui/icons-material/SwapHoriz';
 import HighlightOffIcon from '@mui/icons-material/HighlightOff';
 import type { SelectionDialogConfig, CategoryFilter, MultiTextFilter, UniqueFilter, RangeFilter } from "./SelectionDialogReact";
 import { observer } from "mobx-react-lite";

--- a/src/react/components/SelectionDialogComponent.tsx
+++ b/src/react/components/SelectionDialogComponent.tsx
@@ -668,7 +668,7 @@ const SelectionDialogComponent = () => {
     //we could consider returning some kind of `Result` object from this hook...
     const cols = useParamColumnsExperimental();
     useResetButton();
-    const showAddRow = true;
+    const showAddRow = false;
     return (
         <div className="p-3 absolute w-[100%] h-[100%] overflow-x-hidden overflow-y-auto">
             {cols.map((col) => <AbstractComponent key={col.field} column={col} />)}

--- a/src/react/components/TabHeader.tsx
+++ b/src/react/components/TabHeader.tsx
@@ -9,19 +9,24 @@ type TabHeaderProps<T extends string> = {
 
 const TabHeader = <T extends string>({ activeTab, setActiveTab, tabs }: TabHeaderProps<T>) => {
     const theme = useTheme();
-
+    // TODO consider re-arranging this so we have more proper association with tab panels etc.
     return (
-        <div className="w-full flex justify-around text-xs font-light">
+        <div className="w-full flex justify-around text-xs font-light" role="tablist">
             {tabs.map((tab) => (
                 <button
                     key={tab}
                     onClick={() => setActiveTab(tab)}
                     type="button"
+                    role="tab"
+                    aria-selected={activeTab === tab}
                     className={clsx(
                         "p-2 text-center border-b-2 transition-colors w-full",
-                        activeTab === tab ? "font-bold" : "font-light"
+                        // activeTab === tab ? "font-bold" : "font-light"
+                        "aria-selected:font-bold",
+                        "font-light"
                     )}
                     style={{
+                        // we should probably avoid this style object, need to review how theme related styles should be applied
                         borderColor: activeTab === tab ? theme.palette.primary.main : theme.palette.divider,
                         color: activeTab === tab
                             ? theme.palette.primary.main

--- a/src/react/components/TabHeader.tsx
+++ b/src/react/components/TabHeader.tsx
@@ -1,0 +1,38 @@
+import { useTheme } from "@mui/material";
+import clsx from "clsx";
+
+type TabHeaderProps<T extends string> = {
+    activeTab: T;
+    setActiveTab: (tab: T) => void;
+    tabs: T[];
+};
+
+const TabHeader = <T extends string>({ activeTab, setActiveTab, tabs }: TabHeaderProps<T>) => {
+    const theme = useTheme();
+
+    return (
+        <div className="w-full flex justify-around text-xs font-light">
+            {tabs.map((tab) => (
+                <button
+                    key={tab}
+                    onClick={() => setActiveTab(tab)}
+                    type="button"
+                    className={clsx(
+                        "p-2 text-center border-b-2 transition-colors w-full",
+                        activeTab === tab ? "font-bold" : "font-light"
+                    )}
+                    style={{
+                        borderColor: activeTab === tab ? theme.palette.primary.main : theme.palette.divider,
+                        color: activeTab === tab
+                            ? theme.palette.primary.main
+                            : theme.palette.text.primary,
+                    }}
+                >
+                    {tab}
+                </button>
+            ))}
+        </div>
+    );
+};
+
+export default TabHeader;


### PR DESCRIPTION
This is not complete in that subgroups within a link are still not represented. This will require a little more change to the link_utils implementation, as well as how column-query objects are serialised etc. This shouldn't be difficult, but is not an immediate high-priority, so I'm merging this for now and will address soon.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for handling and displaying multiple links in various components, enabling users to interact with multiple linked datasets through tabbed or multi-pane interfaces.
  - Introduced new components and UI elements for selecting and switching between different links.
  - Enabled rendering of multiple linked foreign row groups with filtering and display controls.

- **Refactor**
  - Updated hooks and components to accept a specific link as a prop, improving flexibility and state management.
  - Split and reorganized components for better modularity and maintainability.
  - Adjusted component layouts and state initialization for multi-link support.
  - Replaced local tab header implementations with a new reusable TabHeader component.

- **Documentation**
  - Enhanced comments and type annotations to clarify usage, limitations, and future improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->