### PR TITLE
Back end taurus changes

### DIFF
--- a/python/mdvtools/conversions.py
+++ b/python/mdvtools/conversions.py
@@ -15,7 +15,9 @@ def convert_scanpy_to_mdv(
     max_dims: int = 3, 
     delete_existing: bool = False, 
     label: str = "",
-    chunk_data: bool = False
+    chunk_data: bool = False,
+    add_layer_data = True,
+    gene_identifier_column = None
 ) -> MDVProject:
     """
     Convert a Scanpy AnnData object to MDV (Multi-Dimensional Viewer) format.
@@ -33,7 +35,13 @@ def convert_scanpy_to_mdv(
             If False, merges with existing data. Defaults to False.
         label (str, optional): Prefix to add to datasource names and metadata columns
             when merging with existing data. Defaults to "".
-
+        chunk_data (bool, optional): For dense marixes, transposing and flattening
+            will be performed in chunks. Saves memory but takes longer. Default is False.
+        add_layer_data (bool, optional): If True (default) then the layer data (log values etc.)
+            will be added, otherwise just the X object will be used
+        gene_identifier_column: (str, optional) This is the gene column that the user will use to
+            identify the gene. If not specified (default) than a column 'name' will be added that is
+            created from the index (which is usaully the unique gene name)
     Returns:
         MDVProject: The configured MDV project object with the converted data
 
@@ -81,7 +89,7 @@ def convert_scanpy_to_mdv(
     # add any dimension reduction to the dataframe
     cell_table = _add_dims(cell_table, scanpy_object.obsm, max_dims)
 
-    # cell_is is the unique barcode and should of type unique
+    # cell_id is the unique barcode and should of type unique
     # (will be text16 by default if number of values are below 65536)
     # hopefully other columns will be of the correct format
     columns=[{
@@ -94,8 +102,13 @@ def convert_scanpy_to_mdv(
     gene_table = scanpy_object.var
     #need a way of detecting which column is the common gene name
     #most times it is the index but sometimes this is just the gene code or an
-    #incremental number. 
-    gene_table[f"{label}name"] = gene_table.index
+    #incremental number.
+    if gene_identifier_column and not gene_identifier_column in gene_table.columns:
+        print(f"gene identifier column {gene_identifier_column} not found, using index")
+        gene_identifier_column= None
+    if not gene_identifier_column:
+        gene_identifier_column= f"{label}name"
+        gene_table[gene_identifier_column] = gene_table.index
     gene_table = _add_dims(gene_table, scanpy_object.varm, max_dims)
 
     #originally column had to be unique - but now is just text
@@ -104,7 +117,7 @@ def convert_scanpy_to_mdv(
     mdv.add_datasource(f"{label}genes", gene_table)
 
     # link the two datasets
-    mdv.add_rows_as_columns_link(f"{label}cells", f"{label}genes", f"{label}name", "Gene Expr")
+    mdv.add_rows_as_columns_link(f"{label}cells", f"{label}genes", gene_identifier_column, "Gene Expr")
 
     #get the matrix in the correct format
     matrix,sparse= get_matrix(scanpy_object.X)
@@ -118,11 +131,12 @@ def convert_scanpy_to_mdv(
         )
 
     #now add layers
-    for layer,matrix in scanpy_object.layers.items():
-        matrix,sparse = get_matrix(matrix)
-        mdv.add_rows_as_columns_subgroup(
-            f"{label}cells", f"{label}genes", matrix, layer, sparse=sparse, chunk_data=chunk_data
-        )     
+    if add_layer_data:
+        for layer,matrix in scanpy_object.layers.items():
+            matrix,sparse = get_matrix(matrix)
+            mdv.add_rows_as_columns_subgroup(
+                f"{label}cells", f"{label}genes", matrix, layer, sparse=sparse, chunk_data=chunk_data
+            )
 
     if delete_existing:
         # If we're deleting existing, create new default view

--- a/python/mdvtools/mdvproject.py
+++ b/python/mdvtools/mdvproject.py
@@ -1341,7 +1341,18 @@ class MDVProject:
         """Adds a set of images to a datasource. The images should be in a folder, with the same name as the column
         Args:
             datasource (str): The name of the datasource.
-            column (str): The name of the column.
+            column (str): The name of the column describing the images. The folder
+                should contain images with the same name as the values in this column
+                minus the file extension (typically .png or .jpg).
+            type (str, optional): The type of the images. Default is 
+                'png'. Other options are 'jpg', 'jpeg', etc.
+            large (bool, optional): If True, the images will be avialable to the Row Summmary Box
+                where only a single image is shown and can be panned and zoomed
+                if false (default) the images will be available in the Image Table and should
+                be thumbnails of the same size
+            setname (str): The name of the image set. More than one set of images can be associated
+                with a datasource. The name should be unique within the datasource and is used tp 
+                create a folder (with a sanitized name) in the images directory     
             folder (str): The path to the folder containing the images.
         """
         ds = self.get_datasource_metadata(datasource)

--- a/python/mdvtools/server.py
+++ b/python/mdvtools/server.py
@@ -42,6 +42,8 @@ def add_safe_headers(resp):
     # headers required if serving endpoints for another server e,g dev server
     resp.headers["Access-Control-Allow-Origin"] = "*"
     resp.headers["Access-Control-Allow-Headers"] = "Content-Type"
+    #required for vite dev
+    resp.headers["Cross-Origin-Resource-Policy"] ="cross-origin"
     return resp
 
 
@@ -218,9 +220,12 @@ def create_app(
     @project_bp.route("/images/<path:path>")
     def images(path):
         try:
-            return _send_file(project.get_image(path))
+            response= make_response(_send_file(project.get_image(path)))
         except Exception:
-            return _send_file(safe_join(project.imagefolder, path))
+            response =  make_response(_send_file(safe_join(project.imagefolder, path)))
+        #make sure images are cached
+        response.headers['Cache-Control'] = 'public, max-age=31536000'  # Cache for 1 year
+        return response
 
     # All the project's metadata
     @project_bp.route("/get_configs", methods=["GET", "POST"])


### PR DESCRIPTION
* in convert_scanpy_to_mdv added options for the gene identifier column and whether to add layer data
* in mdvproject allowed boolean datatype in a pandas series which can be true/false or NaN (missing) - converted into text column with true/false or ND
* converted NaN in pandas text columns to ND as NaN was throwing errors in text coercion
* Added option not to save configs with save_json_config - this was throwing an error in windows and was saving the file with the most restrictive permissions in linux
* column cleaning was changed (coercing all non number fields to NAN) to make it orders of magnitude faster
* extra header added to response in the stand alone server to allow images to be served in dev mode in vite
* added header to cache images to speed up image table

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for specifying a custom gene identifier column and controlling the inclusion of gene expression layers when converting Scanpy data.
  - Introduced configurable safe (atomic) saving of project files.
  - Enabled handling of large image sets in image metadata.

- **Improvements**
  - Enhanced handling of missing and boolean values in data columns.
  - Improved HTTP response headers for images, including long-term caching and cross-origin resource policy support.

- **Bug Fixes**
  - Corrected minor comment typos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->