### PR TITLE
Md 575 dotplot categories bug

### DIFF
--- a/src/charts/BaseChart.ts
+++ b/src/charts/BaseChart.ts
@@ -697,7 +697,7 @@ class BaseChart<T extends BaseConfig> {
     @loadColumnData
     setParams(params: FieldSpecs) {
         //! now the config will just have string[] - we want to allow things that can understand to have other objects
-        // this.config.param = params; // This line is removed/commented as ColumnQueryMapper.setActiveQuery now handles updating the live config.
+        this.config.param = params;
         // if we keep liveParams around it could be useful when serialising the chart
         // although how can we be sure that the liveParams are up to date?
         // maybe as a rule, this method is the only way to set the params...

--- a/src/charts/BaseChart.ts
+++ b/src/charts/BaseChart.ts
@@ -697,7 +697,7 @@ class BaseChart<T extends BaseConfig> {
     @loadColumnData
     setParams(params: FieldSpecs) {
         //! now the config will just have string[] - we want to allow things that can understand to have other objects
-        this.config.param = params;
+        // this.config.param = params; // This line is removed/commented as ColumnQueryMapper.setActiveQuery now handles updating the live config.
         // if we keep liveParams around it could be useful when serialising the chart
         // although how can we be sure that the liveParams are up to date?
         // maybe as a rule, this method is the only way to set the params...

--- a/src/charts/DotPlot.js
+++ b/src/charts/DotPlot.js
@@ -24,7 +24,7 @@ class DotPlot extends SVGChart {
         console.log('setting fields for dot plot', c.param.slice(1));
         //this works ok because the method is decorated... which I think means if there's a query object,
         //`setFields` won't actually be called until the link is properly initialised
-        this.setFields(c.param.slice(1));
+        this.setParams(c.param);
         //work out color scales
         c.color_scale = c.color_scale || { log: false };
         if (!c.color_legend) {
@@ -54,7 +54,7 @@ class DotPlot extends SVGChart {
     }
     @loadColumnData
     setParams(params) {
-        this.config.param = params;
+        // this.config.param = params; // This line is removed/commented as ColumnQueryMapper.setActiveQuery now handles updating the live config.
         this.setFields(params.slice(1));
     }
 
@@ -144,6 +144,7 @@ class DotPlot extends SVGChart {
 
     onDataFiltered(dim) {
         //no need to change anything
+        //(we may want to review what isPinned means in relation to dynamic column selection - would be useful to have a way of pinning that)
         if (this.dim === dim || this.isPinned) {
             return;
         }
@@ -188,6 +189,7 @@ class DotPlot extends SVGChart {
         const cWidth = dim.width / (this.fieldNames.length);
         const fa = this.dim.filterMethod;
         this.setColorFunction();
+        // is this something we need to review to make sure that changing the category column behaves as expected?
         const vals = this.dataStore.getColumnValues(this.config.param[0]);
         const data = this.data.data.filter((x) => x.count !== 0);
         this.y_scale.domain(data.map((x) => vals[x.id]));

--- a/src/charts/DotPlot.js
+++ b/src/charts/DotPlot.js
@@ -24,7 +24,7 @@ class DotPlot extends SVGChart {
         console.log('setting fields for dot plot', c.param.slice(1));
         //this works ok because the method is decorated... which I think means if there's a query object,
         //`setFields` won't actually be called until the link is properly initialised
-        this.setParams(c.param);
+        // this.setParams(c.param);
         //work out color scales
         c.color_scale = c.color_scale || { log: false };
         if (!c.color_legend) {
@@ -34,6 +34,9 @@ class DotPlot extends SVGChart {
             c.fraction_legend = { display: true };
         }
         //this.fractionScale = scaleSqrt().domain([0, 100]);
+        this.mobxAutorun(() => {
+            this._setFields(this.config.param.slice(1));
+        });
     }
     
     // removing this decorator as it muddies the waters with setParams.
@@ -41,7 +44,7 @@ class DotPlot extends SVGChart {
     //   as long as we had the workaround in `setParams()` to manually look for activeQuery
     //   but that was itself a hack.
     // @loadColumnData
-    setFields(fieldNames) {
+    _setFields(fieldNames) {
         //! we don't want to mutate the config object... 
         // we want to have a special value which signifies that it should use this behaviour.
         // then when we save state, it will have the appropriate value.
@@ -52,11 +55,12 @@ class DotPlot extends SVGChart {
         this.x_scale.domain(yLabels);
         this.onDataFiltered();
     }
-    @loadColumnData
-    setParams(params) {
-        this.config.param = params;
-        this.setFields(params.slice(1));
-    }
+    // prefering to setFields in an autorun so there's less potential for confusion
+    // @loadColumnData
+    // setParams(params) {
+    //     this.config.param = params;
+    //     this.setFields(params.slice(1));
+    // }
 
     remove(notify = true) {
         this.dim.destroy(notify);

--- a/src/charts/DotPlot.js
+++ b/src/charts/DotPlot.js
@@ -54,7 +54,7 @@ class DotPlot extends SVGChart {
     }
     @loadColumnData
     setParams(params) {
-        // this.config.param = params; // This line is removed/commented as ColumnQueryMapper.setActiveQuery now handles updating the live config.
+        this.config.param = params;
         this.setFields(params.slice(1));
     }
 

--- a/src/charts/chartConfigUtils.ts
+++ b/src/charts/chartConfigUtils.ts
@@ -40,7 +40,7 @@ import type { TooltipConfig } from "@/react/scatter_state";
 // possibly including things like multi-text columns that automatically mutate over time...
 // - maybe serialised if it's loaded from a file, but internally do we allow it to be a live RowAsColsQuery?
 type SerialisedColumnParam = (FieldName | RowsAsColsQuerySerialized);
-type SerialisedParams = SerialisedColumnParam[];
+export type SerialisedParams = SerialisedColumnParam[];
 export function deserialiseParam(ds: DataStore, param: SerialisedColumnParam) {
     //! should we consider making this whole thing async so that we can know that whatever is needed is loaded?
     // this may not be the best place to do that, but it's a thought...

--- a/src/charts/dialogs/utils/ParamsSettingGui.tsx
+++ b/src/charts/dialogs/utils/ParamsSettingGui.tsx
@@ -2,48 +2,6 @@ import BaseChart, { type BaseConfig } from "@/charts/BaseChart";
 import { type FieldSpec, type FieldSpecs, isMultiColumn } from "@/lib/columnTypeHelpers";
 import { g, isArray } from "@/lib/utils";
 
-/**
- * Helper method to go figure out which entries in a config.param array correspond
- * to a given parameter at index i in the chart type's params array.
- * There is no perfect way to do this - but we should be able to rely on knowing
- * that there is at most one multi-column parameter.
- */
-function getCurrentParam<T extends BaseConfig>(chart: BaseChart<T>, i: number) {
-    const { config } = chart;
-    const chartType = BaseChart.types[config.type];
-    const { params } = chartType;
-    // we only call this in the context of a chart type that has params
-    if (!params) throw new Error("No params for chart type");
-    const isMultiType = isMultiColumn(params[i].type);
-    
-    // const currentParams = config.param;
-    const currentParams = chart.activeQueries.userValues['setParams'] || config.param;
-    const n = currentParams.length;
-    const hasMulti = params.some(p => isMultiColumn(p.type));
-    if (isMultiType) {
-        //! as far as we know, we only ever see params ordered like [_multi] or [single, _multi]
-        const nOthers = params.length - 1;
-        if (i === 0) {
-            // we want the head of the array... the length minus however many other params there are
-            const end = currentParams.length - nOthers;
-            return currentParams.slice(0, end);
-        }
-        // If param type is _multi but it's not the first element of params array
-        // we want the tail of the array, starting from where the nOthers single params end
-        return currentParams.slice(nOthers);
-    }
-    if (hasMulti) {
-        // there is a multi-column parameter, and this is not it.
-        // we already handled the case where we are the multi-column parameter
-        // that means we should be either first or last in the array.
-        if (i === 0) {
-            return currentParams[0];
-        }
-        return currentParams[n - 1];
-    }
-    // there is no multi-column parameter; happy days
-    return currentParams[i];
-}
 
 function updateMultiParam<T extends BaseConfig>(chart: BaseChart<T>, i: number, value: FieldSpecs) {
     // const config = chart.getConfig(); //we don't want serialised config here
@@ -114,10 +72,10 @@ export default function getParamsGuiSpec<T extends BaseConfig>(chart: BaseChart<
     if (!params) return null;
     const multiCount = params.reduce((acc, p) => acc + (isMultiColumn(p.type) ? 1 : 0), 0);
     if (multiCount > 1) throw new Error("More than one multi-column parameter, abandon hope");
+    const currentParams = chart.activeQueries.activeParams();
     const p = params.map((param, i) => {
         const isMultiType = isMultiColumn(param.type);
-        // we could avoid this now that we have the activeParams method...
-        const current_value = getCurrentParam(chart, i);
+        const current_value = currentParams[i];
         return g({
             type: isMultiType ? "multicolumn" : "column",
             label: param.name,

--- a/src/datastore/decorateColumnMethod.ts
+++ b/src/datastore/decorateColumnMethod.ts
@@ -184,43 +184,8 @@ export class ColumnQueryMapper<T extends BaseConfig> {
             this.reactionDisposers.delete(methodName);
             this.chart.reactionDisposers = this.chart.reactionDisposers.filter(v => v !== disposer);
         }
-        
-        if (!alreadyInSetQuery) {
-            this.userValues[methodName] = userValue;
-
-            // Update the live chart configuration if a mapping exists
-            const configPathKey = this.methodToConfigMap[methodName];
-            if (configPathKey) {
-                action(() => { // Ensure mutations happen within an action
-                    const isArrayPath = isArray(configPathKey);
-                    const path = isArrayPath ? configPathKey[0] : configPathKey;
-                    const parts = path.split('.');
-                    
-                    let currentConfigNode = this.chart.config as any;
-                    for (let i = 0; i < parts.length - 1; i++) {
-                        if (currentConfigNode[parts[i]] === undefined || currentConfigNode[parts[i]] === null) {
-                            currentConfigNode[parts[i]] = {};
-                        }
-                        currentConfigNode = currentConfigNode[parts[i]];
-                    }
-                    
-                    const finalKey = parts[parts.length - 1];
-                    if (isArrayPath) { // e.g., map for 'setParams' is ['param']
-                        currentConfigNode[finalKey] = userValue; // e.g., config.param = [cat, query]
-                    } else { // e.g., map for 'colorByColumn' is 'color_by'
-                        // userValue for single arg methods like colorByColumn(col) is [col]
-                        currentConfigNode[finalKey] = userValue ? userValue[0] : null; // e.g., config.color_by = col
-                    }
-                })();
-            }
-        } else {
-            // If nested, we typically don't want to overwrite the primary userValue
-            // or trigger further config updates based on this inner call.
-            // However, the original logic cleared userValues[methodName] = null here.
-            // For now, let's preserve that specific part if `alreadyInSetQuery` is true.
-             this.userValues[methodName] = null;
-        }
-
+        if (!alreadyInSetQuery) this.userValues[methodName] = userValue;
+        else this.userValues[methodName] = null;
         //using chart.mobxAutorun() to ensure that the reaction is disposed when the chart is disposed
         const disposer = this.chart.mobxAutorun(callback);
         this.reactionDisposers.set(methodName, disposer);

--- a/src/datastore/decorateColumnMethod.ts
+++ b/src/datastore/decorateColumnMethod.ts
@@ -1,5 +1,6 @@
 import BaseChart, { type BaseConfig } from "@/charts/BaseChart";
-import { flattenFields, type FieldSpec } from "@/lib/columnTypeHelpers";
+// import { deserialiseParam, type SerialisedParams } from "@/charts/chartConfigUtils";
+import { type FieldSpecs, flattenFields, type FieldSpec } from "@/lib/columnTypeHelpers";
 import { isArray } from "@/lib/utils";
 import { RowsAsColsQuery } from "@/links/link_utils";
 import { action, type IReactionDisposer } from "mobx";
@@ -240,5 +241,36 @@ export class ColumnQueryMapper<T extends BaseConfig> {
         }
 
         return serialized;
+    }
+    //- not implementing for now, 
+    // concentrating on more localised logic for params to reduce testing scope
+    // activeChartConfig() {
+    //     const config = this.chart.getConfig();
+    //     //but deserialised... we don't have a clean method for that, but we can handle param specifically
+    //     const param: SerialisedParams = config.param;
+    //     //!! this is fishy - we don't want new objects, we want to use the activeQueries.userValues
+    //     const processed = param.map(p => deserialiseParam(this.chart.dataStore, p));
+    //     config.param = processed;
+    //     return config;
+    // }
+    /**
+     * Returns the active parameters for the chart.
+     * 
+     * This is the same as the `config.param` property, but it will be the active state of the parameters,
+     * rather than the serialised state (or strings for current fields).
+     * 
+     * This is useful for getting the active state of the parameters, which is needed for things like
+     * the parameter setting dialog.
+     * 
+     * We would prefer to have a method on the chart object that returns the entire active config,
+     * but keeping the implementation focused on params/setParams means that we can be more confident
+     * that the logic is correct.
+     */
+    activeParams() {
+        // if there is some value in activeQueries.userValues['setParams'] that might work...
+        if ('setParams' in this.userValues) {
+            return this.userValues['setParams'] as FieldSpecs;
+        }
+        return this.chart.config.param;
     }
 }

--- a/src/datastore/decorateColumnMethod.ts
+++ b/src/datastore/decorateColumnMethod.ts
@@ -184,8 +184,43 @@ export class ColumnQueryMapper<T extends BaseConfig> {
             this.reactionDisposers.delete(methodName);
             this.chart.reactionDisposers = this.chart.reactionDisposers.filter(v => v !== disposer);
         }
-        if (!alreadyInSetQuery) this.userValues[methodName] = userValue;
-        else this.userValues[methodName] = null;
+        
+        if (!alreadyInSetQuery) {
+            this.userValues[methodName] = userValue;
+
+            // Update the live chart configuration if a mapping exists
+            const configPathKey = this.methodToConfigMap[methodName];
+            if (configPathKey) {
+                action(() => { // Ensure mutations happen within an action
+                    const isArrayPath = isArray(configPathKey);
+                    const path = isArrayPath ? configPathKey[0] : configPathKey;
+                    const parts = path.split('.');
+                    
+                    let currentConfigNode = this.chart.config as any;
+                    for (let i = 0; i < parts.length - 1; i++) {
+                        if (currentConfigNode[parts[i]] === undefined || currentConfigNode[parts[i]] === null) {
+                            currentConfigNode[parts[i]] = {};
+                        }
+                        currentConfigNode = currentConfigNode[parts[i]];
+                    }
+                    
+                    const finalKey = parts[parts.length - 1];
+                    if (isArrayPath) { // e.g., map for 'setParams' is ['param']
+                        currentConfigNode[finalKey] = userValue; // e.g., config.param = [cat, query]
+                    } else { // e.g., map for 'colorByColumn' is 'color_by'
+                        // userValue for single arg methods like colorByColumn(col) is [col]
+                        currentConfigNode[finalKey] = userValue ? userValue[0] : null; // e.g., config.color_by = col
+                    }
+                })();
+            }
+        } else {
+            // If nested, we typically don't want to overwrite the primary userValue
+            // or trigger further config updates based on this inner call.
+            // However, the original logic cleared userValues[methodName] = null here.
+            // For now, let's preserve that specific part if `alreadyInSetQuery` is true.
+             this.userValues[methodName] = null;
+        }
+
         //using chart.mobxAutorun() to ensure that the reaction is disposed when the chart is disposed
         const disposer = this.chart.mobxAutorun(callback);
         this.reactionDisposers.set(methodName, disposer);


### PR DESCRIPTION
There were logic errors in the way that we move between representations of `config.param`, meaning that - for instance - with Dot Plot, if the user had chosen an active query for fields, and later changed the other param for category, this would cause it to overwrite the current "concrete field names" representation stored in `chart.config`.

We now have a way of getting `activeParams` that allows more direct use of this state and getting rid of some horrible internal logic in `ParamsSettingsGui`.

I think we should have specific fields for each parameter in config objects rather than relying on `param[]` - in which case we need to consider versioning/migration of legacy configs etc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved chart title synchronization and dynamic color updates in CategoryChart when configuration changes.
  - Added a method to access active chart parameters for better parameter management dialogs.
  - Updated authentication to use a global JWKS cache, reducing external API calls and improving performance.
  - Conditional redirection after authentication based on environment configuration.

- **Performance Optimization**
  - Implemented caching and refresh intervals for user/project data and JWKS to reduce redundant validations and database calls.
  - Reduced logging verbosity in key request paths for faster response times.

- **Bug Fixes**
  - Ensured project owner field uses a consistent name in API responses.

- **Style**
  - Unified tooltip styling across themes using CSS variables for background and text colors.
  - Updated tooltip and context menu colors to use theme variables for consistent appearance.

- **Documentation**
  - Added a comprehensive guide detailing authentication performance optimizations and recommendations.

- **Refactor**
  - Simplified parameter update logic in chart dialogs for maintainability.
  - Switched DotPlot field updates to use reactive MobX autorun instead of direct calls.

- **Chores**
  - Exported additional type definitions for chart configuration utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->