### PR TITLE
pass arguments for docker build to use cache.

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -99,4 +99,6 @@ jobs:
             --label "org.opencontainers.image.description=${{ steps.release_notes.outputs.release_notes }}" \
             -t ${{ secrets.DOCKER_HUB_USERNAME }}/mdv-frontend:${{ steps.build_metadata.outputs.git_commit_hash }} \
             -t ${{ secrets.DOCKER_HUB_USERNAME }}/mdv-frontend:rbac \
+            --cache-from=type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME }}/mdv-frontend:cache \
+            --cache-to=type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME }}/mdv-frontend:cache,mode=max \
             --push . 


### PR DESCRIPTION
Hopefully this will make the pipeline run faster in majority of cases - was taking >20mins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented registry-backed caching for Docker image builds in the CI pipeline to reduce build times and speed up deployments.
  * Enables more efficient incremental builds by reusing cached layers across runs.
  * Improves deployment reliability and consistency by persisting build caches between workflows.
  * No changes to app functionality or UI; end-user experience remains the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->