### PR TITLE
bias to morphology_focus when present

### DIFF
--- a/python/mdvtools/spatial/conversion.py
+++ b/python/mdvtools/spatial/conversion.py
@@ -554,6 +554,7 @@ def _resolve_regions_for_table(sdata: "SpatialData", table_name: str, sdata_name
         img_candidates = [img for img in sdata.images.items() if cs in _get_transform_keys(img[1])]
 
         # Sort to prioritize morphology_focus images (especially for xenium datasets)
+        # note - there is some dead code below that would interact badly with this if it was actually doing anything
         img_candidates.sort(key=lambda img: (0 if 'morphology_focus' in str(img[0]) else 1, img[0]))
 
         img_entries: list[ImageEntry] = []
@@ -568,6 +569,10 @@ def _resolve_regions_for_table(sdata: "SpatialData", table_name: str, sdata_name
             )
             if T is None and conversion_args.point_transform != "identity":
                 continue
+            
+            ## TODO fix or simplify non-functional size-heuristic...
+            # currently not expecting to do much with wh, and anticipating that this will be less relevant
+            # once we use spatialdata.js
             
             # try to extract pixel size / extent if available
             # nb, this is wrong, it was written by an LLM.


### PR DESCRIPTION
Xenium datasets tend to always have `'morphology_focus'` which is likely to be the main image you want to see, but also may have others like H&E within the same coordinate-system. Later, with `spatialdata.js`, we will have better support for layers with choice of overlaying etc, but the present structure forces a choice, this tweak introduces a bias so that in xenium conversion it will favour that particular image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Adjusted image prioritization when deriving spatial region metadata so images matching morphology-focused criteria are favored, improving consistency of primary image selection and downstream region outputs (e.g., geojson). Also added internal notes about potential size-based heuristics for future refinement.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->