### PR TITLE
update pyproject.toml and readme

### DIFF
--- a/mdvtools_lite_build/pyproject.toml
+++ b/mdvtools_lite_build/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mdvtools"
-version = "1.2.2"
+version = "1.2.3"
 authors = [
     { name= "Martin Sergeant", email="m.j.sergeant1@googlemail.com"},
     { name= "PeterTodd", email="peter.todd@well.ox.ac.uk"},
@@ -18,12 +18,12 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
- "fasteners==0.19",
- "spatialdata==0.5.0",
- "spatialdata-io==0.3.0",
- "setuptools==80.9.0",
- "pandas==2.3.3",
+ "fasteners>=0.19",
+ "spatialdata==0.7.2",
+ "spatialdata-io==0.6.0",
+ "pandas<3.0",
  "Flask>=2.2.0",
+ "ome-zarr==0.13.0",
  "h5py>=3.5.0",
  "mudata>=0.2.3",
  "pyyaml>=5.3",

--- a/mdvtools_lite_build/readme.md
+++ b/mdvtools_lite_build/readme.md
@@ -2,28 +2,44 @@
 This folder contains a .toml file to build a scaled down version of MDVTools which has the compiled version of the JavaScript frontend and a lightweight server for local viewing/editing. Only the necessary python modules and dependencies are included and it is pip installable
 
 To build , first of all you need to build the javascript. In the main directory:-
-```
+```bash
+npm install
 npm run build-flask-vite
 ```
 Make sure you have hatch installed:-
-```
+```bash
 pip install hatch
 ```
 
 Then cd to this directory (mdvtools_lite_build) and build:-
-```
+```bash
 hatch build
 ```
 
-To test, run the following script, which will create a virtual environment, activate it,  install mdvtools and serve an mdv project. Once you stop the server, the virtual environment will be deleted. You will need to change the paths to reflect your set-up.
+To test, run the following script, which will create a virtual environment, activate it,  and install mdvtools in it.
 ```bash
 python -m venv /path/to/venv
 source /path/to/venv/bin/activate
 pip install /path/to/mdv/mdvtools_lite_build
-python -m mdvtools.serverlite /path/to/mdvproject
-deactivate
-rm -r /path/to/venv
 ```
+
+In the environment you can than run various tests e.g. create and view a spatial project
+```bash
+mdvtools convert-spatial --serve  path/to/outputproject  /path/to/spatialdata
+```
+
+To upload to pypi/testpypi make sure you have twine installed:-
+```bash
+pip install twine
+```
+
+and then upload (assuming you are in the mdvtools_lite_build directory)
+```bash
+twine upload --repository testpypi dist/* #upload to test pypi
+twine upload  dist/* #upload to main repository
+```
+
+You will need a to be member of the mdvtools project and have the right permissions as you will need to authenticate
 
 //TODO
 include only necessary modules in the JavaScript build

--- a/python/mdvtools/mdvproject.py
+++ b/python/mdvtools/mdvproject.py
@@ -41,6 +41,7 @@ datatype_mappings = {
     "float64": "double",
     "float32": "double",
     "object": "text",
+    "str":"text",
     "category": "text",
     "bool": "text",
     "int32": "double",


### PR DESCRIPTION
Updated mdvtools_lite_build/pyproject.toml to reflect new dependencies:-
spatialdata==0.7.2
spatialdata-io==0.6.0
Removed the deprecated pinned setuptools as this is no longer required for new versions of spatial data
pinned ome-zarr to 0.13.0 , as 0.14.0 seems not to be compatible with the latest version of zarr (3.1.5)
restricted version of pandas (<3) as later versions not compatible with anndata (0.12.10)

updated readme

added str to pandas - mdv mappings in acticipation of updating pandas to 3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for string datatype conversion.

* **Documentation**
  * Updated setup and testing instructions.
  * Added PyPI publishing guide with authentication requirements.

* **Chores**
  * Version bumped to 1.2.3.
  * Updated dependencies for improved compatibility and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->