### PR TITLE
Fix/viv config saved with a number of channels other than 4 caused errors especially when opening color dialog

### DIFF
--- a/src/react/components/VivMDVReact.tsx
+++ b/src/react/components/VivMDVReact.tsx
@@ -338,7 +338,7 @@ class VivMdvReact extends BaseReactChart<VivMdvReactConfig> {
                     contrast: channels.contrast,
                     domains: channels.domains,
                     selections: channels.selections,
-                    ids: channels.ids,
+                    // ids: channels.ids, // don't need to be serialised as long as they are synthesised correctly in applyDefaultChannelState
                 },
                 imageSettingsStore: {
                     // could be interested in lensEnabled, zoomLock, panLock, etc.

--- a/src/react/components/avivatorish/state.tsx
+++ b/src/react/components/avivatorish/state.tsx
@@ -386,14 +386,12 @@ export const applyDefaultChannelState = (config: Partial<VivConfig>) => {
     const expectedLength = newConfig.channelsStore.channelsVisible?.length || 0;
     
     // Ensure ids array exists and has the correct length
-    // This handles backward compatibility for configs saved before ids was serialized
-    if (!newConfig.channelsStore.ids || newConfig.channelsStore.ids.length !== expectedLength) {
-        if (expectedLength > 0) {
-            newConfig.channelsStore.ids = Array.from({ length: expectedLength }, 
-                () => String(Math.random()));
-        } else {
-            newConfig.channelsStore.ids = [];
-        }
+    // Ignore any serialised value in config (not expected to be there other than in test config used during dev)
+    if (expectedLength > 0) {
+        newConfig.channelsStore.ids = Array.from({ length: expectedLength }, 
+            () => String(Math.random()));
+    } else {
+        newConfig.channelsStore.ids = [];
     }
     
     // Handle brightness and contrast arrays (legacy support)


### PR DESCRIPTION
When we serialise the `channelsStore`, we didn't include `ids`, and then when loading a chart, the `adaptConfig` function called `applyDefaultChannelState` which wasn't properly handling this case.

The CodeRabbit summary is misleading here in some ways.

In particular, there is no change to whether channel selections are included in the serialisation (although a comment was made on the type, which still currently makes it seem like keys for `z` & `t` will always be there, which they are not). At one stage channel `ids` were added to serialisation, but this is redundant information that can be created at runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Channel selections are now included in saved configuration

* **Bug Fixes**
  * Improved handling of image channels that may lack z/t dimensions
  * Enhanced robustness of channel initialization for variable-length image data
  * Brightness and contrast defaults now properly adapt to the number of available channels

* **Chores**
  * Strengthened TypeScript error expectations for state mutations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->