### PR TITLE
bypass viv loader cache as it was glitchy

### DIFF
--- a/src/react/components/avivatorish/hooks.ts
+++ b/src/react/components/avivatorish/hooks.ts
@@ -15,6 +15,7 @@ import {
     // type PixelSource,
 } from "./state";
 import {
+    createLoader,
     buildDefaultSelection,
     guessRgb,
     getMultiSelectionStats,
@@ -23,7 +24,8 @@ import {
 } from "./utils";
 import { COLOR_PALLETE, FILL_PIXEL_VALUE } from "./constants";
 import { useVivConfig } from "@/react/context";
-import { getOrCreateVivLoader } from "@/react/viv_loader_cache";
+// pending bug fixes...
+// import { getOrCreateVivLoader } from "@/react/viv_loader_cache";
 
 const EMPTY_RASTER = { width: 0, height: 0, data: new Float32Array() };
 
@@ -89,7 +91,8 @@ export const useImage = (
             if (use3d) toggleUse3d();
             if (!source) throw "this should never happen - this is a type-guard";
             const { urlOrFile } = source;
-            const newLoader = await getOrCreateVivLoader(
+            // const newLoader = await getOrCreateVivLoader(
+            const newLoader = await createLoader(
                 urlOrFile,
                 toggleIsOffsetsSnackbarOn,
                 (message) =>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal loader initialization mechanism to enhance system efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->