### PR TITLE
Fix: Merge subgroups when inserting existing rows_as_columns links

### DIFF
--- a/python/mdvtools/mdvproject.py
+++ b/python/mdvtools/mdvproject.py
@@ -1281,7 +1281,27 @@ class MDVProject:
         if not llink:
             llink = {}
             links[linkto] = llink
-        llink[linktype] = data
+        
+        # Check if link already exists and merge subgroups for rows_as_columns links
+        if linktype == "rows_as_columns" and linktype in llink:
+            existing_link = llink[linktype]
+            # Merge subgroups: preserve existing subgroups, add new ones from data
+            if "subgroups" in existing_link and "subgroups" in data:
+                # Merge subgroups dictionaries
+                merged_subgroups = existing_link["subgroups"].copy()
+                merged_subgroups.update(data["subgroups"])
+                data["subgroups"] = merged_subgroups
+            # Preserve other existing properties if they match
+            if existing_link.get("name_column") == data.get("name_column"):
+                # Same link configuration, merge subgroups
+                llink[linktype] = data
+            else:
+                # Different link configuration, overwrite (shouldn't happen in normal flow)
+                llink[linktype] = data
+        else:
+            # No existing link or not rows_as_columns type, overwrite as before
+            llink[linktype] = data
+        
         self.set_datasource_metadata(ds)
 
     def add_rows_as_columns_link(


### PR DESCRIPTION
When merging MDV projects, insert_link() was overwriting existing
rows_as_columns links with empty subgroups, causing loss of subgroup
definitions during project merges. 

Now checks if a rows_as_columns link already exists and merges the
subgroups dictionaries instead of overwriting, preserving existing
subgroups while allowing new ones to be added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced data linking behavior to merge existing data intelligently instead of overwriting blindly, preventing unintended data loss.
  * Improved property preservation logic during data linking to maintain data integrity and consistency across records.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->