### PR TITLE
fix scatter_state to filter zeros when "treat zero as missing" and "hide missing" are both selected.

### DIFF
--- a/src/react/scatter_state.ts
+++ b/src/react/scatter_state.ts
@@ -299,8 +299,14 @@ function useShouldFilterNaN() {
         ? (typeof colorBySpec === "string" ? colorBySpec : "column" in colorBySpec ? colorBySpec.column?.field : undefined)
         : undefined;
     const colorColumn = useFieldSpec(colorByField);
-    const shouldFilter = !!(chart.config.hideMissing && colorColumn && !isDatatypeCategorical(colorColumn.datatype));
-    return { shouldFilter, colorColumn };
+    const hideMissing = !!chart.config.hideMissing;
+    const fallbackOnZero = !!chart.config.fallbackOnZero;
+    const isNumericColor = !!(colorColumn && !isDatatypeCategorical(colorColumn.datatype));
+    // We only apply the deck.gl DataFilterExtension when `hideMissing` is enabled and the
+    // color column is numeric. `fallbackOnZero` then extends what counts as \"missing\"
+    // inside the filter (zeros as well as NaN/Inf), but does not by itself trigger filtering.
+    const shouldFilter = hideMissing && isNumericColor;
+    return { shouldFilter, colorColumn, fallbackOnZero };
 }
 
 /**
@@ -335,7 +341,7 @@ export function useScatterplotLayer(modelMatrix: Matrix4, hoveredFieldId?: Field
     );
     const contourLayers = useLegacyDualContour(hoveredFieldId);
 
-    const { shouldFilter: shouldFilterNaN, colorColumn } = useShouldFilterNaN();
+    const { shouldFilter: shouldFilterMissing, colorColumn, fallbackOnZero } = useShouldFilterNaN();
 
     // todo - Tooltip should be a separate component
     // would rather not even need to call a hook here, but just have some
@@ -421,10 +427,15 @@ export function useScatterplotLayer(modelMatrix: Matrix4, hoveredFieldId?: Field
             ...({
                 // todo - consider lower overhead version of this.
                 // future work https://deck.gl/docs/developer-guide/performance#use-binary-data
-                //currently useFieldSpec is typed as DataColumn|undefined, 
+                //currently useFieldSpec is typed as DataColumn|undefined,
                 //if not undefined is guaranteed to be loaded but we may change how we manage lazy-loading.
-                getFilterValue: shouldFilterNaN && colorColumn?.data 
-                    ? (i: number) => Number.isFinite(colorColumn.data[i]) ? 1 : 0
+                getFilterValue: shouldFilterMissing && colorColumn?.data
+                    ? (i: number) => {
+                        const v = colorColumn.data[i];
+                        if (!Number.isFinite(v)) return 0;
+                        if (fallbackOnZero && v === 0) return 0;
+                        return 1;
+                    }
                     : (_: number) => 1,
                 filterRange: [0.5, 1],
             } as any),
@@ -432,7 +443,7 @@ export function useScatterplotLayer(modelMatrix: Matrix4, hoveredFieldId?: Field
                 getFillColor: colorBy,
                 getLineWidth,
                 getPosition: [cx, cy, cz],
-                getFilterValue: [colorColumn, shouldFilterNaN],
+                getFilterValue: [colorColumn, shouldFilterMissing, fallbackOnZero],
             },
             pickable: true,
             onHover: (info) => {
@@ -482,8 +493,9 @@ export function useScatterplotLayer(modelMatrix: Matrix4, hoveredFieldId?: Field
         getLineWidth,
         contourLayers,
         config.dimension,
-        shouldFilterNaN,
+        shouldFilterMissing,
         colorColumn,
+        fallbackOnZero,
     ]);
     // this should take into account axis margins... not chart.contentDiv,
     // but the actual area where the scatterplot is rendered


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved missing value handling in scatter plots with enhanced filtering logic that better distinguishes between zero values and missing data points, ensuring more accurate visualizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->