### PR TITLE
use pn user from base image, change poetry config to use environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@ __pycache__
 .git
 node_modules
 venv
+.venv
 docsenv
 # subject to review
 # docs/jsdocs/build

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@
 # not sure if there's a way of pinning a more specific build of the base image. May want to see if we can reproduce this issue outside of docker.
 FROM nikolaik/python-nodejs:python3.12-nodejs20 AS frontend-builder
 
+# Install system packages as root (these require root privileges)
 # this layer will change less frequently than the others, so it's good to have it first
 # Install HDF5 library, for some reason poetry can't install it in this context as of now
 # see https://github.com/h5py/h5py/issues/2146 for similar-ish issue
@@ -12,14 +13,49 @@ RUN apt-get install -y netcat-openbsd || (cat /var/log/apt/term.log && exit 1)
 RUN apt-get install -y telnet || (cat /var/log/apt/term.log && exit 1)
 RUN apt-get install -y iputils-ping || (cat /var/log/apt/term.log && exit 1)
 
+# Switch to the pn user early in the process to avoid permission issues
+USER pn
+WORKDIR /app
+
+# Configure poetry for the pn user - let it create virtual environments for isolation
+# 
+# VIRTUAL ENVIRONMENTS IN DOCKER CONSIDERATIONS:
+# 
+# PROS of using virtual environments (current approach):
+# - Security: poetry install runs in isolated environment, can't affect system packages
+# - Permission isolation: avoids conflicts with system-installed packages like certifi
+# - Standard practice: how poetry is intended to be used
+# - Safer with untrusted code: LLM-generated code runs in more isolated environment
+# 
+# CONS of using virtual environments:
+# - Less convenient for terminal use: need to run `poetry shell` or `poetry run` for commands
+# - Seems redundant: container already provides isolation from host system
+# - Extra layer: adds complexity when debugging dependency issues
+# - Performance: slight overhead from virtual environment activation
+# 
+# PROS of disabling virtual environments (previous approach):
+# - Convenience: can run python/pip commands directly in terminal without activation
+# - Simpler: no need to remember to use `poetry run` or `poetry shell`
+# - Direct access: easier to inspect installed packages and run ad-hoc scripts
+# 
+# CONS of disabling virtual environments:
+# - Permission conflicts: user can't modify system packages (the current issue)
+# - Security risk: poetry install can affect system Python environment
+# - Mixing concerns: system packages and project packages in same namespace
+# 
+# DECISION: Using virtual environments for security and permission isolation,
+# despite the convenience tradeoff. For terminal use inside container:
+# - Use `poetry shell` to activate the environment
+# - Or prefix commands with `poetry run`
+# - Or add alias in bashrc: alias python='poetry run python'
+RUN poetry config virtualenvs.in-project true
+
 # Install Python dependencies using Poetry
 # this should be early in the process because it's less likely to change
-WORKDIR /app
-# copy poetry files first to cache the install step
-COPY python/pyproject.toml ./python/
-COPY python/poetry.lock ./python/
+# copy poetry files first to cache the install step (with correct ownership)
+COPY --chown=pn:pn python/pyproject.toml ./python/
+COPY --chown=pn:pn python/poetry.lock ./python/
 WORKDIR /app/python
-RUN poetry config virtualenvs.create false
 # trouble with this is that it doesn't have the mdvtools code yet...
 # still worth installing heavy dependencies here
 # BUT - 
@@ -34,15 +70,13 @@ RUN poetry config virtualenvs.create false
 RUN poetry install --with dev,backend,auth --no-root
 
 WORKDIR /app
-# copy the package.json and package-lock.json as a separate step so npm install can be cached
-COPY package*.json ./
+# copy the package.json and package-lock.json as a separate step so npm install can be cached (with correct ownership)
+COPY --chown=pn:pn package*.json ./
 ## Install npm dependencies
 RUN npm install
 
-
-# Copy the entire project to the working directory
-COPY . .
-
+# Copy the entire project to the working directory (with correct ownership)
+COPY --chown=pn:pn . .
 
 # & start dev server (should only happen in dev - but other yml configs won't expose the port)
 # RUN npm run dev # run manually in container
@@ -50,7 +84,6 @@ COPY . .
 ## Run the npm build script for Flask and Vite
 # this will often change, so it's good to have it last... doesn't seem to be cached
 RUN npm run build-flask-dockerjs
-
 
 WORKDIR /app/python
 # installing again so we have mdvtools as a module, on top of the previous install layer with dependencies
@@ -64,20 +97,15 @@ EXPOSE 5055
 # something changed causing npm to need this in order for `source` to work in npm scripts
 RUN npm config set script-shell "/bin/bash"
 
-# Create logs directory and set permissions before switching user
-RUN mkdir -p /app/logs && \
-    touch /app/logs/error.log /app/logs/access.log && \
-    chmod -R 755 /app/logs
-
-# Create non-root user and assign permissions
-RUN useradd -u 1010 -m mdvuser \
-    && chown -R mdvuser:mdvuser /app
-
-# Switch to non-root user
-USER mdvuser
-# apply the same config to the user so that `poetry run` works for tests etc.
-RUN poetry config virtualenvs.create false
-
+# Add convenience aliases for terminal use with virtual environments
+# This makes it easier to work in the container terminal without remembering poetry run
+RUN echo 'alias python="poetry run python"' >> ~/.bashrc && \
+    echo 'alias pip="poetry run pip"' >> ~/.bashrc && \
+    echo 'alias pytest="poetry run pytest"' >> ~/.bashrc && \
+    echo 'alias flask="poetry run flask"' >> ~/.bashrc && \
+    echo 'alias gunicorn="poetry run gunicorn"' >> ~/.bashrc && \
+    echo 'alias mdv="poetry run python -m mdvtools"' >> ~/.bashrc && \
+    echo 'echo "💡 Tip: Virtual environment is active. Use poetry shell for full activation or commands are aliased."' >> ~/.bashrc
 
 # Command to run Gunicorn
 CMD ["poetry", "run", "gunicorn", "-k", "gevent", "-t", "200", "-w", "1", "-b", "0.0.0.0:5055", "--reload", "--access-logfile", "/app/logs/access.log", "--error-logfile", "/app/logs/error.log", "--capture-output", "mdvtools.dbutils.safe_mdv_app:app"]

--- a/docker-secrets.yml
+++ b/docker-secrets.yml
@@ -9,8 +9,13 @@ services:
       # - "5170:5170"
     volumes:
       # https://stackoverflow.com/questions/29181032/add-a-volume-to-docker-but-exclude-a-sub-folder
+      # Volume isolation strategy:
+      # - Mount source code from host for development (hot reload)
+      # - Exclude build artifacts, dependencies, and virtual environments from host
+      # - This prevents architecture conflicts and permission issues
       - .:/app
-      - /app/venv/
+      - /app/venv/                    # Legacy venv directory (if any)
+      - /app/python/.venv/            # Poetry virtual environment isolation
       - /app/docsenv/
       # subject to review - 'could not empty the output directory' errors etc...
       # - /app/docs/jsdocs/build/


### PR DESCRIPTION
There may apparently also be security benefits to the way we now install poetry dependencies as non-root, as well as being more when developing inside the devcontainer and doing anything involving poetry.