### PR TITLE
remove `linux/arm64` platform from docker buildx command.

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Build and push linux/amd64 image
         run: |
           echo "Building and pushing image..."
-          docker buildx build --platform linux/amd64,linux/arm64 \
+          docker buildx build --platform linux/amd64 \
             --build-arg GIT_COMMIT_DATE="${{ steps.build_metadata.outputs.git_commit_date }}" \
             --build-arg GIT_BRANCH_NAME="${{ steps.build_metadata.outputs.git_branch_name }}" \
             --build-arg GIT_COMMIT_HASH="${{ steps.build_metadata.outputs.git_commit_hash }}" \


### PR DESCRIPTION
This appears to be causing the workflow to take a very long time to complete. I'm not sure what it was used for.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build pipeline to publish Docker images for linux/amd64 only.
  * Discontinued publishing linux/arm64 images.

* **Impact**
  * Users on amd64 platforms are unaffected.
  * Users on arm64 platforms will no longer receive new image builds; use amd64-compatible environments or prior arm64 images if needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->