### PR TITLE
fix bugs in mudata conversion

### DIFF
--- a/python/mdvtools/mdvproject.py
+++ b/python/mdvtools/mdvproject.py
@@ -1040,7 +1040,8 @@ class MDVProject:
                 # TablePlot parameters
                 title=name,
                 #params = ["leiden", "ARVCF", "DOK3", "FAM210B", "GBGT1", "NFE2L2", "UBE2D4", "YPEL2"]
-                params = dataframe.columns.to_list()
+                #only want columns from the dataframe that were added to the datasource
+                params = [x["field"] for x in columns]
                 size = [792, 472]
                 position = [10, 10]
             


### PR DESCRIPTION
In mudata conversion - the var of a modality (a datatframe of the genes,proteins,ATAC sites etc)  can have no columns, just an index  which was the gene/protein/ATAC identifier. 
This index was added to the datasource after its creation, Now it is added to the dataframe, so there is at least one column in it to ensure the datasource can be created without error.
Also any DR for the modality (gene/protein clustering) is now added.
In addition, when default tables are added to the view only columns which were actually added to the datasource are included 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of gene/feature identifiers during modality data conversion to ensure consistent naming.
  * Table plots now display only relevant fields instead of all available columns.

* **Improvements**
  * Dimension reductions are now properly integrated into modality data during the conversion process.
  * Added validation logging for existing identifiers in modality data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->