### PR TITLE
change vivjs-experimental to normal viv, with zarrita update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
         "@fontsource/roboto": "^5.0.8",
+        "@hms-dbmi/viv": "^0.19.0",
         "@luma.gl/core": "~9.1.9",
         "@mui/icons-material": "^6.1.6",
         "@mui/material": "^6.1.6",
@@ -26,7 +27,6 @@
         "@radix-ui/react-radio-group": "^1.1.3",
         "@tanstack/react-query": "^5.80.0",
         "@visx/visx": "^3.12.0",
-        "@vivjs-experimental/viv": "^1.0.1",
         "axios": "^1.10.0",
         "canvas-to-svg": "^1.0.3",
         "class-variance-authority": "^0.7.0",
@@ -2108,6 +2108,21 @@
         "@shikijs/themes": "^3.5.0",
         "@shikijs/types": "^3.5.0",
         "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@hms-dbmi/viv": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@hms-dbmi/viv/-/viv-0.19.0.tgz",
+      "integrity": "sha512-wH/GBjti9686xwuGnZp9sMwwkE6pLGRaRW3Qc27S/3GRwq5j6C9Fd3du12F4InFfle47GV2nv0X9mWO+wiRwsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vivjs/constants": "0.19.0",
+        "@vivjs/extensions": "0.19.0",
+        "@vivjs/layers": "0.19.0",
+        "@vivjs/loaders": "0.19.0",
+        "@vivjs/types": "0.19.0",
+        "@vivjs/viewers": "0.19.0",
+        "@vivjs/views": "0.19.0"
       }
     },
     "node_modules/@interactjs/types": {
@@ -7665,55 +7680,84 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/@vivjs-experimental/constants": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@vivjs-experimental/constants/-/constants-1.0.1.tgz",
-      "integrity": "sha512-fVsQEMPAIL87AwPsWSD2KQVX1oHBCHgKh76+Q49pZ+d22viCD2qKBA9I86py4f5wcsTWaFc0mzH/TUXhjRXzDA==",
+    "node_modules/@vivjs/constants": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@vivjs/constants/-/constants-0.19.0.tgz",
+      "integrity": "sha512-1X0cKfPGlFNscEgtXBhHsZu7BixMIq2cznZ1hNuvTnCtG7SDW9nsiAa3WrOMowDwYyzMFWkoaWmVcoJSdN0wkg==",
+      "license": "MIT",
       "dependencies": {
         "@luma.gl/constants": "~9.1.9"
       }
     },
-    "node_modules/@vivjs-experimental/extensions": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@vivjs-experimental/extensions/-/extensions-1.0.1.tgz",
-      "integrity": "sha512-2/FxSjRgAXve3qT54d96tmioCgPTmuKv0Ze4qKv+N+vwpZJzjCQJ2r8CEHjop1w+fvTtHq73361VCQdYePNYgw==",
+    "node_modules/@vivjs/extensions": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@vivjs/extensions/-/extensions-0.19.0.tgz",
+      "integrity": "sha512-EHg7Y83+uv720micAaRjBh/Edw9lOq/uAfSQCbK0H4HBv7xUGzeXbCLmN/9ye8UgHWZd1cO6xvGDwBTQ7hp3gg==",
+      "license": "MIT",
       "dependencies": {
-        "@vivjs-experimental/constants": "1.0.1"
+        "@vivjs/constants": "0.19.0"
       },
       "peerDependencies": {
         "@deck.gl/core": "~9.1.11"
       }
     },
-    "node_modules/@vivjs-experimental/loaders": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@vivjs-experimental/loaders/-/loaders-1.0.1.tgz",
-      "integrity": "sha512-7YLuKsc2fHxGSrYN3oI9unOzHQE8bc6175EKkdTKl/IbkZQOJ+RQtHpn13yQH35vHa46Ib0VhrioU36apAm/aA==",
+    "node_modules/@vivjs/layers": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@vivjs/layers/-/layers-0.19.0.tgz",
+      "integrity": "sha512-M8zdlPsO8zEpESDevBiAnuEg9kv+H25B38XLfpPzTZS78hA6VD4PRw08xh5GjRHlaCV6CVnnKYAQDrvYNufDkg==",
+      "license": "MIT",
       "dependencies": {
-        "@vivjs-experimental/types": "1.0.1",
+        "@math.gl/core": "^4.0.1",
+        "@math.gl/culling": "^4.0.1",
+        "@vivjs/constants": "0.19.0",
+        "@vivjs/extensions": "0.19.0",
+        "@vivjs/loaders": "0.19.0",
+        "@vivjs/types": "0.19.0"
+      },
+      "peerDependencies": {
+        "@deck.gl/core": "~9.1.11",
+        "@deck.gl/geo-layers": "~9.1.11",
+        "@deck.gl/layers": "~9.1.11",
+        "@luma.gl/constants": "~9.1.9",
+        "@luma.gl/core": "~9.1.9",
+        "@luma.gl/engine": "~9.1.9",
+        "@luma.gl/shadertools": "~9.1.9",
+        "@luma.gl/webgl": "~9.1.9"
+      }
+    },
+    "node_modules/@vivjs/loaders": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@vivjs/loaders/-/loaders-0.19.0.tgz",
+      "integrity": "sha512-mCE2F8dih42hmIj96qYCPfvUqyNtuYlDKJa/i0LfT3Hrb5SclqgOpUrp4KW+C5Wy68O0P9c0ZIlmvWX0sMGJ8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@vivjs/types": "0.19.0",
         "geotiff": "^2.0.5",
         "lzw-tiff-decoder": "^0.1.1",
         "quickselect": "^2.0.0",
-        "zarr": "^0.6.2",
+        "zarrita": "^0.5.4",
         "zod": "^3.22.4"
       }
     },
-    "node_modules/@vivjs-experimental/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@vivjs-experimental/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-99qHIDP6o2FwkSeV9YB0ajO89ph9pP5Us+2Ks2jeC8stzjoXwnXATxuNX7r67/nu+tCSifzjgoSSrRnl2Zw1uQ==",
+    "node_modules/@vivjs/types": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@vivjs/types/-/types-0.19.0.tgz",
+      "integrity": "sha512-936eBNXNmgSJUsfQ+iJcrC4oTVJS9vCb6J6I+TiSn7bymO0uKia+3yvLFN6cWGrjQiWo5hSTSh6ZV+ydiE4i5g==",
+      "license": "MIT",
       "dependencies": {
-        "@vivjs-experimental/constants": "1.0.1",
+        "@vivjs/constants": "0.19.0",
         "math.gl": "^4.0.1"
       }
     },
-    "node_modules/@vivjs-experimental/viewers": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@vivjs-experimental/viewers/-/viewers-1.0.1.tgz",
-      "integrity": "sha512-vxqvTZ6kY2uGwXGuHckHBKbJXOKgP59tiqqDJ8BrIWpWy90wkYIyKTiwSc6o2sM4SzR6dB5QjzqELWspoH5c9w==",
+    "node_modules/@vivjs/viewers": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@vivjs/viewers/-/viewers-0.19.0.tgz",
+      "integrity": "sha512-Y58b/4F9J3RjZjPG80GciikiWZHFyIncRHFsmVqpIdE/7ubTUJTvzI0ZdrT5Y6NoP7dxjevIrhfSWQGbmjgZJQ==",
+      "license": "MIT",
       "dependencies": {
-        "@vivjs-experimental/constants": "1.0.1",
-        "@vivjs-experimental/extensions": "1.0.1",
-        "@vivjs-experimental/views": "1.0.1",
+        "@vivjs/constants": "0.19.0",
+        "@vivjs/extensions": "0.19.0",
+        "@vivjs/views": "0.19.0",
         "fast-deep-equal": "^3.1.3"
       },
       "peerDependencies": {
@@ -7721,79 +7765,20 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@vivjs-experimental/views": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@vivjs-experimental/views/-/views-1.0.1.tgz",
-      "integrity": "sha512-7m0F0SFbAm7HfzJCn9ofybIcRCNkJSHVVXb3upDiDxiWOD6PXPvKEpUWMb/kzxi1waaqZ9oM+mR1NBwBda2duA==",
+    "node_modules/@vivjs/views": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@vivjs/views/-/views-0.19.0.tgz",
+      "integrity": "sha512-2jSH6mfHaFk1ovE5oFvS3fAdUaVqZGr14gY+HlEF7V4lASgALcJoVvA8oVJflHvUZIn8jiwOqfIcoF9t7/m5eg==",
+      "license": "MIT",
       "dependencies": {
         "@math.gl/core": "^4.0.1",
-        "@vivjs-experimental/layers": "1.0.1",
-        "@vivjs-experimental/loaders": "1.0.1",
+        "@vivjs/layers": "0.19.0",
+        "@vivjs/loaders": "0.19.0",
         "math.gl": "^4.0.1"
       },
       "peerDependencies": {
         "@deck.gl/core": "~9.1.11",
         "@deck.gl/layers": "~9.1.11"
-      }
-    },
-    "node_modules/@vivjs-experimental/views/node_modules/@vivjs-experimental/layers": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@vivjs-experimental/layers/-/layers-1.0.1.tgz",
-      "integrity": "sha512-20zykmWCaiF0AJywOflAZUaMAeGmuLBS0gJUnqnht/CKiv9NYGaP1VvwzkUdSRMl7ytqmXmkcAmMUt1Kv6lNbQ==",
-      "dependencies": {
-        "@math.gl/core": "^4.0.1",
-        "@math.gl/culling": "^4.0.1",
-        "@vivjs-experimental/constants": "1.0.1",
-        "@vivjs-experimental/extensions": "1.0.1",
-        "@vivjs-experimental/loaders": "1.0.1",
-        "@vivjs-experimental/types": "1.0.1"
-      },
-      "peerDependencies": {
-        "@deck.gl/core": "~9.1.11",
-        "@deck.gl/geo-layers": "~9.1.11",
-        "@deck.gl/layers": "~9.1.11",
-        "@luma.gl/constants": "~9.1.9",
-        "@luma.gl/core": "~9.1.9",
-        "@luma.gl/engine": "~9.1.9",
-        "@luma.gl/shadertools": "~9.1.9",
-        "@luma.gl/webgl": "~9.1.9"
-      }
-    },
-    "node_modules/@vivjs-experimental/viv": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@vivjs-experimental/viv/-/viv-1.0.1.tgz",
-      "integrity": "sha512-HJAhRaD1tJiHQv6JRLENaPGFy66v7uOTh+TpV7+tsjcPi1FgsFnyzxBhdaHJUXYwi0em/aZO/r1LGdTa2zs/GQ==",
-      "dependencies": {
-        "@vivjs-experimental/constants": "1.0.1",
-        "@vivjs-experimental/extensions": "1.0.1",
-        "@vivjs-experimental/layers": "1.0.1",
-        "@vivjs-experimental/loaders": "1.0.1",
-        "@vivjs-experimental/types": "1.0.1",
-        "@vivjs-experimental/viewers": "1.0.1",
-        "@vivjs-experimental/views": "1.0.1"
-      }
-    },
-    "node_modules/@vivjs-experimental/viv/node_modules/@vivjs-experimental/layers": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@vivjs-experimental/layers/-/layers-1.0.1.tgz",
-      "integrity": "sha512-20zykmWCaiF0AJywOflAZUaMAeGmuLBS0gJUnqnht/CKiv9NYGaP1VvwzkUdSRMl7ytqmXmkcAmMUt1Kv6lNbQ==",
-      "dependencies": {
-        "@math.gl/core": "^4.0.1",
-        "@math.gl/culling": "^4.0.1",
-        "@vivjs-experimental/constants": "1.0.1",
-        "@vivjs-experimental/extensions": "1.0.1",
-        "@vivjs-experimental/loaders": "1.0.1",
-        "@vivjs-experimental/types": "1.0.1"
-      },
-      "peerDependencies": {
-        "@deck.gl/core": "~9.1.11",
-        "@deck.gl/geo-layers": "~9.1.11",
-        "@deck.gl/layers": "~9.1.11",
-        "@luma.gl/constants": "~9.1.9",
-        "@luma.gl/core": "~9.1.9",
-        "@luma.gl/engine": "~9.1.9",
-        "@luma.gl/shadertools": "~9.1.9",
-        "@luma.gl/webgl": "~9.1.9"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -7969,6 +7954,16 @@
       "dev": true,
       "license": "Apache-2.0",
       "peer": true
+    },
+    "node_modules/@zarrita/storage": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@zarrita/storage/-/storage-0.1.3.tgz",
+      "integrity": "sha512-ZyCMYN3LuCNtKxro9876r/KyHyXV+ie2Bhk1qYsJR4Jp+sAjoVRRNNSJPsJxk64ZgFFezayO5S2hCu88/1Odwg==",
+      "license": "MIT",
+      "dependencies": {
+        "reference-spec-reader": "^0.2.0",
+        "unzipit": "^1.4.3"
+      }
     },
     "node_modules/@zip.js/zip.js": {
       "version": "2.7.52",
@@ -12941,14 +12936,6 @@
       "version": "15.8.1",
       "license": "MIT"
     },
-    "node_modules/numcodecs": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/numcodecs/-/numcodecs-0.2.2.tgz",
-      "integrity": "sha512-Y5K8mv80yb4MgVpcElBkUeMZqeE4TrovxRit/dTZvoRl6YkB6WEjY+fiUjGCblITnt3T3fmrDg8yRWu0gOLjhQ==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/nwsapi": {
       "version": "2.2.20",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.20.tgz",
@@ -13058,32 +13045,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-queue": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.4.1.tgz",
-      "integrity": "sha512-vRpMXmIkYF2/1hLBKisKeVYJZ8S2tZ0zEAmIJgdVKP2nq0nh4qCdf8bgw+ZgKrkh71AOCaqzwbJJk1WtdcF3VA==",
-      "dependencies": {
-        "eventemitter3": "^5.0.1",
-        "p-timeout": "^5.0.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-timeout": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
-      "integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew==",
-      "engines": {
-        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -14111,6 +14072,12 @@
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
+    },
+    "node_modules/reference-spec-reader": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/reference-spec-reader/-/reference-spec-reader-0.2.0.tgz",
+      "integrity": "sha512-q0mfCi5yZSSHXpCyxjgQeaORq3tvDsxDyzaadA/5+AbAUwRyRuuTh0aRQuE/vAOt/qzzxidJ5iDeu1cLHaNBlQ==",
+      "license": "MIT"
     },
     "node_modules/refractor": {
       "version": "3.6.0",
@@ -15857,6 +15824,18 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/unzipit": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/unzipit/-/unzipit-1.4.3.tgz",
+      "integrity": "sha512-gsq2PdJIWWGhx5kcdWStvNWit9FVdTewm4SEG7gFskWs+XCVaULt9+BwuoBtJiRE8eo3L1IPAOrbByNLtLtIlg==",
+      "license": "MIT",
+      "dependencies": {
+        "uzip-module": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.1.1",
       "dev": true,
@@ -15958,6 +15937,12 @@
       "bin": {
         "uuid": "dist/esm/bin/uuid"
       }
+    },
+    "node_modules/uzip-module": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/uzip-module/-/uzip-module-1.0.3.tgz",
+      "integrity": "sha512-AMqwWZaknLM77G+VPYNZLEruMGWGzyigPK3/Whg99B3S6vGHuqsyl5ZrOv1UUF3paGK1U6PM0cnayioaryg/fA==",
+      "license": "MIT"
     },
     "node_modules/vfile": {
       "version": "6.0.3",
@@ -16747,16 +16732,29 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/zarr": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/zarr/-/zarr-0.6.3.tgz",
-      "integrity": "sha512-v7g3i/NfLEHtGtCEX8zl9b/LMY+8BY7fIYvbNX3nskAhliMCY5mA12jlc8Rbe91hSwL/4Nh2d3fUcVmnthXQkQ==",
+    "node_modules/zarrita": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/zarrita/-/zarrita-0.5.4.tgz",
+      "integrity": "sha512-i88iN2+HqIQ+uiCEWLfhjbYNXAJD7IrM4h3lFwFclfqEOOhxp10amRWtqmgN5jbuy3+h0LwdyLVVzk4y9rTLgg==",
+      "license": "MIT",
       "dependencies": {
-        "numcodecs": "^0.2.2",
-        "p-queue": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=12"
+        "@zarrita/storage": "^0.1.3",
+        "numcodecs": "^0.3.2"
+      }
+    },
+    "node_modules/zarrita/node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
+    },
+    "node_modules/zarrita/node_modules/numcodecs": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/numcodecs/-/numcodecs-0.3.2.tgz",
+      "integrity": "sha512-6YSPnmZgg0P87jnNhi3s+FVLOcIn3y+1CTIgUulA3IdASzK9fJM87sUFkpyA+be9GibGRaST2wCgkD+6U+fWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "fflate": "^0.8.0"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@radix-ui/react-radio-group": "^1.1.3",
     "@tanstack/react-query": "^5.80.0",
     "@visx/visx": "^3.12.0",
-    "@vivjs-experimental/viv": "^1.0.1",
+    "@hms-dbmi/viv": "^0.19.0",
     "axios": "^1.10.0",
     "canvas-to-svg": "^1.0.3",
     "class-variance-authority": "^0.7.0",

--- a/src/charts/dialogs/SimpleTiffViewer.tsx
+++ b/src/charts/dialogs/SimpleTiffViewer.tsx
@@ -1,8 +1,8 @@
 import type React from 'react';
 import { useEffect, useMemo } from 'react';
 import { observer } from "mobx-react-lite";
-import { DetailView, getDefaultInitialViewState } from '@vivjs-experimental/viv';
-import { ColorPaletteExtension } from '@vivjs-experimental/viv';
+import { DetailView, getDefaultInitialViewState } from '@hms-dbmi/viv';
+import { ColorPaletteExtension } from '@hms-dbmi/viv';
 import { useLoader, useChannelsStore, useViewerStore, useViewerStoreApi } from '../../react/components/avivatorish/state';
 import { shallow } from 'zustand/shallow';
 import MDVivViewer from '../../react/components/avivatorish/MDVivViewer';

--- a/src/react/components/VivScatterComponent.tsx
+++ b/src/react/components/VivScatterComponent.tsx
@@ -2,7 +2,7 @@ import {
     getDefaultInitialViewState,
     ColorPaletteExtension,
     DetailView,
-} from "@vivjs-experimental/viv";
+} from "@hms-dbmi/viv";
 import { observer } from "mobx-react-lite";
 import { useMemo, useEffect, useRef, useState } from "react";
 import { shallow } from "zustand/shallow";

--- a/src/react/components/avivatorish/MDVivViewer.tsx
+++ b/src/react/components/avivatorish/MDVivViewer.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
 import DeckGL from "@deck.gl/react";
 import type { MjolnirEvent } from 'mjolnir.js';
-// import { getVivId } from '@vivjs-experimental/views';
+// import { getVivId } from '@hms-dbmi/views';
 // No need to use the ES6 or React variants.
 import equal from "fast-deep-equal";
-import { ScaleBarLayer } from "@vivjs-experimental/viv";
+import { ScaleBarLayer } from "@hms-dbmi/viv";
 import type { OrthographicViewState, OrbitViewState, DeckGLProps, PickingInfo } from "deck.gl";
 import { rebindMouseEvents } from "@/lib/deckMonkeypatch";
 import type { EditableGeoJsonLayer } from "@deck.gl-community/editable-layers";
@@ -413,7 +413,7 @@ class MDVivViewerWrapper extends React.PureComponent<
 }
 
 /**
- * This is a wrapper around the VivViewer component from @vivjs-experimental/viv
+ * This is a wrapper around the VivViewer component from @hms-dbmi/viv
  * *** THIS IS NOW ACTUALLY NECESSARY ***
  * to fix issues with mouse events in popouts.
  * In future, we may handle more interesting things here to do with layer rendering.

--- a/src/react/components/avivatorish/state.tsx
+++ b/src/react/components/avivatorish/state.tsx
@@ -1,5 +1,5 @@
 import { type PropsWithChildren, createContext, useContext } from "react";
-import type { loadBioformatsZarr, loadOmeTiff, loadOmeZarr } from "@vivjs-experimental/viv";
+import type { loadOmeTiff, loadOmeZarr } from "@hms-dbmi/viv";
 import { createStore } from "zustand";
 import { useStoreWithEqualityFn } from "zustand/traditional";
 import { observer } from "mobx-react-lite";
@@ -9,11 +9,10 @@ import type { EqFn, Selector, ZustandStore } from "./zustandTypes";
 // ... not to mention HTJ2K?
 export type OME_TIFF = Awaited<ReturnType<typeof loadOmeTiff>>;
 export type OME_ZARR = Awaited<ReturnType<typeof loadOmeZarr>>;
-export type BIO_ZARR = Awaited<ReturnType<typeof loadBioformatsZarr>>;
-export type PixelSource = OME_TIFF | OME_ZARR | BIO_ZARR;
+export type PixelSource = OME_TIFF | OME_ZARR;
 
 // --- copied straight from Avivator's code::: with notes / changes for MDV ---
-import { RENDERING_MODES } from "@vivjs-experimental/viv";
+import { RENDERING_MODES } from "@hms-dbmi/viv";
 import { getEntries } from "@/lib/utils";
 
 const capitalize = (string: string) => string.charAt(0).toUpperCase() + string.slice(1);
@@ -359,7 +358,7 @@ type OME_METADATA = OME_ZARR['metadata'] & {
         PhysicalSizeXUnit?: string;
     }
 }
-export type Metadata = OME_TIFF['metadata'] | OME_METADATA | BIO_ZARR['metadata'];
+export type Metadata = OME_TIFF['metadata'] | OME_METADATA;
 //export type Metadata = TiffPreviewProps["metadata"];
 export const useMetadata = (): Metadata | undefined | null => {
     try {

--- a/src/utilities/VivUtils.js
+++ b/src/utilities/VivUtils.js
@@ -1,4 +1,4 @@
-import { getChannelStats } from "@vivjs-experimental/viv";
+import { getChannelStats } from "@hms-dbmi/viv";
 import { Matrix4 } from "@math.gl/core";
 
 /** copied (not quite verbatim) from avivator utils */

--- a/src/webgl/VivViewerMDV.js
+++ b/src/webgl/VivViewerMDV.js
@@ -6,7 +6,7 @@ import {
     ColorPalette3DExtensions,
     DETAIL_VIEW_ID,
     getChannelStats,
-} from "@vivjs-experimental/viv";
+} from "@hms-dbmi/viv";
 
 import { hexToRGB, RGBToHex } from "../datastore/DataStore.js";
 import { Deck } from "@deck.gl/core";


### PR DESCRIPTION
Using the latest release of viv, which notably adds support for OME-NGFF 0.5 / v3 zarr stores. https://github.com/hms-dbmi/viv/pull/930

Also removes support for Bioformats Zarr, so associated (essentially unused) code is removed.

This should allow us to change the `spatialdata` Python dependency to `0.6.1` - but that's probably better left to a separate PR, there is a risk of running conversions that would output data incompatible with older version.