### PR TITLE
changes to allow legacy projects

### DIFF
--- a/src/charts/RowSummaryBox.js
+++ b/src/charts/RowSummaryBox.js
@@ -6,8 +6,7 @@ import { getProjectURL } from "../dataloaders/DataLoaderUtil.ts";
 class RowSummaryBox extends BaseChart {
     constructor(dataStore, div, config) {
         super(dataStore, div, config);
-
-        if (config.image) {
+        if (config.image || config.image_set) {
             const d = createEl(
                 "div",
                 {
@@ -16,7 +15,23 @@ class RowSummaryBox extends BaseChart {
                 },
                 this.contentDiv,
             );
+            if (config.image_set){
+                this.img_data =  JSON.parse(JSON.stringify(dataStore.large_images[config.image_set]));
+            }
+            //legacy - images defined in config
+            else{
+                this.img_data =  JSON.parse(JSON.stringify(config.image));
+                this.img_data.key_column = this.config.param[this.img_data.param];
+            }
+            //base url may be stub e.g /project/data/im
+            //in which case trailing / added by getProjectURL needs to be removed
+            let base_url  = getProjectURL(this.img_data.base_url);
+            if (!this.img_data.base_url.endsWith("/")) {
+                base_url = base_url.replace(/\/+$/, "");
+            }
+            this.img_data.base_url = base_url;
             this.imViewer = new ImagePanZoom(d, this._getImage(0));
+            
         }
         this.paramHolders = {};
         const sectionDiv = createEl("div", {}, this.contentDiv);
@@ -65,11 +80,8 @@ class RowSummaryBox extends BaseChart {
     }
 
     _getImage(index) {
-        const c = this.config;
-        const p = c.param[c.image.param];
-        this.img_param = p;
-        const data = this.dataStore.getRowText(index, p);
-        return getProjectURL(`${c.image.base_url}${data}.${c.image.type}`);
+        const data = this.dataStore.getRowText(index, this.img_data.key_column);
+        return `${this.img_data.base_url}${data}.${this.img_data.type}`;
     }
 
     setSize(x, y) {

--- a/src/charts/WGLScatterPlot.js
+++ b/src/charts/WGLScatterPlot.js
@@ -402,6 +402,7 @@ class WGLScatterPlot extends WGLChart {
 
     addBackgroundImage(ic, change = false) {
         const im = new Image();
+        im.crossOrigin = "anonymous";
         const c = this.config;
         c.image_opacity = c.image_opacity || 1;
         im.src = ic.url
@@ -610,6 +611,7 @@ class WGLScatterPlot extends WGLChart {
     getSettings() {
         const settings = super.getSettings({ pointMax: 30, pointMin: 0 });
         const c = this.config;
+        //this is legacy and probably not used anymore
         if (c.image_choices) {
             const ic = c.image_choices.slice(0);
             ic.unshift(["None", "__none__"]);
@@ -649,18 +651,19 @@ class WGLScatterPlot extends WGLChart {
                 },
             });
         }
+        //the choice of images should be in the datastore 
         const rs = this.dataStore.regions;
         if (c.region && rs && !c.viv) {
             const ic = rs.all_regions[c.region].images;
-            const vals = [["None", "__none__"]];
+            const vals = [{"name":"None", "field":"__none__"}];
             for (const n in ic) {
-                vals.push([n, n]);
+                vals.push({ name: n, field: n });
             }
             const cv = c.background_image?.name || "__none__";
             settings.splice(1, 0, {
                 type: "dropdown",
                 current_value: cv,
-                values: [vals, 0, 1],
+                values: [vals, "name", "field"],
                 label: "Change Image",
                 func: (x) => {
                     if (x === "__none__") {

--- a/src/table/ImageTable.js
+++ b/src/table/ImageTable.js
@@ -23,9 +23,17 @@ class ImageTable {
         this.display_columns = [];
         this.selection_mode = true;
         this.imageFunc = config.imageFunc;
-        //config.background_color=config.background_color?config.background_color:"lightgray";
-
-        this.base_url = getProjectURL(config.base_url);
+        //The base url contains the stub of the image e.g. /images/img
+        //and is not just the folder- need to remove trailing slash
+        //Although clunky this allows integer columns to represent the img
+        //eg. 1 becomes /images/im1.png
+        
+        this.base_url = getProjectURL(config.base_url)
+        if (!config.base_url.endsWith("/")) {
+            this.base_url = this.base_url.replace(/\/+$/, "");
+        }
+        
+      
         this.parent = parent_div;
         this.selected_tiles = {};
 
@@ -105,11 +113,11 @@ class ImageTable {
             }
             this._resize();
         };
-
-        const burl = getProjectURL(this.config.base_url);
+        //load in first image to get preferred dimensions
+        //if none are given
         const type = this.config.image_type;
         const image = this.data_view.getItemField(1, this.config.image_key);
-        im.src = `${burl}${image}.${type}`;
+        im.src = `${this.base_url}${image}.${type}`;
     }
 
     mouseOver(e, img) {
@@ -549,7 +557,6 @@ class ImageTable {
         let x = 0;
         const w = `${this.t_width}px`;
         const h = `${this.t_height}px`;
-        const burl = getProjectURL(this.config.base_url);
         const type = this.config.image_type;
         // looking for something to provide a default name; "Gene" is ok for ytrap...
         const titleColumn = this.config.image_title || "Gene";
@@ -605,7 +612,7 @@ class ImageTable {
             createEl(
                 "img",
                 {
-                    src: `${burl}${image}.${type}`,
+                    src: `${this.base_url}${image}.${type}`,
                     id: `mlvtile-${this.domId}-${i}`,
                     styles: {
                         border: border,


### PR DESCRIPTION
These changes are only for legacy charts and should have no impact elsewhere

- In the computed image paths for the ImageTableChart and the RowSummary dialog, the trailing / is removed where appropriate
- In legacy scatterplots (WGLScatterPlot)   , bugs were fixed in the way images were selected
- Also in serverlite.py,  an option to compress column data is available (some uncompressed data is blocked by anti-virus software but only from local host) - thus this  is only required for testing and any front end will have to decompress the data if this option is used

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional data compression support for server responses.
  * Enhanced image rendering with improved data resolution and image set support.

* **Improvements**
  * Refined image selection mechanism for better usability.
  * Added cross-origin support for image loading.
  * Improved image URL construction and base URL handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->