### PR TITLE
Avoid crash with many viewstate-linked charts by defering ignoreStateUpdate=false until event-loop settles

### DIFF
--- a/src/react/chartLinkHooks.ts
+++ b/src/react/chartLinkHooks.ts
@@ -66,7 +66,9 @@ export const useViewStateLink = () => {
                     c.viewerStore?.setState({ viewState: newViewState });
                 });
             });
-            thisChart.ignoreStateUpdate = false;
+            queueMicrotask(() => {
+                thisChart.ignoreStateUpdate = false;
+            });
         });
         return unsubscribe;
     }, [


### PR DESCRIPTION
When a `link.type == "view_state"` has more than a few charts, it could get into a state where there is an infinite loop.

There are still a lot of performance issues (memory particularly) which could probably be improved by making sure that charts are able to better share viv-resources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved state synchronization timing to prevent update conflicts during subscription setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->