### PR TITLE
mdvtools cli

### DIFF
--- a/mdvtools_lite_build/pyproject.toml
+++ b/mdvtools_lite_build/pyproject.toml
@@ -39,6 +39,9 @@ dependencies = [
 [tool.hatch.build]
 directory = "./dist"
 
+[project.scripts]
+mdvtools = "mdvtools.cli:cli"
+
 [tool.hatch.build.targets.wheel.force-include]
 "../python/mdvtools/mdvproject.py" = "mdvtools/mdvproject.py"
 "../python/mdvtools/__init__.py" = "mdvtools/__init__.py"
@@ -50,6 +53,8 @@ directory = "./dist"
 "../python/mdvtools/static"="mdvtools/static"
 "../python/mdvtools/templates"="mdvtools/templates"
 "../python/mdvtools/chart_prototypes.py" = "mdvtools/chart_prototypes.py"
+"../python/mdvtools/logging_config.py"="mdvtools/logging_config.py"
+"../python/mdvtools/cli.py"="mdvtools/cli.py"
 
 
 

--- a/python/mdvtools/cli.py
+++ b/python/mdvtools/cli.py
@@ -4,7 +4,7 @@ import mudata as mu
 import shutil
 import zipfile
 import os
-from os.path import exists, join
+from os.path import exists, join, basename
 from .conversions import convert_scanpy_to_mdv, convert_mudata_to_mdv, convert_vcf_to_mdv
 
 def zip_and_remove(folder):
@@ -42,10 +42,17 @@ def cli():
 @click.option('--add_layer_data', is_flag=True, default=True, help='Add layer data (log values etc.).')
 @click.option('--gene_identifier_column', default=None, help='Gene column for identification.')
 @click.option('--zip', 'zip_output', is_flag=True, help='Zip the output folder and delete the original.')
-def convert_scanpy(folder, scanpy_object, max_dims, delete_existing, label, chunk_data, add_layer_data, gene_identifier_column, zip_output):
+@click.option('--chatmdv', is_flag=True, help='Include the original Scanpy .h5ad file in the zipped project.')
+def convert_scanpy(folder, scanpy_object, max_dims, delete_existing, label, chunk_data, add_layer_data, gene_identifier_column, zip_output, chatmdv):
     """Convert Scanpy AnnData object to MDV format."""
     adata = sc.read_h5ad(scanpy_object)
     convert_scanpy_to_mdv(folder, adata, max_dims, delete_existing, label, chunk_data, add_layer_data, gene_identifier_column)
+
+    if chatmdv:
+        dest_path = os.path.join(folder, basename(scanpy_object))
+        shutil.copy(scanpy_object, dest_path)
+        click.echo(f"Included original scanpy file: {dest_path}")
+
     if zip_output:
         zip_and_remove(folder)
 

--- a/python/mdvtools/cli.py
+++ b/python/mdvtools/cli.py
@@ -1,0 +1,57 @@
+import click
+from os.path import exists,join
+from .conversions import convert_scanpy_to_mdv, convert_mudata_to_mdv, convert_vcf_to_mdv
+
+@click.group()
+def cli():
+    """MDV Tools CLI"""
+    pass
+
+@cli.command()
+@click.argument('folder')
+@click.argument('scanpy_object')
+@click.option('--max_dims', default=3, help='Maximum number of dimensions to include from dimensionality reductions.')
+@click.option('--delete_existing', is_flag=True, help='Delete existing project data.')
+@click.option('--label', default='', help='Prefix to add to datasource names and metadata columns.')
+@click.option('--chunk_data', is_flag=True, help='Transpose and flatten in chunks to save memory.')
+@click.option('--add_layer_data', is_flag=True, default=True, help='Add layer data (log values etc.).')
+@click.option('--gene_identifier_column', default=None, help='Gene column for identification.')
+def convert_scanpy(folder, scanpy_object, max_dims, delete_existing, label, chunk_data, add_layer_data, gene_identifier_column):
+    """Convert Scanpy AnnData object to MDV format."""
+    convert_scanpy_to_mdv(folder, scanpy_object, max_dims, delete_existing, label, chunk_data, add_layer_data, gene_identifier_column)
+
+@cli.command()
+@click.argument('folder')
+@click.argument('mudata_object')
+@click.option('--max_dims', default=3, help='Maximum number of dimensions to include from dimensionality reductions.')
+@click.option('--delete_existing', is_flag=True, help='Delete existing project data.')
+@click.option('--chunk_data', is_flag=True, help='Transpose and flatten in chunks to save memory.')
+def convert_mudata(folder, mudata_object, max_dims, delete_existing, chunk_data):
+    """Convert MuData object to MDV format."""
+    convert_mudata_to_mdv(folder, mudata_object, max_dims, delete_existing, chunk_data)
+
+@cli.command()
+@click.argument('folder')
+@click.argument('vcf_filename')
+def convert_vcf(folder, vcf_filename):
+    """Convert VCF file to MDV format."""
+    convert_vcf_to_mdv(folder, vcf_filename)
+
+
+
+@cli.command()
+@click.argument('folder')
+def serve(folder):
+    """Serve MDV project."""
+    from .serverlite import serve_project
+    from .mdvproject import MDVProject
+    if not exists(folder):
+            raise FileNotFoundError(f"{folder} not found")
+    #could do more extensive check
+    ds_path = join(folder, "datasources.json")
+    if not exists(ds_path):
+        raise FileNotFoundError(f"{folder} does not contain a valid MDV project.")
+    serve_project(MDVProject(folder))
+
+if __name__ == '__main__':
+    cli()

--- a/python/mdvtools/cli.py
+++ b/python/mdvtools/cli.py
@@ -1,4 +1,6 @@
 import click
+import scanpy as sc
+import mudata as mu
 from os.path import exists,join
 from .conversions import convert_scanpy_to_mdv, convert_mudata_to_mdv, convert_vcf_to_mdv
 
@@ -18,7 +20,8 @@ def cli():
 @click.option('--gene_identifier_column', default=None, help='Gene column for identification.')
 def convert_scanpy(folder, scanpy_object, max_dims, delete_existing, label, chunk_data, add_layer_data, gene_identifier_column):
     """Convert Scanpy AnnData object to MDV format."""
-    convert_scanpy_to_mdv(folder, scanpy_object, max_dims, delete_existing, label, chunk_data, add_layer_data, gene_identifier_column)
+    adata = sc.read_h5ad(scanpy_object)
+    convert_scanpy_to_mdv(folder, adata, max_dims, delete_existing, label, chunk_data, add_layer_data, gene_identifier_column)
 
 @cli.command()
 @click.argument('folder')
@@ -28,7 +31,8 @@ def convert_scanpy(folder, scanpy_object, max_dims, delete_existing, label, chun
 @click.option('--chunk_data', is_flag=True, help='Transpose and flatten in chunks to save memory.')
 def convert_mudata(folder, mudata_object, max_dims, delete_existing, chunk_data):
     """Convert MuData object to MDV format."""
-    convert_mudata_to_mdv(folder, mudata_object, max_dims, delete_existing, chunk_data)
+    mdata = mu.read(mudata_object)
+    convert_mudata_to_mdv(folder, mdata, max_dims, delete_existing, chunk_data)
 
 @cli.command()
 @click.argument('folder')

--- a/python/mdvtools/cli.py
+++ b/python/mdvtools/cli.py
@@ -1,8 +1,31 @@
 import click
 import scanpy as sc
 import mudata as mu
-from os.path import exists,join
+import shutil
+import zipfile
+import os
+from os.path import exists, join
 from .conversions import convert_scanpy_to_mdv, convert_mudata_to_mdv, convert_vcf_to_mdv
+
+def zip_and_remove(folder):
+    """Zip a directory and delete the original."""
+    if not exists(folder):
+        raise FileNotFoundError(f"{folder} not found")
+
+    zip_filename = f"{folder.rstrip(os.sep)}.zip"
+    click.echo(f"Zipping folder: {folder} → {zip_filename}")
+
+    with zipfile.ZipFile(zip_filename, 'w', zipfile.ZIP_DEFLATED) as zipf:
+        for root, dirs, files in os.walk(folder):
+            for file in files:
+                file_path = os.path.join(root, file)
+                arcname = os.path.relpath(file_path, start=folder)
+                zipf.write(file_path, arcname)
+
+    click.echo(f"Zip created: {zip_filename}")
+    click.echo(f"Removing original folder: {folder}")
+    shutil.rmtree(folder)
+    click.echo("Done.")
 
 @click.group()
 def cli():
@@ -18,10 +41,13 @@ def cli():
 @click.option('--chunk_data', is_flag=True, help='Transpose and flatten in chunks to save memory.')
 @click.option('--add_layer_data', is_flag=True, default=True, help='Add layer data (log values etc.).')
 @click.option('--gene_identifier_column', default=None, help='Gene column for identification.')
-def convert_scanpy(folder, scanpy_object, max_dims, delete_existing, label, chunk_data, add_layer_data, gene_identifier_column):
+@click.option('--zip', 'zip_output', is_flag=True, help='Zip the output folder and delete the original.')
+def convert_scanpy(folder, scanpy_object, max_dims, delete_existing, label, chunk_data, add_layer_data, gene_identifier_column, zip_output):
     """Convert Scanpy AnnData object to MDV format."""
     adata = sc.read_h5ad(scanpy_object)
     convert_scanpy_to_mdv(folder, adata, max_dims, delete_existing, label, chunk_data, add_layer_data, gene_identifier_column)
+    if zip_output:
+        zip_and_remove(folder)
 
 @cli.command()
 @click.argument('folder')
@@ -29,19 +55,23 @@ def convert_scanpy(folder, scanpy_object, max_dims, delete_existing, label, chun
 @click.option('--max_dims', default=3, help='Maximum number of dimensions to include from dimensionality reductions.')
 @click.option('--delete_existing', is_flag=True, help='Delete existing project data.')
 @click.option('--chunk_data', is_flag=True, help='Transpose and flatten in chunks to save memory.')
-def convert_mudata(folder, mudata_object, max_dims, delete_existing, chunk_data):
+@click.option('--zip', 'zip_output', is_flag=True, help='Zip the output folder and delete the original.')
+def convert_mudata(folder, mudata_object, max_dims, delete_existing, chunk_data, zip_output):
     """Convert MuData object to MDV format."""
     mdata = mu.read(mudata_object)
     convert_mudata_to_mdv(folder, mdata, max_dims, delete_existing, chunk_data)
+    if zip_output:
+        zip_and_remove(folder)
 
 @cli.command()
 @click.argument('folder')
 @click.argument('vcf_filename')
-def convert_vcf(folder, vcf_filename):
+@click.option('--zip', 'zip_output', is_flag=True, help='Zip the output folder and delete the original.')
+def convert_vcf(folder, vcf_filename, zip_output):
     """Convert VCF file to MDV format."""
     convert_vcf_to_mdv(folder, vcf_filename)
-
-
+    if zip_output:
+        zip_and_remove(folder)
 
 @cli.command()
 @click.argument('folder')
@@ -50,8 +80,7 @@ def serve(folder):
     from .serverlite import serve_project
     from .mdvproject import MDVProject
     if not exists(folder):
-            raise FileNotFoundError(f"{folder} not found")
-    #could do more extensive check
+        raise FileNotFoundError(f"{folder} not found")
     ds_path = join(folder, "datasources.json")
     if not exists(ds_path):
         raise FileNotFoundError(f"{folder} does not contain a valid MDV project.")

--- a/python/mdvtools/mdvproject.py
+++ b/python/mdvtools/mdvproject.py
@@ -27,7 +27,6 @@ import tempfile
 from mdvtools.image_view_prototype import create_image_view_prototype
 from mdvtools.charts.table_plot import TablePlot
 from mdvtools.logging_config import get_logger
-from mdvtools.server_extension import MDVServerOptions
 
 logger = get_logger(__name__)
 


### PR DESCRIPTION
## Features

### Supported Input Formats
- **AnnData (.h5ad)**
  - Converts Scanpy AnnData objects to MDV format
  - Preserves cell and gene metadata
  - Handles dimensionality reductions (PCA, UMAP, t-SNE)
  - Supports sparse matrix formats

- **MuData (.h5mu)**
  - Converts multi-modal data to MDV format
  - Preserves modality-specific dimensionality reductions
  - Handles multiple layers per modality
  - Maintains cell and feature metadata across modalities

- **VCF (.vcf)**
  - Converts variant call format files to MDV format
  - Computes END positions for variants
  - Preserves all VCF metadata columns
  - Handles standard VCF header formats

### Output Options
- **Standard Directory Output**
  - Creates an MDV project directory with all necessary files
  - Maintains data structure compatible with MDV viewer

- **Zipped Output**
  - Optional compression of the output directory
  - Creates a single portable file
  - Maintains MDV compatibility

### ChatMDV Integration
- Option to include original data object in the project file
- Makes the project compatible with ChatMDV functionality
- Preserves all metadata for LLM context

### Performance Features
- Chunked data processing for large files
- Memory-efficient handling of sparse matrices
- Progress reporting during conversion

## Usage Examples

### Converting AnnData Files
```bash
mdvtools convert anndata input.h5ad output_folder \
  --delete-existing \
  --chunk-data \
  --zip-output
```

### Converting MuData Files
```bash
mdvtools convert mudata input.h5mu output_folder \
  --max-dims 3 \
  --delete-existing \
  --zip-output
```

### Converting VCF Files
```bash
mdvtools convert vcf input.vcf output_folder
```

## Configuration Options

### Global Options
- `--delete-existing`: Whether to delete existing project data (default: True)
- `--zip-output`: Compress output directory into a zip file
- `--chatmdv`: Include original data for ChatMDV compatibility

### AnnData Specific Options
- `--chunk-data`: Process large matrices in chunks (default: False)
- `--add-layer-data`: Include layer data in conversion (default: True)
- `--gene-identifier-column`: Specify column for gene identifiers
- `--max-dims`: Maximum dimensions for reduction (default: 3)

### MuData Specific Options
- `--max-dims`: Maximum dimensions for reduction (default: 3)
- `--chunk-data`: Process large matrices in chunks (default: False)

## Technical Details

### Data Processing Flow
1. Input validation and format detection
2. Data loading with memory optimization
3. Metadata preservation and structure mapping
4. Conversion to MDV format
5. Optional compression and cleanup

### Memory Management
- Chunked processing for large datasets
- Sparse matrix support for efficient storage
- Backed mode for reading large h5ad files

## Testing
The conversion utilities have been tested previously with:
- Various sizes of AnnData objects
- Multi-modal datasets with different layer configurations
- Standard VCF files with different variant types

I haven't done extensive testing after wrapping the CLI

## Dependencies
- scanpy
- mudata
- pandas
- numpy
- h5py
- scipy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduces a mdvtools command-line interface for converting Scanpy (.h5ad), MuData, and VCF files into MDV format.
  - Optional zipping of outputs with automatic cleanup.
  - Serve an MDV project from a folder with basic validation.
- Chores
  - Added a console script entry to install the CLI globally.
  - Ensured required CLI components are included in packaged builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->