### PR TITLE
autorun on changes to param in CategoryChart

### DIFF
--- a/src/charts/CategoryChart.js
+++ b/src/charts/CategoryChart.js
@@ -14,6 +14,13 @@ class CategoryChart extends SVGChart {
         this.dim = this.dataStore.getDimension("category_dimension");
         this.colors = this.dataStore.getColumnColors(config.param[0]);
         this.filter = [];
+        this.mobxAutorun(() => {
+            // we need to react to config.param changes and updateData() or similar...
+            console.log("config.param changed", this.config.param);
+            this.colors = this.dataStore.getColumnColors(this.config.param[0]);
+            this.onDataFiltered();
+            this.updateData();
+        });
     }
 
     remove(notify = true) {

--- a/src/charts/CategoryChart.js
+++ b/src/charts/CategoryChart.js
@@ -1,4 +1,5 @@
 import SVGChart from "./SVGChart.js";
+import { action } from "mobx";
 
 class CategoryChart extends SVGChart {
     constructor(dataStore, div, config, axisTypes) {
@@ -22,12 +23,15 @@ class CategoryChart extends SVGChart {
         this.mobxAutorun(() => {
             // we need to react to config.param changes and updateData() or similar...
             console.log("config.param changed", this.config.param);
-            this.colors = this.dataStore.getColumnColors(this.config.param[0]);
-            this.onDataFiltered();
-            this.updateData();
-            if (hadDefaultTitle && this.config.title === originalTitle) {
-                this.config.title = dataStore.getColumnName(this.config.param[0]);
-            }
+            setTimeout(action(() => {
+                // colors could probably be `@computed` from dataStore.getColumnColors(this.config.param[0])...
+                this.colors = this.dataStore.getColumnColors(this.config.param[0]);
+                this.onDataFiltered();
+                // this.updateData();
+                if (hadDefaultTitle && this.config.title === originalTitle) {
+                    this.config.title = dataStore.getColumnName(this.config.param[0]);
+                }
+            }), 0);
         });
     }
 

--- a/src/charts/CategoryChart.js
+++ b/src/charts/CategoryChart.js
@@ -9,7 +9,12 @@ class CategoryChart extends SVGChart {
             // is much less than would be needed elsewhere with more generic code.
             config.param = [config.param];
         }
-        config.title = config.title || dataStore.getColumnName(config.param[0]);
+        // would be nice to have a more generic way to handle this...
+        // if we have an explicitly set title, we keep it, otherwise we use the column name & update it if it changes
+        const colName = dataStore.getColumnName(config.param[0]);
+        const hadDefaultTitle = !config.title || config.title === colName;
+        config.title = config.title || colName;
+        const originalTitle = config.title;
         super(dataStore, div, config, axisTypes);
         this.dim = this.dataStore.getDimension("category_dimension");
         this.colors = this.dataStore.getColumnColors(config.param[0]);
@@ -20,6 +25,9 @@ class CategoryChart extends SVGChart {
             this.colors = this.dataStore.getColumnColors(this.config.param[0]);
             this.onDataFiltered();
             this.updateData();
+            if (hadDefaultTitle && this.config.title === originalTitle) {
+                this.config.title = dataStore.getColumnName(this.config.param[0]);
+            }
         });
     }
 


### PR DESCRIPTION
Previously, "Pie Chart" and "Row Chart" would exhibit glitchy/undefined behaviour when parameters configuration changed.

This appears to be ok with a `mobxAutorun` to apply changes that are otherwise done in the constructor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The chart now automatically updates its colors, data, and title in response to configuration changes, providing a more dynamic and responsive user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->