### PR TITLE
Fix Socket.IO Uploads by Aligning Server/Client Paths

### DIFF
--- a/python/mdvtools/websocket.py
+++ b/python/mdvtools/websocket.py
@@ -27,7 +27,7 @@ class SocketIOContextRequest(FlaskRequest):
 def mdv_socketio(app: Flask):
     """
     Experimental and not to be trusted pending design work etc.
-    
+
     Do we have a SocketIO for the entire app and route messages internally,
     - yes probably.
     What `path` should it use? We'll need to make sure it is compatible with
@@ -40,8 +40,15 @@ def mdv_socketio(app: Flask):
     global socketio
     # allow cors for localhost:5170-5179
     # cors = [f"http://localhost:{i}" for i in range(5170,5180)]
-    socketio = SocketIO(app, cors_allowed_origins="*")
-    log("socketio initialized with cors_allowed_origins wildcard")
+
+    # Get the API root path for SocketIO path configuration
+    api_root = app.config.get('mdv_api_root', '/')
+    if api_root != '/' and not api_root.endswith('/'):
+        api_root += '/'
+    socketio_path = f"{api_root}socket.io"
+
+    socketio = SocketIO(app, cors_allowed_origins="*", path=socketio_path)
+    log(f"socketio initialized with cors_allowed_origins wildcard and path={socketio_path}")
 
     # @socketio.on("message")
     # def message(data):


### PR DESCRIPTION
This PR aims to fix the Socket.IO upload failures that were causing 500 errors when connecting. The root of the problem was a mismatch between the client and server socket paths. The client was attempting to connect using a sub-path such as /server/socket.io, while the server was only listening on the default /socket.io. This caused the upload handshake requests to hit an unhandled route, resulting in errors.

The issue was introduced in commit [78c48fa8 ](https://github.com/Taylor-CCB-Group/MDV/commit/78c48fa86746153cd71ec6c4051247eafc9f457f)(“SocketIO Import and Create Project Fix (#263)”), when the serverUrl parameter was removed and replaced with a dynamically constructed socketPath based on mdvApiRoot. This change allowed the client to adapt to sub-path deployments, but the server-side initialization in websocket.py was not updated at the same time. The result was that the client and server were no longer aligned, and uploads stopped working.

The fix was to update the server configuration so that it also respects MDV_API_ROOT when setting up the Socket.IO instance. Now the server computes the socket path dynamically: it uses /socket.io when deployed at the root, and <MDV_API_ROOT>/socket.io when deployed under a sub-path such as /server/ or /carroll/. With this change, the client and server are once again in sync, and uploads succeed regardless of deployment structure.
