### PR TITLE
change base image in dockerfile to use node22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@
 # warning - we had an obscure npm error with cross-env not found, and it seems like using an earlier nodejs version fixed it
 # for some reason node_modules/.bin wasn't populated after `RUN npm install` - but manually running it in the container worked
 # not sure if there's a way of pinning a more specific build of the base image. May want to see if we can reproduce this issue outside of docker.
-FROM nikolaik/python-nodejs:python3.12-nodejs20 AS frontend-builder
+# revisiting in 2026: node20 is reaching EOL, and we have a "npm warn EBADENGINE Unsupported engine" related to "vite-plugin-glsl" in npm install
+# changing to node22 again.
+FROM nikolaik/python-nodejs:python3.12-nodejs22 AS frontend-builder
 
 # ARG and ENV for build information, to be passed in from the CI pipeline
 ARG GIT_COMMIT_DATE="unknown"


### PR DESCRIPTION
We have been using Node v20, which is approaching EOL and also lead to a warning during `npm install`.

Changing to v22 is believed to be safe at this point, and this certainly Works On My Machine. We had previously explicitly downgraded because of a specific build-breaking issue as commented in the Dockerfile - that issue is believed to have been very temporary and I think we're more likely to have issues with an EOL version than a current LTS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build environment to use Node.js 22 for improved stability and compatibility with development dependencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->