### PR TITLE
Change spatial view template with densityFields as active link

### DIFF
--- a/python/mdvtools/spatial/spatial_view_template.json
+++ b/python/mdvtools/spatial/spatial_view_template.json
@@ -4,16 +4,16 @@
       {
         "course_radius": 1,
         "radius": 10,
-        "opacity": 1,
+        "opacity": 0.25,
         "tooltip": {
           "show": false
         },
         "category_filters": [],
         "zoom_on_filter": false,
         "point_shape": "circle",
-        "contour_fill": false,
-        "contour_bandwidth": 0.1,
-        "contour_intensity": 1,
+        "contour_fill": true,
+        "contour_bandwidth": 30,
+        "contour_intensity": 0.7,
         "contour_opacity": 0.5,
         "dimension": "2d",
         "on_filter": "hide",
@@ -35,6 +35,13 @@
           "maxItems": 1,
           "type": "RowsAsColsQuery"
         },
+        "densityFields": [
+          {
+            "linkedDsName": "genes",
+            "maxItems": 15,
+            "type": "RowsAsColsQuery"
+          }       
+        ],
         "background_filter": {
           "column": "spatial_region",
           "category": "<SPATIAL_REGION_NAME>"


### PR DESCRIPTION
In the JSON used as template for default view in spatial conversion, `densityFields` is set to an active link with "genes", with 15 items (may be a bit much for visual noise/some configurations but seems somewhat ok). Other visual settings tweaked for a hopefully useful baseline.

An argument could be made for not having this so strongly prominent by default, more ways of configuring during conversion etc, but I think this is ok as is.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added density field configuration supporting genes visualization with customizable parameters.
  * Enhanced contour rendering with improved fill display and parameter adjustments for better clarity.
  * Refined default transparency settings in spatial views for improved visual presentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->