### PR TITLE
Update Settings Dialog to have general folder and search feature

### DIFF
--- a/src/react/components/SettingsDialogComponent.tsx
+++ b/src/react/components/SettingsDialogComponent.tsx
@@ -563,12 +563,12 @@ const FolderComponent = ({ props }: { props: GuiSpec<"folder"> }) => {
     const isSearchActive = searchTerm.trim().length > 0;
     // When the dialog first opens (and search is empty), expand "General" so the user sees settings immediately.
     const [isOpen, setIsOpen] = useState(() => props.label === "General");
-    // Derive stable keys so nested items are not remounted on each render.
     const settings = useMemo(
         () =>
-            props.current_value.map((setting, index) => ({
+            props.current_value.map((setting) => ({
                 setting,
-                id: `${props.label}:${setting.type}:${setting.label}:${index}`,
+                id: (setting as AnyGuiSpec & { _stableId?: string })._stableId ||
+                    `${props.label}:${setting.type}:${setting.label}`,
             })),
         [props.current_value, props.label],
     );
@@ -746,7 +746,11 @@ export default observer(<T extends BaseConfig,>({ chart }: { chart: BaseChart<T>
                                 input: {
                                     endAdornment: searchTerm.trim().length > 0 ? (
                                         <InputAdornment position="end">
-                                            <IconButton aria-label="clear search" onClick={() => setSearchTerm("")}>
+                                            <IconButton
+                                                aria-label="clear search"
+                                                onMouseDown={(e) => e.preventDefault()}
+                                                onClick={() => setSearchTerm("")}
+                                            >
                                                 <Clear />
                                             </IconButton>
                                         </InputAdornment>
@@ -757,7 +761,9 @@ export default observer(<T extends BaseConfig,>({ chart }: { chart: BaseChart<T>
                     </Box>
                     {settings.length === 0 && (
                         <Typography variant="body1" color="text.secondary" sx={{ marginTop: 1, p: 1 }}>
-                            No settings match your search.
+                            {searchTerm.trim().length > 0
+                                ? "No settings match your search."
+                                : "No settings available."}
                         </Typography>
                     )}
                     <Divider sx={{ marginY: 0.75, opacity: 0.6 }} />

--- a/src/react/hooks/useFilteredGroupedSettings.ts
+++ b/src/react/hooks/useFilteredGroupedSettings.ts
@@ -2,11 +2,24 @@ import { useMemo } from "react";
 import { makeAutoObservable } from "mobx";
 import type { AnyGuiSpec, GuiSpec } from "../../charts/charts";
 
-function filterSettingsByLabel(specs: AnyGuiSpec[], searchTerm: string): AnyGuiSpec[] {
+type StableGuiSpec = AnyGuiSpec & { _stableId?: string };
+
+function stampStableIds(specs: StableGuiSpec[], parentPath = "") {
+    specs.forEach((spec, index) => {
+        if (!spec._stableId) {
+            spec._stableId = `${parentPath}${spec.type}:${spec.label}:${index}`;
+        }
+        if (spec.type === "folder" && Array.isArray(spec.current_value)) {
+            stampStableIds(spec.current_value as StableGuiSpec[], `${spec._stableId}/`);
+        }
+    });
+}
+
+function filterSettingsByLabel(specs: StableGuiSpec[], searchTerm: string): StableGuiSpec[] {
     const query = searchTerm.trim().toLowerCase();
     if (!query) return specs;
 
-    return specs.reduce<AnyGuiSpec[]>((acc, spec) => {
+    return specs.reduce<StableGuiSpec[]>((acc, spec) => {
         const labelMatches = spec.label.toLowerCase().includes(query);
 
         if (spec.type !== "folder") {
@@ -16,13 +29,13 @@ function filterSettingsByLabel(specs: AnyGuiSpec[], searchTerm: string): AnyGuiS
         }
 
         // Folder setting: recurse into children so nested matches are preserved.
-        const filteredChildren = filterSettingsByLabel(spec.current_value, query);
+        const filteredChildren = filterSettingsByLabel(spec.current_value as StableGuiSpec[], query);
         if (!labelMatches && filteredChildren.length === 0) {
             // Neither this folder nor any descendant matches.
             return acc;
         }
 
-        const filteredFolder: GuiSpec<"folder"> = {
+        const filteredFolder: GuiSpec<"folder"> & { _stableId?: string } = {
             ...spec,
             // If the folder label itself matches, keep all children so folder-name searches
             // show the full folder instead of an empty one.
@@ -58,7 +71,7 @@ export function useFilteredGroupedSettings(rawSettings: AnyGuiSpec[], searchTerm
         );
 
         // Keep UI tidy by collecting top level settings under a single "General" folder.
-        const wrappedTopLevelSettings: AnyGuiSpec[] =
+        const wrappedTopLevelSettings: StableGuiSpec[] =
             groupedSettings.topLevelSettings.length > 0
                 ? [
                     {
@@ -69,7 +82,9 @@ export function useFilteredGroupedSettings(rawSettings: AnyGuiSpec[], searchTerm
                 ]
                 : [];
 
-        return [...wrappedTopLevelSettings, ...groupedSettings.folderSettings];
+        const settings = [...wrappedTopLevelSettings, ...groupedSettings.folderSettings] as StableGuiSpec[];
+        stampStableIds(settings);
+        return settings;
     }, [rawSettings]);
 
     const filteredSettings = useMemo(() => {
@@ -79,10 +94,10 @@ export function useFilteredGroupedSettings(rawSettings: AnyGuiSpec[], searchTerm
 
     return useMemo(() => {
         const settings = filteredSettings.map(
-            (setting, index) => ({
+            (setting) => ({
                 setting,
-                // Stable id rather than uuid() so that uuid is not called for every render
-                id: `${setting.type}:${setting.label}:${index}`,
+                // Stable across filtering/search transitions.
+                id: setting._stableId || `${setting.type}:${setting.label}`,
             }),
         );
 

--- a/src/tests/hooks/useFilteredGroupedSettings.test.ts
+++ b/src/tests/hooks/useFilteredGroupedSettings.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { g } from "@/lib/utils";
+import type { AnyGuiSpec, GuiSpec } from "@/charts/charts";
+import { useFilteredGroupedSettings } from "../../react/hooks/useFilteredGroupedSettings";
+
+function getFolder(
+    settings: Array<{ setting: AnyGuiSpec; id: string }>,
+    label: string,
+): GuiSpec<"folder"> | undefined {
+    const match = settings.find(
+        (entry) => entry.setting.type === "folder" && entry.setting.label === label,
+    )?.setting;
+    if (!match || match.type !== "folder") return undefined;
+    return match;
+}
+
+describe("useFilteredGroupedSettings", () => {
+    test("wraps top-level non-folder settings into General folder", () => {
+        const rawSettings: AnyGuiSpec[] = [
+            g({ type: "slider", label: "Opacity", current_value: 0.6 }),
+            g({
+                type: "folder",
+                label: "Axes",
+                current_value: [g({ type: "check", label: "Show grid", current_value: true })],
+            }),
+            g({ type: "check", label: "Show legend", current_value: true }),
+        ];
+
+        const { result } = renderHook(() =>
+            useFilteredGroupedSettings(rawSettings, ""),
+        );
+
+        const general = getFolder(result.current, "General");
+        const axes = getFolder(result.current, "Axes");
+
+        expect(general).toBeDefined();
+        expect(general?.current_value.map((item) => item.label)).toEqual([
+            "Opacity",
+            "Show legend",
+        ]);
+        expect(axes).toBeDefined();
+    });
+
+    test("matches General folder by name when searching", () => {
+        const rawSettings: AnyGuiSpec[] = [
+            g({ type: "slider", label: "Opacity", current_value: 0.4 }),
+            g({ type: "check", label: "Show legend", current_value: true }),
+        ];
+
+        const { result } = renderHook(() =>
+            useFilteredGroupedSettings(rawSettings, "general"),
+        );
+
+        const general = getFolder(result.current, "General");
+        expect(result.current).toHaveLength(1);
+        expect(general).toBeDefined();
+        expect(general?.current_value.map((item) => item.label)).toEqual([
+            "Opacity",
+            "Show legend",
+        ]);
+    });
+
+    test("keeps full folder content when folder label matches search", () => {
+        const rawSettings: AnyGuiSpec[] = [
+            g({
+                type: "folder",
+                label: "Axes",
+                current_value: [
+                    g({ type: "slider", label: "X min", current_value: 0 }),
+                    g({ type: "slider", label: "Y min", current_value: 0 }),
+                ],
+            }),
+        ];
+
+        const { result } = renderHook(() =>
+            useFilteredGroupedSettings(rawSettings, "axes"),
+        );
+
+        const axes = getFolder(result.current, "Axes");
+        expect(axes).toBeDefined();
+        expect(axes?.current_value.map((item) => item.label)).toEqual([
+            "X min",
+            "Y min",
+        ]);
+    });
+
+    test("keeps only matching descendants when folder does not match", () => {
+        const rawSettings: AnyGuiSpec[] = [
+            g({
+                type: "folder",
+                label: "Axes",
+                current_value: [
+                    g({ type: "slider", label: "X min", current_value: 0 }),
+                    g({ type: "slider", label: "Y min", current_value: 0 }),
+                ],
+            }),
+        ];
+
+        const { result } = renderHook(() =>
+            useFilteredGroupedSettings(rawSettings, "x min"),
+        );
+
+        const axes = getFolder(result.current, "Axes");
+        expect(axes).toBeDefined();
+        expect(axes?.current_value.map((item) => item.label)).toEqual(["X min"]);
+    });
+
+    test("keeps stable ids across filtering changes", () => {
+        const rawSettings: AnyGuiSpec[] = [
+            g({ type: "slider", label: "Opacity", current_value: 0.5 }),
+            g({
+                type: "folder",
+                label: "Axes",
+                current_value: [g({ type: "slider", label: "X min", current_value: 0 })],
+            }),
+        ];
+
+        const { result, rerender } = renderHook(
+            ({ term }) => useFilteredGroupedSettings(rawSettings, term),
+            { initialProps: { term: "" } },
+        );
+
+        const axesBefore = result.current.find((entry) => entry.setting.label === "Axes");
+        expect(axesBefore).toBeDefined();
+
+        rerender({ term: "axes" });
+
+        const axesAfter = result.current.find((entry) => entry.setting.label === "Axes");
+        expect(axesAfter).toBeDefined();
+        expect(axesAfter?.id).toBe(axesBefore?.id);
+    });
+});
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search bar in the settings dialog now filters settings and groups results into folders (including a synthesized "General" group for top-level items).
  * Folders automatically expand when a search is active to reveal matches.

* **Bug Fixes / Stability**
  * Improved stable IDs/keys so items and folders remain consistent across searches and re-renders.
  * Inputs are cleared appropriately when search is active.

* **Style**
  * Settings folders now use an outlined, paper-like container for cleaner visuals.

* **Tests**
  * Added tests covering grouping, filtering behavior, stability of folder IDs, and search matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->