### PR TITLE
Converting annotated shapes to geojson in spatialdata conversion

### DIFF
--- a/python/mdvtools/spatial/conversion.py
+++ b/python/mdvtools/spatial/conversion.py
@@ -494,7 +494,7 @@ if __name__ == "__main__":
     parser.add_argument("spatialdata_path", type=str, help="Path to SpatialData data")
     parser.add_argument("output_folder", type=str, help="Output folder for MDV project")
     parser.add_argument("--preserve-existing", action="store_true", help="Preserve existing project data")
-    parser.add_argument("--output_geojson", action="store_true", help="Output geojson for each region")
+    parser.add_argument("--output_geojson", action="store_true", help="Output geojson for each region (this feature to be deprecated in favour of spatialdata.js layers with shapes)")
     parser.add_argument("--serve", action="store_true", help="Serve the project after conversion")
     args = parser.parse_args()
     print(f"Converting SpatialData from '{args.spatialdata_path}' to {args.output_folder}")


### PR DESCRIPTION
Pending proper implementation of spatialdata.js, write geojson corresponding to cell boundaries and associate with viv regions.

First draft had points but not polygons when converting xenium data, because the elements annotated by tables are `"cell_circles"` rather than e.g. `"cell_boundaries"`. For now it is hard-coded to look for `"cell_boundaries"` and use them if present.... this logic is quite bad in various ways that would be problematic if the data happened to have an element with that name that didn't match this assumption. The intention is that the use of geojson will only be a temporary measure and we should probably entirely remove the related code once proper shape layer support is in place.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional GeoJSON export via a CLI flag to produce per-region JSON alongside converted spatial data.
  * Generated GeoJSON files are written to a temporary staging folder and moved into the final spatial directory on completion.
  * Per-region metadata records the presence and path of generated GeoJSON.
  * GeoJSON coordinates are transformed into image space for correct alignment.
  * GeoJSON generation is safe for multi-threaded conversion and includes user-facing notices for fallback cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->