### PR TITLE
Taurus frontend changes

### DIFF
--- a/src/charts/SelectionDialog.js
+++ b/src/charts/SelectionDialog.js
@@ -133,7 +133,7 @@ class SelectionDialog extends BaseChart {
 
         const c = this.config;
         const dim = this.dataStore.getDimension("range_dimension");
-        dim.noclear = true;
+        dim.noClear = true;
         this.dims[col.field] = dim;
         const mm = this.dataStore.getMinMaxForColumn(col.field);
 
@@ -252,7 +252,7 @@ class SelectionDialog extends BaseChart {
         //div.style.whiteSpace="nowrap";
         const c = this.config;
         const dim = this.dataStore.getDimension("category_dimension");
-        dim.noclear = true;
+        dim.noClear = true;
         this.dims[col.field] = dim;
         let fil = c.filters[col.field];
         if (!fil) {

--- a/src/charts/ViewManager.ts
+++ b/src/charts/ViewManager.ts
@@ -195,7 +195,6 @@ class ViewManager {
         try {
             const { viewData, dsIndex, contentDiv } = this.cm;
             this.setAllViews([...this.all_views, viewName]);
-
             // Optionally make it the current view
             this.setView(viewName);
             if (!isCloneView) {
@@ -212,19 +211,14 @@ class ViewManager {
                 const state = this.cm.getState();
                 state.view.initialCharts = {};
                 state.view.dataSources = {};
-                //only one datasource
-                if (Object.keys(viewData.dataSources)?.length === 1) {
-                    const name = Object.keys(viewData.dataSources)?.[0];
-                    state.view.initialCharts[name] = [];
-                    state.view.dataSources[name] = {};
-                } else {
-                    for (const ds in dsIndex) {
-                        if (checkedDs[ds]) {
-                            state.view.initialCharts[ds] = [];
-                            state.view.dataSources[ds] = {};
-                        }
+                //add the required datasources (checkedIds) to the view
+                for (let name in checkedDs){
+                    if (checkedDs[name]){
+                        state.view.initialCharts[name] = [];
+                        state.view.dataSources[name] = {};
                     }
                 }
+              
                 contentDiv.innerHTML = "";
                 await this.cm._init(state.view);
                 await this.saveView();

--- a/src/charts/ViewManager.ts
+++ b/src/charts/ViewManager.ts
@@ -45,6 +45,10 @@ class ViewManager {
         // }, 1000);
     }
 
+    getAllDataSources() {
+        return this.cm.dataSources.map(x => x.name);
+    }
+
     getCleanPrevState() {
         return removeImageProp(toJS(this.lastSavedState));
     }

--- a/src/charts/ViewManager.ts
+++ b/src/charts/ViewManager.ts
@@ -46,7 +46,7 @@ class ViewManager {
     }
 
     getAllDataSources() {
-        return this.cm.dataSources.map(x => x.name);
+        return this.cm.dataSources.map((x) => x.name);
     }
 
     getCleanPrevState() {
@@ -84,7 +84,7 @@ class ViewManager {
         // if (this.hasUnsavedChanges()) {
         //     this.cm.showSaveViewDialog(() => this.cm.showAddViewDialog());
         // } else {
-            this.cm.showAddViewDialog();
+        this.cm.showAddViewDialog();
         // }
     }
 
@@ -97,7 +97,7 @@ class ViewManager {
         //         this.changeView(view);
         //     });
         // } else {
-            this.changeView(view);
+        this.changeView(view);
         // }
     }
 
@@ -216,13 +216,13 @@ class ViewManager {
                 state.view.initialCharts = {};
                 state.view.dataSources = {};
                 //add the required datasources (checkedIds) to the view
-                for (let name in checkedDs){
-                    if (checkedDs[name]){
+                for (const name in checkedDs) {
+                    if (checkedDs[name]) {
                         state.view.initialCharts[name] = [];
                         state.view.dataSources[name] = {};
                     }
                 }
-              
+
                 contentDiv.innerHTML = "";
                 await this.cm._init(state.view);
                 await this.saveView();

--- a/src/charts/ViewManager.ts
+++ b/src/charts/ViewManager.ts
@@ -45,10 +45,6 @@ class ViewManager {
         // }, 1000);
     }
 
-    getAllDataSources() {
-        return this.cm.dataSources.map((x) => x.name);
-    }
-
     getCleanPrevState() {
         return removeImageProp(toJS(this.lastSavedState));
     }

--- a/src/charts/dialogs/AddViewDialog.tsx
+++ b/src/charts/dialogs/AddViewDialog.tsx
@@ -18,14 +18,19 @@ const AddViewDialogComponent = (props: {
     const [viewName, setViewName] = useState("");
     const [isCloneView, setIsCloneView] = useState(false);
     const [checkedDs, setCheckedDs] = useState<{ [name: string]: boolean }>({});
+    //must be a better way than using the window object
     const { viewManager, viewData } = window.mdv.chartManager;
-    const dataSources = useMemo(() => Object.keys(viewData.dataSources), [viewData.dataSources]);
+    //we want a choice of all datasources (not just ones on the current view)
+    //not sure how to get all the datasources available - this is just a temporary hack
+    //if we don't use useMemo get constant re-rendering ?
+    const dataSources = useMemo(()=>viewManager.cm.dataSources.map(x=>x.name),[viewManager.cm])
+    const currentDataSources = useMemo(() => Object.keys(viewData.dataSources), [viewData.dataSources]);
 
     useEffect(() => {
         // Initialising the checkedDs with the data sources inside the view
         const tempDs: { [name: string]: boolean } = {};
         dataSources?.forEach?.((ds) => {
-            tempDs[ds] = false;
+            tempDs[ds] =currentDataSources.indexOf(ds) !=-1;
         });
         setCheckedDs(tempDs);
     }, [dataSources]);
@@ -33,7 +38,7 @@ const AddViewDialogComponent = (props: {
     const handleCheckboxChange = (ds: string) => {
         setCheckedDs((prevDs) => ({ ...prevDs, [ds]: !prevDs[ds] }));
     };
-
+    
     const checkInvalidName = (name: string) => {
         return viewManager.all_views.includes(name);
     };

--- a/src/charts/dialogs/AddViewDialog.tsx
+++ b/src/charts/dialogs/AddViewDialog.tsx
@@ -1,3 +1,4 @@
+import { useDataSources } from "@/react/hooks";
 import {
     Button,
     Checkbox,
@@ -20,20 +21,17 @@ const AddViewDialogComponent = (props: {
     const [checkedDs, setCheckedDs] = useState<{ [name: string]: boolean }>({});
     //must be a better way than using the window object
     const { viewManager, viewData } = window.mdv.chartManager;
-    //we want a choice of all datasources (not just ones on the current view)
-    //not sure how to get all the datasources available - this is just a temporary hack
-    //if we don't use useMemo get constant re-rendering ?
-    const dataSources = useMemo(()=>viewManager.getAllDataSources(),[viewManager])
+    const dataSources = useDataSources();
     const currentDataSources = useMemo(() => Object.keys(viewData.dataSources), [viewData.dataSources]);
 
     useEffect(() => {
         // Initialising the checkedDs with the data sources inside the view
         const tempDs: { [name: string]: boolean } = {};
-        dataSources?.forEach?.((ds) => {
+        dataSources.forEach?.(({name: ds}) => {
             tempDs[ds] = currentDataSources.indexOf(ds) !== -1;
         });
         setCheckedDs(tempDs);
-    }, [dataSources]);
+    }, [dataSources, currentDataSources]);
 
     const handleCheckboxChange = (ds: string) => {
         setCheckedDs((prevDs) => ({ ...prevDs, [ds]: !prevDs[ds] }));
@@ -75,7 +73,7 @@ const AddViewDialogComponent = (props: {
 
                 {dataSources.length > 1 && (
                     <FormGroup sx={{ mt: 2 }}>
-                        {dataSources?.map?.((ds) => (
+                        {dataSources?.map?.(({name: ds}) => (
                             <FormControlLabel
                                 key={ds}
                                 control={

--- a/src/charts/dialogs/AddViewDialog.tsx
+++ b/src/charts/dialogs/AddViewDialog.tsx
@@ -23,7 +23,7 @@ const AddViewDialogComponent = (props: {
     //we want a choice of all datasources (not just ones on the current view)
     //not sure how to get all the datasources available - this is just a temporary hack
     //if we don't use useMemo get constant re-rendering ?
-    const dataSources = useMemo(()=>viewManager.cm.dataSources.map(x=>x.name),[viewManager.cm])
+    const dataSources = useMemo(()=>viewManager.getAllDataSources(),[viewManager])
     const currentDataSources = useMemo(() => Object.keys(viewData.dataSources), [viewData.dataSources]);
 
     useEffect(() => {

--- a/src/charts/dialogs/AddViewDialog.tsx
+++ b/src/charts/dialogs/AddViewDialog.tsx
@@ -30,7 +30,7 @@ const AddViewDialogComponent = (props: {
         // Initialising the checkedDs with the data sources inside the view
         const tempDs: { [name: string]: boolean } = {};
         dataSources?.forEach?.((ds) => {
-            tempDs[ds] =currentDataSources.indexOf(ds) !=-1;
+            tempDs[ds] = currentDataSources.indexOf(ds) !== -1;
         });
         setCheckedDs(tempDs);
     }, [dataSources]);

--- a/src/datastore/Dimension.js
+++ b/src/datastore/Dimension.js
@@ -6,6 +6,7 @@ class Dimension {
     constructor(parent) {
         this.filterBuffer = new SharedArrayBuffer(parent.size);
         this.parent = parent;
+        this.noclear=false;
         this.filterArray = new Uint8Array(this.filterBuffer);
         this.filterArguments = null;
         this.filterIndexes = null;
@@ -57,6 +58,14 @@ class Dimension {
         //I'm a bit dubious about the general pattern
         //- using filter(methodName...) for now to be more in line with other things
         //this.parent._callListeners("filtered", this);
+    }
+    /**
+     * 
+     * @param {*} noclear - if true, then the filter will not be cleared 
+     * when a removeAllFilters is called on the parent DataStore. Default is false.
+     */
+    setNoClear(noclear){
+        this.noclear = noclear;
     }
 
     removeFilter(notify = true) {

--- a/src/datastore/Dimension.js
+++ b/src/datastore/Dimension.js
@@ -6,7 +6,7 @@ class Dimension {
     constructor(parent) {
         this.filterBuffer = new SharedArrayBuffer(parent.size);
         this.parent = parent;
-        this.noclear=false;
+        this.noClear = false;
         this.filterArray = new Uint8Array(this.filterBuffer);
         this.filterArguments = null;
         this.filterIndexes = null;
@@ -61,11 +61,11 @@ class Dimension {
     }
     /**
      * 
-     * @param {*} noclear - if true, then the filter will not be cleared 
+     * @param {*} noClear - if true, then the filter will not be cleared 
      * when a removeAllFilters is called on the parent DataStore. Default is false.
      */
-    setNoClear(noclear){
-        this.noclear = noclear;
+    setNoClear(noClear){
+        this.noClear = noClear;
     }
 
     removeFilter(notify = true) {

--- a/src/react/components/SelectionDialogComponent.tsx
+++ b/src/react/components/SelectionDialogComponent.tsx
@@ -65,7 +65,7 @@ const TextComponent = observer(({ column }: Props<CategoricalDataType>) => {
     useCloseOnIntersection(ref, () => setOpen(false));
 
     useEffect(() =>{
-        // todo consider having this state per-dimension rather than globally
+        // todo consider having ui for this state per-dimension rather than globally
         dim.setNoClear(conf.noClearFilters);
     },[dim, conf.noClearFilters]);
  

--- a/src/react/components/SelectionDialogComponent.tsx
+++ b/src/react/components/SelectionDialogComponent.tsx
@@ -50,7 +50,7 @@ const TextComponent = observer(({ column }: Props<CategoricalDataType>) => {
     const [selectAll, setSelectAll] = useState(false);
     const ref = useRef<HTMLInputElement>(null);
     const dim = useDimensionFilter(column);
-    const filters = useConfig<SelectionDialogConfig>().filters;
+    const conf = useConfig<SelectionDialogConfig>();
     const { values } = column;
     const filter = useFilterConfig(column);
     const value = filter?.category || [];
@@ -58,19 +58,26 @@ const TextComponent = observer(({ column }: Props<CategoricalDataType>) => {
         const newFilter = filter || { category: [] };
         action(() => {
             newFilter.category = newValue;
-            filters[column.field] = newFilter;
+            conf.filters[column.field] = newFilter;
         })();
-    }, [filters, column.field, filter]);
+    }, [conf.filters, column.field, filter]);
 
     useCloseOnIntersection(ref, () => setOpen(false));
-    
+
+    useEffect(() =>{
+        dim.setNoClear(conf.noClearFilters);
+    },[dim, conf.noClearFilters]);
+ 
     // react to changes in value and update the filter
     useEffect(() => {
+        
         // filter could be undefined - but we previously checked for null causing component to crash
         if ((!filter) || (filter.category.length === 0)) {
             dim.removeFilter();
             return;
         }
+        //probably there is better place to set this
+        
         dim.filter("filterCategories", [column.field], value, true);
     }, [dim, column.field, value, filter]);
 
@@ -224,11 +231,11 @@ const UniqueComponent = observer(({ column }: Props<"unique">) => {
  */
 function useRangeFilter(column: DataColumn<NumberDataType>) {
     const filter = useDimensionFilter(column) as RangeDimension;
-    const filters = useConfig<SelectionDialogConfig>().filters;
+    const conf = useConfig<SelectionDialogConfig>()
     //nb - we may want to allow value to be null, rather than defaulting to minMax
     //relates to e.g. clearBrush function
     // const value = (filters[column.field] || column.minMax) as [number, number];
-    const fVal = filters[column.field] as RangeFilter | null;
+    const fVal = conf.filters[column.field] as RangeFilter | null;
     // if (!isArray(fVal)) throw new Error("Expected range filter to be an array");
     const value = fVal;
     // const value = fVal;
@@ -242,7 +249,9 @@ function useRangeFilter(column: DataColumn<NumberDataType>) {
         return small < 0.001 ? small/1000 : 0.001;
     }, [isInteger, minMax]);
     const [debouncedValue] = useDebounce(value, 10);
-
+     useEffect(() =>{
+        filter.setNoClear(conf.noClearFilters);
+    },[filter, conf.noClearFilters]);
     // Effect to manage the filter state
     useEffect(() => {
         const value = debouncedValue;
@@ -633,9 +642,9 @@ const ForeignRows = observer(() => {
  */
 function useResetButton() {
     const chart = useChart();
-    const filters = useConfig<SelectionDialogConfig>().filters;
+    const conf = useConfig<SelectionDialogConfig>();
     // todo: what about category filters with empty array?
-    const hasFilter = Object.values(filters).some((f) => f !== null);
+    const hasFilter = Object.values(conf.filters).some((f) => f !== null);
     useEffect(() => {
         console.log("hasFilter changed (in hook): ", hasFilter);
         chart.resetButton.style.display = hasFilter ? "inline" : "none";
@@ -647,15 +656,20 @@ function useResetButton() {
         const k = `SelectionDialog-${id}`;
         const resetAll = (type: string, data: string) => {
             if (type !== "filtered" || data !== "all_removed") return;
-            runInAction(() => {
-                for (const key in filters) {
-                    delete filters[key];
-                }
-            });
+            //actually removeAllFilters already clears all the filters (if they are 
+            //not tagged with noclear in single action for performance
+            //filters will be cleared again here but it is not much of an issue
+            if (!conf.noClearFilters){
+                runInAction(() => {
+                    for (const key in conf.filters) {
+                        delete conf.filters[key];
+                    }
+                });
+            }
         };
         ds.addListener(k, resetAll);
         return () => ds.removeListener(k);
-    }, [ds, id, filters]);
+    }, [ds, id, conf.filters]);
 }
 
 const SelectionDialogComponent = () => {

--- a/src/react/components/SelectionDialogComponent.tsx
+++ b/src/react/components/SelectionDialogComponent.tsx
@@ -65,6 +65,7 @@ const TextComponent = observer(({ column }: Props<CategoricalDataType>) => {
     useCloseOnIntersection(ref, () => setOpen(false));
 
     useEffect(() =>{
+        // todo consider having this state per-dimension rather than globally
         dim.setNoClear(conf.noClearFilters);
     },[dim, conf.noClearFilters]);
  

--- a/src/react/components/SelectionDialogReact.tsx
+++ b/src/react/components/SelectionDialogReact.tsx
@@ -49,7 +49,7 @@ class SelectionDialogReact extends BaseReactChart<SelectionDialogConfig> {
 
     getSettings(){
           const settings = super.getSettings();
-          const c= this.config;
+          const c = this.config;
           return [
             ...settings,
             g({
@@ -58,9 +58,8 @@ class SelectionDialogReact extends BaseReactChart<SelectionDialogConfig> {
                 current_value: c.noClearFilters || false,
                 label: "Filters remain on Reset All",
                 func: (x) => {
-                    action(() => {
-                        c.noClearFilters = x;
-                    })();
+                    // func() is already called in an action, so no need to wrap again
+                    c.noClearFilters = x;
                 }
             })
           ]

--- a/src/react/components/SelectionDialogReact.tsx
+++ b/src/react/components/SelectionDialogReact.tsx
@@ -2,15 +2,15 @@ import { action } from "mobx";
 import BaseChart, { type BaseConfig } from "../../charts/BaseChart";
 import { BaseReactChart } from "./BaseReactChart";
 import SelectionDialogComponent from "./SelectionDialogComponent";
-import { observer } from "mobx-react-lite";
 import type DataStore from "@/datastore/DataStore";
 import { g } from "@/lib/utils";
 
+// export type CommonFilter = { noClear?: boolean, invert?: boolean }; //todo - implement these features.
 export type CategoryFilter = { category: string[] };
 export type MultiTextFilter = CategoryFilter & { operand: "or" | "and" };
 export type RangeFilter = [number, number];
 export type UniqueFilter = string;
-export type SelectionDialogFilter = CategoryFilter | MultiTextFilter | UniqueFilter | RangeFilter;
+export type SelectionDialogFilter = (CategoryFilter | MultiTextFilter | UniqueFilter | RangeFilter);// & CommonFilter;
 
 export type SelectionDialogConfig = {
     type: "selection_dialog";

--- a/src/react/components/SelectionDialogReact.tsx
+++ b/src/react/components/SelectionDialogReact.tsx
@@ -5,6 +5,7 @@ import SelectionDialogComponent from "./SelectionDialogComponent";
 import { observer } from "mobx-react-lite";
 import type DataStore from "@/datastore/DataStore";
 import { g } from "@/lib/utils";
+import { C } from "test_proj/bcells_static/static/assets/Button-B6V-Y5XJ";
 
 export type CategoryFilter = { category: string[] };
 export type MultiTextFilter = CategoryFilter & { operand: "or" | "and" };
@@ -14,6 +15,7 @@ export type SelectionDialogFilter = CategoryFilter | MultiTextFilter | UniqueFil
 
 export type SelectionDialogConfig = {
     type: "selection_dialog";
+    noClearFilters?:boolean;
     filters: Record<string, SelectionDialogFilter | null>;
 } & BaseConfig;
 
@@ -44,6 +46,25 @@ class SelectionDialogReact extends BaseReactChart<SelectionDialogConfig> {
                 this.config.filters[key] = null;
             }
         })();
+    }
+
+    getSettings(){
+          const settings = super.getSettings();
+          const c= this.config;
+          return [
+            ...settings,
+            g({
+                //set whether filters are cleared on Reset All
+                type: "check",
+                current_value: c.noClearFilters || false,
+                label: "Filters remain on Reset All",
+                func: (x) => {
+                    action(() => {
+                        c.noClearFilters = x;
+                    })();
+                }
+            })
+          ]
     }
 }
 

--- a/src/react/components/SelectionDialogReact.tsx
+++ b/src/react/components/SelectionDialogReact.tsx
@@ -5,7 +5,6 @@ import SelectionDialogComponent from "./SelectionDialogComponent";
 import { observer } from "mobx-react-lite";
 import type DataStore from "@/datastore/DataStore";
 import { g } from "@/lib/utils";
-import { C } from "test_proj/bcells_static/static/assets/Button-B6V-Y5XJ";
 
 export type CategoryFilter = { category: string[] };
 export type MultiTextFilter = CategoryFilter & { operand: "or" | "and" };

--- a/src/utilities/PanZoom.js
+++ b/src/utilities/PanZoom.js
@@ -28,16 +28,19 @@ class ImagePanZoom {
     fit() {
         const box = this.container.getBoundingClientRect();
         const ratio =  this.img.naturalWidth / this.img.naturalHeight;
-        this.img.style.height = `${box.height}px`;
-        this.img.style.width = `${this.img.height * ratio}px`;
-        if (this.img.width > box.width) {
+        const fitHeight = box.height;
+        const fitWidth = fitHeight * ratio;
+        this.img.style.height = `${fitHeight}px`;
+        this.img.style.width = `${fitWidth}px`;
+        if (fitWidth > box.width) {
+            const constrainedHeight = box.width / ratio;
             this.img.style.width = `${box.width}px`;
-            this.img.style.height = `${this.img.width / ratio}px`;
-            this.img.style.top = `${(box.height - this.img.height) / 2}px`;
+            this.img.style.height = `${box.width / ratio}px`;
+            this.img.style.top = `${(box.height - constrainedHeight) / 2}px`;
             this.img.style.left = "0px";
         } else {
             this.img.style.top = "0px";
-            this.img.style.left = `${(box.width - this.img.width) / 2}px`;
+            this.img.style.left = `${(box.width - fitWidth) / 2}px`;
         }
     }
 

--- a/src/utilities/PanZoom.js
+++ b/src/utilities/PanZoom.js
@@ -6,13 +6,9 @@ class ImagePanZoom {
         this.img = new Image();
 
         this.img.style.position = "absolute";
+        this.img.style.maxWidth= 'none'
 
         this.img.onload = (e) => {
-            this.orig_dim = [
-                this.img.naturalWidth,
-                this.img.naturalHeight,
-                this.img.naturalWidth / this.img.naturalHeight,
-            ];
             this.container.append(this.img);
             this.fit();
         };
@@ -31,11 +27,12 @@ class ImagePanZoom {
 
     fit() {
         const box = this.container.getBoundingClientRect();
-        this.img.height = box.height;
-        this.img.width = this.img.height * this.orig_dim[2];
+        const ratio =  this.img.naturalWidth / this.img.naturalHeight;
+        this.img.style.height = `${box.height}px`;
+        this.img.style.width = `${this.img.height * ratio}px`;
         if (this.img.width > box.width) {
-            this.img.width = box.width;
-            this.img.height = this.img.width / this.orig_dim[2];
+            this.img.style.width = `${box.width}px`;
+            this.img.style.height = `${this.img.width / ratio}px`;
             this.img.style.top = `${(box.height - this.img.height) / 2}px`;
             this.img.style.left = "0px";
         } else {
@@ -53,8 +50,8 @@ class ImagePanZoom {
         const dy =
             (event.clientY - cbox.top - this.img.offsetTop) * (amount - 1);
 
-        this.img.width = ibox.width * amount;
-        this.img.height = ibox.height * amount;
+        this.img.style.width = `${ibox.width * amount}px`;
+        this.img.style.height = `${ibox.height * amount}px`;
         this.img.style.left = `${this.img.offsetLeft - dx}px`;
         this.img.style.top = `${this.img.offsetTop - dy}px`;
     }


### PR DESCRIPTION
Changes for the Taurus data 

* In PanZoom.js (probably be deprecated soon) the base css img settings were interfering with pan/zooming. Fixes to prevent this
* Only datasources present in the current view could be  used to create a new view - this was changed so that any datasource could be used
* added an option so that filters in a selection dialogue are not removed on reset all. This used to be default but was then removed (which makes sense) . Now is optional  can be used for  a view of e.g. a single cell type and will not reset to all cells. Other dialogues for querying can be added with default behaviour

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an option to prevent filters from being cleared when using "Reset All" in selection dialogs. Users can enable this via a new checkbox in the settings.
- **Improvements**
  - Enhanced the way data sources are managed and selected when adding new views, providing a more consistent experience.
  - Improved image zoom and pan functionality for smoother resizing and better aspect ratio handling.
  - Updated filter handling to respect the new "no clear filters" configuration, improving filter persistence behavior.
  - Fixed filter property naming for better consistency and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->