### PR TITLE
user sync script not called during init, has configurable time

### DIFF
--- a/python/mdvtools/dbutils/mdv_server_app.py
+++ b/python/mdvtools/dbutils/mdv_server_app.py
@@ -91,11 +91,8 @@ def create_flask_app(config_name=None):
 
             if ENABLE_AUTH:
                 try:
-                    logger.info("Syncing users from Auth provider into the database...")
-                    # potentially redundant - still may be worth reviewing lifecycle for querying auth API
-                    auth_provider = get_auth_provider()
-                    auth_provider.sync_users_to_db()
-
+                    # Note: sync_users_to_db() is no longer called automatically on startup.
+                    # It should only be called manually from manage_project_permissions.py script.
                     logger.info("Caching user-projects data...")
                     cache_user_projects()  # Cache the user-project mappings into Redis only when Auth is enabled
 


### PR DESCRIPTION
- Removed automatic calls to sync_users_to_db() on application startup and project creation; now requires manual invocation from manage_project_permissions.py.
- Added user_processing_delay parameter to sync_users_to_db() to manage rate limits more effectively.
- Updated documentation to clarify usage and potential rate limiting issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable per-user processing delay for sync operations (default: 1.0s) to control pacing of user-role fetches.

* **Changed Behavior**
  * User-to-database synchronization no longer runs automatically on startup; it must be invoked manually via management tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->