### PR TITLE
Make sure openjpeg module is reused once it's been fetched

### DIFF
--- a/src/utilities/jpeg2000/Jpeg2000Decoder.ts
+++ b/src/utilities/jpeg2000/Jpeg2000Decoder.ts
@@ -59,12 +59,12 @@ type CompressedImageFrame = {
 */
 
 export default class Jpeg2000Decoder extends BaseDecoder {
-    private static openjpeg: OpenJpegModule | null = null;
+    private static openjpeg?: Promise<OpenJpegModule>;
 
     private async getOpenJPEG(): Promise<OpenJpegModule> {
         if (!Jpeg2000Decoder.openjpeg) {
             try {
-                Jpeg2000Decoder.openjpeg = await openJpegFactory({
+                Jpeg2000Decoder.openjpeg = openJpegFactory({
                     locateFile: (file: string) => {
                         if (file.endsWith(".wasm")) {
                             return openjpegWasm.href;


### PR DESCRIPTION
A new instance of `Jpeg2000Decoder` was being created for every image tile, hitting the server for the `wasm` code. Making the field static means all instances of the class can re-use it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Decoder initialization is now centralized so the decoding module is shared across instances.
  * Improved cleanup to reduce resource leaks and improve stability.
  * No changes to decoding outputs or user workflows; repeated decodes may show minor performance gains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->