### PR TITLE
move markdown_utils.py out of llm

### DIFF
--- a/python/mdvtools/llm/chat_server_extension.py
+++ b/python/mdvtools/llm/chat_server_extension.py
@@ -7,7 +7,7 @@ from mdvtools.llm.chat_protocol import (
   ProjectChatProtocol, 
   chat_enabled
 )
-from mdvtools.llm.markdown_utils import create_project_markdown, create_error_markdown
+from mdvtools.markdown_utils import create_project_markdown, create_error_markdown
 from mdvtools.mdvproject import MDVProject
 from mdvtools.project_router import ProjectBlueprintProtocol
 # from mdvtools.dbutils.config import config

--- a/python/mdvtools/llm/langchain_mdv.py
+++ b/python/mdvtools/llm/langchain_mdv.py
@@ -19,7 +19,7 @@ from langchain_community.vectorstores import FAISS
 from langchain.text_splitter import Language
 from langchain_core.pydantic_v1 import BaseModel, Field
 from langchain.schema import HumanMessage
-from .markdown_utils import create_suggested_questions_prompt
+from mdvtools.markdown_utils import create_suggested_questions_prompt
 
 # from langchain.prompts import PromptTemplate
 

--- a/python/mdvtools/llm/templates.py
+++ b/python/mdvtools/llm/templates.py
@@ -1,6 +1,6 @@
 from mdvtools.mdvproject import MDVProject
 from typing import Any
-from mdvtools.llm.markdown_utils import create_project_markdown, create_column_markdown
+from mdvtools.markdown_utils import create_project_markdown, create_column_markdown
 prompt_data = """
 Your task is to:  
 1. Identify the type of data the user needs (e.g., categorical, numerical, etc.) by inspecting the DataFrames provided.

--- a/python/mdvtools/markdown_utils.py
+++ b/python/mdvtools/markdown_utils.py
@@ -119,6 +119,12 @@ def create_column_markdown(cols: list[dict]) -> str:
     
     return f"{markdown}\n\n"
 
+## ---------------------------------
+## ---------------------------------
+## chat/LLM related stuff... there could be an argument for having this in `mdvtools.llm`
+## but it doesn't have any external module dependencies etc.
+
+
 chart_types_md = """
 - Abundance Box Plot
 - Box Plot

--- a/python/mdvtools/spatial/conversion.py
+++ b/python/mdvtools/spatial/conversion.py
@@ -71,7 +71,7 @@ def add_readme_to_project(mdv: "MDVProject", adata: Optional["AnnData"], convers
     We may consider adding more configuration options etc.
     """
     from mdvtools.spatial.mermaid import sdata_to_mermaid
-    from mdvtools.llm.markdown_utils import create_project_markdown
+    from mdvtools.markdown_utils import create_project_markdown
     from mdvtools.charts.text_box_plot import TextBox
     from mdvtools.build_info import get_build_info_markdown
     import json
@@ -641,7 +641,7 @@ def convert_spatialdata_to_mdv(args: SpatialDataConversionArgs):
 
     # from mdvtools.spatial.spatial_conversion import convert_spatialdata_to_mdv
     from mdvtools.conversions import convert_scanpy_to_mdv
-    from mdvtools.llm.markdown_utils import create_project_markdown
+    from mdvtools.markdown_utils import create_project_markdown
     from mdvtools.build_info import get_build_info
     
     # Print version banner if build info is available


### PR DESCRIPTION
Mostly so that "mdvlite" build doesn't have `llm` dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal module import paths to consolidate utility functions within the package structure.
  * Added markdown constants to support additional chart types in documentation generation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->