### PR TITLE
spatial conversion view doesn't include density fields by default

### DIFF
--- a/python/mdvtools/spatial/spatial_view_template.json
+++ b/python/mdvtools/spatial/spatial_view_template.json
@@ -36,11 +36,7 @@
           "type": "RowsAsColsQuery"
         },
         "densityFields": [
-          {
-            "linkedDsName": "genes",
-            "maxItems": 15,
-            "type": "RowsAsColsQuery"
-          }       
+          "<DENSITY_FIELDS>"      
         ],
         "background_filter": {
           "column": "spatial_region",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--density` command-line option for spatial data conversion. When enabled, density field configuration is automatically included in spatial views, providing enhanced density data visualization capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->