### PR TITLE
Rename chart names

### DIFF
--- a/src/charts/TableChart.js
+++ b/src/charts/TableChart.js
@@ -540,7 +540,7 @@ export default TableChart;
 
 BaseChart.types["table_chart"] = {
     class: TableChart,
-    name: "Table",
+    name: "Table (Classic)",
     params: [
         {
             type: "_multi_column:all",

--- a/src/charts/WGLScatterPlot.js
+++ b/src/charts/WGLScatterPlot.js
@@ -734,7 +734,7 @@ class WGLScatterPlot extends WGLChart {
 }
 
 BaseChart.types["wgl_scatter_plot"] = {
-    name: "2D Scatter Plot",
+    name: "2D Scatter Plot (Classic)",
     class: WGLScatterPlot,
     params: [
         {

--- a/src/react/components/DeckScatterReactWrapper.tsx
+++ b/src/react/components/DeckScatterReactWrapper.tsx
@@ -263,7 +263,7 @@ BaseChart.types["DeckScatter3D"] = {
     },
 };
 BaseChart.types["wgl_scatter_plot_dev"] = {
-    name: "2D Scatter Plot (experimental)",
+    name: "2D Scatter Plot",
     class: DeckScatterReact,
     allow_user_add: true,
     params: [

--- a/src/react/components/TableChartReactWrapper.tsx
+++ b/src/react/components/TableChartReactWrapper.tsx
@@ -172,7 +172,7 @@ class TableChartReact extends BaseReactChart<TableChartReactConfig> {
 }
 
 BaseChart.types["table_chart_react"] = {
-    name: "Table Chart (React)",
+    name: "Table",
     class: TableChartReact,
     allow_user_add: true,
     params: [

--- a/src/react/components/VivMDVReact.tsx
+++ b/src/react/components/VivMDVReact.tsx
@@ -387,7 +387,7 @@ BaseChart.types["VivMdvRegionReact"] = {
         };
     },
     class: VivMdvReact,
-    name: "Viv Scatter Plot (react)",
+    name: "Spatial Image Viewer",
 };
 
 export type VivMdvReactType = typeof VivMdvReact;


### PR DESCRIPTION
Update the chart names for the following charts for add chart dialog:

- Old Scatter Plot: 2D Scatter Plot (Classic)
- Deck Scatter Plot: 2D Scatter Plot
- Old Table: Table (Classic)
- React Table: Table
- Viv Scatter Plot: Spatial Image Viewer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated display names for various chart types to enhance user experience and organization. Classic versions of Table and Scatter Plot charts are now clearly labeled with "(Classic)" designation. The experimental Scatter Plot variant is now identified as the standard version, and the Spatial Image Viewer chart has been renamed for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->