### PR TITLE
Chat lint pass

### DIFF
--- a/python/mdvtools/llm/code_manipulation.py
+++ b/python/mdvtools/llm/code_manipulation.py
@@ -117,17 +117,15 @@ def _lint_code_with_ruff(code: str, log=print):
         )
 
         if ruff_result.stderr:
-                log(f"# Ruff stderr:\n{ruff_result.stderr}")
+            log(f"# Ruff stderr:\n{ruff_result.stderr}")
 
         with open(temp_file_path, 'r', encoding='utf-8') as temp_file:
             linted_code = temp_file.read()
         log("# Ruff pass complete.")
         return linted_code
 
-    except (subprocess.CalledProcessError, FileNotFoundError) as e:
+    except FileNotFoundError as e:
         log(f"# Ruff pass failed: {e}")
-        if isinstance(e, subprocess.CalledProcessError):
-            log(f"Ruff stderr: {e.stderr}")
         # continue with the un-linted code
         return code
     finally:

--- a/python/poetry.lock
+++ b/python/poetry.lock
@@ -5050,7 +5050,7 @@ version = "0.3.7"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "ruff-0.3.7-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:0e8377cccb2f07abd25e84fc5b2cbe48eeb0fea9f1719cad7caedb061d70e5ce"},
     {file = "ruff-0.3.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:15a4d1cc1e64e556fa0d67bfd388fed416b7f3b26d5d1c3e7d192c897e39ba4b"},
@@ -6466,4 +6466,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.13"
-content-hash = "7a8125da5387c99353613ac6154994b4a65f08d2f0871c704376cbbfb75b6dc9"
+content-hash = "fa6b08e1e302e9a3a1758f20d24b77900074f0ce5af6fb237c673cb344059257"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -38,6 +38,7 @@ faiss-cpu = "=1.8.0.post1"
 tabulate = "^0.9.0"
 python-dotenv = "^1.0.1"
 nbformat = "^5.10.4"
+ruff = "^0.3.7"
 
 [tool.poetry.group.dev]
 optional = true
@@ -45,7 +46,6 @@ optional = true
 [tool.poetry.group.dev.dependencies]
 pyright = "^1.1.358"
 pytest = "^8.1.1"
-ruff = "^0.3.7"
 ome-types = "^0.5.0"
 jupyterlab = "^4.1.8"
 leidenalg = "^0.10.2"


### PR DESCRIPTION
Passes generated code through `ruff` to remove unused import statements etc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added automatic linting and formatting of generated Python code using Ruff during code preparation.
- **Chores**
	- Made Ruff a core dependency, ensuring it is always available in all environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->