### PR TITLE
Fix parameter settings gui, particularly for multicolumn values

### DIFF
--- a/src/charts/dialogs/utils/ParamsSettingGui.tsx
+++ b/src/charts/dialogs/utils/ParamsSettingGui.tsx
@@ -2,6 +2,48 @@ import BaseChart, { type BaseConfig } from "@/charts/BaseChart";
 import { type FieldSpec, type FieldSpecs, isMultiColumn } from "@/lib/columnTypeHelpers";
 import { g, isArray } from "@/lib/utils";
 
+/**
+ * Helper method to go figure out which entries in a config.param array correspond
+ * to a given parameter at index i in the chart type's params array.
+ * There is no perfect way to do this - but we should be able to rely on knowing
+ * that there is at most one multi-column parameter.
+ */
+function getCurrentParam<T extends BaseConfig>(chart: BaseChart<T>, i: number) {
+    const { config } = chart;
+    const chartType = BaseChart.types[config.type];
+    const { params } = chartType;
+    // we only call this in the context of a chart type that has params
+    if (!params) throw new Error("No params for chart type");
+    const isMultiType = isMultiColumn(params[i].type);
+
+    // const currentParams = config.param;
+    const currentParams = chart.activeQueries.userValues['setParams'] || config.param;
+    const n = currentParams.length;
+    const hasMulti = params.some(p => isMultiColumn(p.type));
+    if (isMultiType) {
+        //! as far as we know, we only ever see params ordered like [_multi] or [single, _multi]
+        const nOthers = params.length - 1;
+        if (i === 0) {
+            // we want the head of the array... the length minus however many other params there are
+            const end = currentParams.length - nOthers;
+            return currentParams.slice(0, end);
+        }
+        // If param type is _multi but it's not the first element of params array
+        // we want the tail of the array, starting from where the nOthers single params end
+        return currentParams.slice(nOthers);
+    }
+    if (hasMulti) {
+        // there is a multi-column parameter, and this is not it.
+        // we already handled the case where we are the multi-column parameter
+        // that means we should be either first or last in the array.
+        if (i === 0) {
+            return currentParams[0];
+        }
+        return currentParams[n - 1];
+    }
+    // there is no multi-column parameter; happy days
+    return currentParams[i];
+}
 
 function updateMultiParam<T extends BaseConfig>(chart: BaseChart<T>, i: number, value: FieldSpecs) {
     // const config = chart.getConfig(); //we don't want serialised config here
@@ -75,7 +117,7 @@ export default function getParamsGuiSpec<T extends BaseConfig>(chart: BaseChart<
     const currentParams = chart.activeQueries.activeParams();
     const p = params.map((param, i) => {
         const isMultiType = isMultiColumn(param.type);
-        const current_value = currentParams[i];
+        const current_value = getCurrentParam(chart, i);
         return g({
             type: isMultiType ? "multicolumn" : "column",
             label: param.name,


### PR DESCRIPTION
I had wrongly thought that the internal logic of `ParameterSettingsGui` no longer needed extra logic for figuring out which section of the param list corresponded to a given `multicolumn`, but this was wrong.