### PR TITLE
don't add empty objects for highlight data in ChartManager.getState

### DIFF
--- a/src/charts/ChartManager.js
+++ b/src/charts/ChartManager.js
@@ -1240,7 +1240,14 @@ export class ChartManager {
         view.initialCharts = initialCharts;
         for (const ds of this.dataSources) {
             const h = ds.dataStore.getHighlightedData?.();
-            if (!view.dataSources[ds.name]) view.dataSources[ds.name] = {};
+            // adding empty entries to view.dataSources here is no-bueno.
+            if (!view.dataSources[ds.name]) {
+                // not expecting that there should be any highlight data to save when the dataSource is not part of the view
+                if (h) {
+                    console.warn(`unexpected highlighted data for dataSource '${ds.name}' which is not part of current viewData`);
+                }
+                continue;
+            }
             if (Array.isArray(h) && h.length > 0) {
                 view.dataSources[ds.name].highlight = [...h];
             } else {


### PR DESCRIPTION
The `getState()` serialisation had been modified to add highlight data, during which process empty objects could be added and would not be removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chart data serialization to prevent creation of invalid empty entries when data sources contain highlights, with enhanced warning notifications for data inconsistencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->