### PR TITLE
schema validation logging ui

### DIFF
--- a/src/charts/ChartManager.js
+++ b/src/charts/ChartManager.js
@@ -56,7 +56,7 @@ import "./DeepToolsHeatMap";
 import connectIPC from "../utilities/InterProcessCommunication";
 import { addChartLink } from "../links/link_utils";
 import popoutChart from "@/utilities/Popout";
-import { makeObservable, observable, action } from "mobx";
+import { makeObservable, observable, action, makeAutoObservable } from "mobx";
 import { createMdvPortal } from "@/react/react_utils";
 import ViewManager from "./ViewManager";
 import ErrorComponentReactWrapper from "@/react/components/ErrorComponentReactWrapper";
@@ -65,6 +65,7 @@ import { deserialiseParam, getConcreteFieldNames } from "./chartConfigUtils";
 import AddChartDialogReact from "./dialogs/AddChartDialogReact";
 import MenuBarWrapper from "@/react/components/MenuBarComponent";
 import { getOrCreateGateManager } from "@/react/gates/useGateManager";
+import ValidationFindingsStore from "@/lib/ValidationFindingsStore";
 
 
 //order of column data in an array buffer
@@ -121,6 +122,7 @@ function listenPreferredColorScheme(callback) {
 * 
 */
 export class ChartManager {
+    validationFindings = new ValidationFindingsStore();
     /**
      * @param {string|HTMLElement} div - The DOM element or id of the element to house the app
      * @param {import("@/charts/charts").DataSource[]} dataSources - An array of datasource configs - see  [Data Source](../../docs/extradocs/datasource.md).
@@ -189,6 +191,9 @@ export class ChartManager {
         /** @type {{[k: string]: DataSource | undefined}} */
         this.dsIndex = {};
         this.columnsLoading = {};
+        // Aggregated validation/schema findings for UI + reporting.
+        // Created before React mounts the menu bar so observers track it from first render.
+        this.validationFindings = new ValidationFindingsStore();
         for (const d of dataSources) {
             const ds = {
                 name: d.name,

--- a/src/charts/chartConfigUtils.ts
+++ b/src/charts/chartConfigUtils.ts
@@ -9,8 +9,8 @@ import { isArray } from "@/lib/utils";
 import type { BaseConfig } from "./BaseChart";
 import type { TooltipConfig } from "@/react/scatter_state";
 import { getChartConfigSchema } from "./schemas/ChartConfigRegistry";
-import { BaseConfigSchema } from "./schemas/ChartConfigSchema";
-import { logValidationError } from "@/lib/validationLogging";
+import { BaseConfigSchema, type ChartConfig } from "./schemas/ChartConfigSchema";
+import { logChartValidationError } from "@/lib/validationLogging";
 
 /**
  * This is a utility module for handling the serialisation and deserialisation of chart configurations.
@@ -173,7 +173,7 @@ export function initialiseChartConfig<C extends BaseConfig, T extends BaseChart<
     const validate = schema ?? BaseConfigSchema;
     const result = validate.safeParse(originalConfig);
     if (!result.success) {
-        logValidationError({ context: "chart", rawConfig: originalConfig, error: result.error });
+        logChartValidationError(originalConfig as unknown as ChartConfig, result.error);
     }
     
     let config: C = JSON.parse(JSON.stringify(originalConfig));

--- a/src/lib/ValidationFindingsStore.ts
+++ b/src/lib/ValidationFindingsStore.ts
@@ -1,0 +1,143 @@
+import { makeAutoObservable, observable, type ObservableMap } from "mobx";
+
+export type ValidationContext = "datasource" | "chart";
+
+export interface ValidationIssue {
+    path: string;
+    message: string;
+    code?: string;
+}
+
+export interface ValidationFindingDetails {
+    issues: ValidationIssue[];
+    rawConfig?: unknown;
+    details?: Record<string, unknown>;
+}
+
+export interface ValidationFinding {
+    context: ValidationContext;
+    /** Chart type for `chart`, datasource name for `datasource` */
+    subject: string;
+    signature: string;
+    count: number;
+    firstSeenAt: number;
+    lastSeenAt: number;
+    latest?: ValidationFindingDetails;
+}
+
+function issueSignature(issues: ValidationIssue[]): string {
+    // Stable-ish key for grouping repeated reports of the same underlying problem.
+    // Prefer code+path+message where available. Join multiple issues so zod-style multi-issue
+    // errors group together.
+    return issues
+        .map((i) => `${i.code ?? ""}|${i.path}|${i.message}`)
+        .join("\n");
+}
+
+type FindingMap = ObservableMap<string, ObservableMap<string, ValidationFinding>>;
+
+export default class ValidationFindingsStore {
+    private chartsByType: FindingMap = observable.map();
+    private datasourcesByName: FindingMap = observable.map();
+
+    constructor() {
+        makeAutoObservable(this, {}, { autoBind: true });
+    }
+
+    clearAll() {
+        this.chartsByType.clear();
+        this.datasourcesByName.clear();
+    }
+
+    clearCharts() {
+        this.chartsByType.clear();
+    }
+
+    clearDatasources() {
+        this.datasourcesByName.clear();
+    }
+
+    get hasAny(): boolean {
+        return this.chartsByType.size > 0 || this.datasourcesByName.size > 0;
+    }
+
+    get totalCount(): number {
+        let total = 0;
+        for (const [, bySig] of this.chartsByType) {
+            for (const [, f] of bySig) total += f.count;
+        }
+        for (const [, bySig] of this.datasourcesByName) {
+            for (const [, f] of bySig) total += f.count;
+        }
+        return total;
+    }
+
+    get chartTypeCounts(): Record<string, number> {
+        const out: Record<string, number> = {};
+        for (const [chartType, bySig] of this.chartsByType) {
+            let count = 0;
+            for (const [, f] of bySig) count += f.count;
+            out[chartType] = count;
+        }
+        return out;
+    }
+
+    /**
+     * UI/reporting-friendly structure.
+     * Returned objects are derived from observable state but are plain serialisable data.
+     */
+    get snapshot(): {
+        charts: Record<string, ValidationFinding[]>;
+        datasources: Record<string, ValidationFinding[]>;
+        totalCount: number;
+    } {
+        const charts: Record<string, ValidationFinding[]> = {};
+        for (const [chartType, bySig] of this.chartsByType) {
+            charts[chartType] = [...bySig.values()].sort((a, b) => b.lastSeenAt - a.lastSeenAt);
+        }
+        const datasources: Record<string, ValidationFinding[]> = {};
+        for (const [dsName, bySig] of this.datasourcesByName) {
+            datasources[dsName] = [...bySig.values()].sort((a, b) => b.lastSeenAt - a.lastSeenAt);
+        }
+        return { charts, datasources, totalCount: this.totalCount };
+    }
+
+    addChartFinding(chartType: string, details: ValidationFindingDetails) {
+        this.addFinding("chart", chartType, details);
+    }
+
+    addDatasourceFinding(dsName: string, details: ValidationFindingDetails) {
+        this.addFinding("datasource", dsName, details);
+    }
+
+    private addFinding(context: ValidationContext, subject: string, details: ValidationFindingDetails) {
+        const now = Date.now();
+        const signature = issueSignature(details.issues);
+        const root = context === "chart" ? this.chartsByType : this.datasourcesByName;
+
+        let bySig = root.get(subject);
+        if (!bySig) {
+            bySig = observable.map();
+            root.set(subject, bySig);
+        }
+
+        const existing = bySig.get(signature);
+        if (existing) {
+            existing.count += 1;
+            existing.lastSeenAt = now;
+            existing.latest = details;
+            return;
+        }
+
+        bySig.set(signature, {
+            context,
+            subject,
+            signature,
+            count: 1,
+            firstSeenAt: now,
+            lastSeenAt: now,
+            latest: details,
+        });
+    }
+}
+

--- a/src/lib/validationLogging.ts
+++ b/src/lib/validationLogging.ts
@@ -1,3 +1,6 @@
+import type ValidationFindingsStore from "./ValidationFindingsStore";
+import type { ChartConfig } from "@/charts/schemas/ChartConfigSchema";
+
 type ValidationContext = "datasource" | "chart";
 
 export interface ValidationIssue {
@@ -40,27 +43,61 @@ function extractIssues(error: unknown): ValidationIssue[] {
     }];
 }
 
-export function logValidationError(options: LogValidationErrorOptions): void {
+function getFindingsStore(): ValidationFindingsStore | undefined {
+    if (typeof window === "undefined") return undefined;
+    const mdv = window.mdv;
+    if (!mdv) return undefined;
+    const cm = mdv.chartManager;
+    if (!cm) return undefined;
+    return cm.validationFindings;
+}
+
+export function logValidationError(options: LogValidationErrorOptions) {
     const { context, name, rawConfig, error, details } = options;
     const issues = extractIssues(error);
     const bucketName = context === "datasource" ? "datasources" : "charts";
     const label = name ?? (context === "datasource" ? "(unknown datasource)" : "(unknown chart)");
 
     console.error(
-        `Invalid ${context} config for '${label}'. See window.mdv.validationErrors.${bucketName} for full details.`,
+        `Invalid ${context} config for '${label}'. See Debug / Report for aggregated details.`,
         issues,
     );
 
-    if (typeof window !== "undefined" && (window as any).mdv) {
-        const mdv: any = (window as any).mdv;
-        const store = (mdv.validationErrors ??= { datasources: [], charts: [] });
-        const bucket = store[bucketName] as any[];
-        bucket.push({
-            ...(name !== undefined && { name: label }),
+    const store = getFindingsStore();
+    if (!store) return;
+
+    if (context === "chart") {
+        store.addChartFinding(label, {
             issues,
             rawConfig,
-            ...(details && Object.keys(details).length > 0 && { details }),
+            ...(details && Object.keys(details).length > 0 ? { details } : {}),
         });
+        return;
     }
+
+    store.addDatasourceFinding(label, {
+        issues,
+        rawConfig,
+        ...(details && Object.keys(details).length > 0 ? { details } : {}),
+    });
 }
 
+export function logChartValidationError(
+    config: ChartConfig,
+    error: unknown,
+    options?: { details?: Record<string, unknown> },
+) {
+    const cfg = config as { type?: string; version?: string };
+    const label = cfg.version ? `${cfg.type ?? "unknown"} v${cfg.version}` : (cfg.type ?? "unknown");
+    logValidationError({
+        context: "chart",
+        name: label,
+        rawConfig: config,
+        error,
+        details: options?.details,
+    });
+}
+
+export function useValidationErrors() {
+
+}

--- a/src/modules/static_index.ts
+++ b/src/modules/static_index.ts
@@ -25,10 +25,6 @@ declare global {
             chartManager: ChartManager;
             chartTypes?: any;
             debugChart?: any;
-            validationErrors?: {
-                datasources: any[];
-                charts: any[];
-            };
         };
     }
 }
@@ -38,10 +34,6 @@ window.mdv = {
     // not sure what I'd use the class for - would generally import in a module
     ChartManager,
     chartTypes: BaseChart.types,
-    validationErrors: {
-        datasources: [],
-        charts: [],
-    },
 };
 
 document.addEventListener("DOMContentLoaded", async () => {

--- a/src/react/components/DebugButton.tsx
+++ b/src/react/components/DebugButton.tsx
@@ -1,0 +1,94 @@
+import { Box } from "@mui/material";
+import { PestControl as PestControlIcon } from "@mui/icons-material";
+import { useState } from "react";
+import { observer } from "mobx-react-lite";
+import IconWithTooltip from "./IconWithTooltip";
+import { useProject } from "@/modules/ProjectContext";
+import { fetchJsonConfig } from "@/dataloaders/DataLoaderUtil";
+import BaseChart from "@/charts/BaseChart";
+import DebugChartReactWrapper from "./DebugJsonDialogReactWrapper";
+import ReusableAlertDialog from "@/charts/dialogs/ReusableAlertDialog";
+import DebugErrorComponent, { type DebugErrorComponentProps } from "@/charts/dialogs/DebugErrorComponent";
+import useBuildInfo from "@/catalog/hooks/useBuildInfo";
+import { useChartManager } from "../hooks";
+
+const DebugButton = observer(() => {
+    const [error, setError] = useState<DebugErrorComponentProps["error"] | null>(null);
+    const [open, setOpen] = useState(false);
+
+    const { validationFindings } = useChartManager();
+    const { root } = useProject();
+    const { buildInfo } = useBuildInfo();
+
+    const handleDebugButtonClick = async () => {
+        setError(null);
+        setOpen(false);
+        try {
+            const datasources = await fetchJsonConfig(`${root}/datasources.json`, root);
+            const views = await fetchJsonConfig(`${root}/views.json`, root);
+            const state = await fetchJsonConfig(`${root}/state.json`, root);
+
+            const chartTypes = Object.entries(BaseChart.types).map(([k, v]) => {
+                const { class: omit, ...props } = v;
+                return [k, props];
+            });
+
+            new DebugChartReactWrapper({
+                chartTypes,
+                datasources,
+                views,
+                state,
+                buildInfo,
+                ...(validationFindings?.hasAny && { validationFindings: validationFindings.snapshot }),
+            });
+        } catch (err) {
+            setError(err instanceof Error ? {
+                message: err.message,
+                stack: err?.stack,
+            } : {
+                message: "Error occurred while fetching JSON",
+                stack: `${err}`,
+            });
+            setOpen(true);
+            console.error("Error occurred while fetching JSON: ", err);
+        }
+    };
+
+    const showDot = Boolean(validationFindings?.hasAny);
+
+    return (
+        <>
+            <IconWithTooltip tooltipText="Debug / Report issue" onClick={handleDebugButtonClick}>
+                <Box sx={{ position: "relative", display: "inline-flex", alignItems: "center" }}>
+                    <PestControlIcon sx={{ height: "1.5rem", width: "1.5rem" }} />
+                    {showDot && (
+                        <Box
+                            sx={{
+                                position: "absolute",
+                                top: 0,
+                                right: 0,
+                                width: 8,
+                                height: 8,
+                                borderRadius: "50%",
+                                backgroundColor: "#f2c94c",
+                                boxShadow: "0 0 0 2px rgba(0,0,0,0.15)",
+                            }}
+                        />
+                    )}
+                </Box>
+            </IconWithTooltip>
+
+            {error && (
+                <ReusableAlertDialog
+                    open={open}
+                    handleClose={() => setOpen(false)}
+                    component={<DebugErrorComponent error={error} />}
+                    isAlertErrorComponent
+                />
+            )}
+        </>
+    );
+});
+
+export default DebugButton;
+

--- a/src/react/components/DebugJsonDialogComponent.tsx
+++ b/src/react/components/DebugJsonDialogComponent.tsx
@@ -8,9 +8,10 @@ import { useMemo, useState } from "react";
 import { useDebounce } from "use-debounce";
 import { vivLoaderCacheTelemetryObservable } from "../viv_loader_cache";
 import "../../utilities/css/JsonDialogStyles.css";
-import { Accordion, AccordionDetails, AccordionSummary, Divider, Link, Typography } from "@mui/material";
+import { Accordion, AccordionDetails, AccordionSummary, Box, Button, Divider, Link, Typography } from "@mui/material";
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { DEBUG_JSON_REPORT_MESSAGE, MDV_EMAIL } from "@/utilities/constants";
+import { useChartManager } from "../hooks";
 
 type JSONObject = { [key: string]: any };
 
@@ -67,12 +68,15 @@ function filterJSON(obj: JSONObject, filter: string): JSONObject {
 const DebugJsonDialogComponent = observer(function DebugJsonDialogComponent({
     json,
     header,
+    showValidationSection = false,
 }: {
     json: any;
     header?: string;
+    showValidationSection?: boolean;
 }) {
     const [filter, setFilter] = useState("");
     const [debouncedFilter] = useDebounce(filter, 300); //why is this returning a tuple?
+    const { validationFindings } = useChartManager();
     const jsonWithVivTelemetry = useMemo(
         () => ({
             ...json,
@@ -84,6 +88,8 @@ const DebugJsonDialogComponent = observer(function DebugJsonDialogComponent({
         () => filterJSON(jsonWithVivTelemetry, debouncedFilter),
         [jsonWithVivTelemetry, debouncedFilter],
     );
+    const chartTypeCounts = validationFindings?.chartTypeCounts ?? {};
+    const hasAnyFindings = Boolean(validationFindings?.hasAny);
 
     return (
         <div className="overflow-auto p-4" style={{ userSelect: "text" }}>
@@ -120,6 +126,60 @@ const DebugJsonDialogComponent = observer(function DebugJsonDialogComponent({
                     </Typography>
                 </AccordionDetails>
             </Accordion>
+
+            {showValidationSection && (
+                <Accordion
+                    defaultExpanded={hasAnyFindings}
+                    sx={{
+                        border: "1px solid var(--border_menu_bar_color)",
+                        mb: 2,
+                    }}
+                >
+                    <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                        <Typography variant="h6">
+                            Validation issues
+                        </Typography>
+                    </AccordionSummary>
+                    <Divider />
+                    <AccordionDetails sx={{ mt: 1 }}>
+                        {hasAnyFindings ? (
+                            <>
+                                <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 2, mb: 1 }}>
+                                    <Typography>
+                                        Total: <strong>{validationFindings.totalCount}</strong>
+                                    </Typography>
+                                    <Button
+                                        variant="outlined"
+                                        size="small"
+                                        onClick={() => validationFindings.clearAll()}
+                                    >
+                                        Clear
+                                    </Button>
+                                </Box>
+                                <Box sx={{ mb: 1 }}>
+                                    {Object.entries(chartTypeCounts).length > 0 ? (
+                                        Object.entries(chartTypeCounts)
+                                            .sort((a, b) => b[1] - a[1])
+                                            .map(([chartType, count]) => (
+                                                <Typography key={chartType} sx={{ fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" }}>
+                                                    {chartType}: {count}
+                                                </Typography>
+                                            ))
+                                    ) : (
+                                        <Typography>No chart validation issues recorded yet.</Typography>
+                                    )}
+                                </Box>
+                                <Typography variant="body2" sx={{ opacity: 0.8, mb: 1 }}>
+                                    Aggregated details are also available in the JSON below under <code>validationFindings</code>.
+                                </Typography>
+                            </>
+                        ) : (
+                            <Typography>No validation issues recorded.</Typography>
+                        )}
+                    </AccordionDetails>
+                </Accordion>
+            )}
+
             <input
                 type="text"
                 value={filter}

--- a/src/react/components/DebugJsonDialogReactWrapper.tsx
+++ b/src/react/components/DebugJsonDialogReactWrapper.tsx
@@ -7,10 +7,18 @@ import type BaseChart from "../../charts/BaseChart";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 
 const DebugChart = observer(
-    ({ chart, header }: { chart: any; header?: string }) => {
+    ({
+        chart,
+        header,
+        showValidationSection = false,
+    }: {
+        chart: any;
+        header?: string;
+        showValidationSection?: boolean;
+    }) => {
         return (
             <>
-                <Gui json={chart} header={header} />
+                <Gui json={chart} header={header} showValidationSection={showValidationSection} />
                 <ReactQueryDevtools initialIsOpen={false}  />
             </>
         );
@@ -45,7 +53,16 @@ class DebugChartReactWrapper extends BaseDialog {
     }
     init(parent: any) {
         const div = createEl("div", {}, this.dialog);
-        this.root = createMdvPortal(<DebugChart chart={parent} />, div, this);
+        const showValidationSection = Boolean(
+            parent &&
+            typeof parent === "object" &&
+            "validationFindings" in parent,
+        );
+        this.root = createMdvPortal(
+            <DebugChart chart={parent} showValidationSection={showValidationSection} />,
+            div,
+            this,
+        );
     }
     close() {
         super.close();

--- a/src/react/components/MenuBarComponent.tsx
+++ b/src/react/components/MenuBarComponent.tsx
@@ -6,33 +6,24 @@ import {
     Add as AddIcon,
     Remove as RemoveIcon,
     CloudUpload as CloudUploadIcon,
-    PestControl as PestControlIcon,
 } from "@mui/icons-material";
 import ToggleThemeWrapper from "@/charts/dialogs/ToggleTheme";
 import IconWithTooltip from "./IconWithTooltip";
 import ViewSelectorWrapper from "./ViewSelectorComponent";
 import ViewThumbnailComponent from "./ViewThumbnailComponent";
 import FileUploadDialogReact from "@/charts/dialogs/FileUploadDialogWrapper";
-import { fetchJsonConfig } from "@/dataloaders/DataLoaderUtil";
-import BaseChart from "@/charts/BaseChart";
 import { useProject } from "@/modules/ProjectContext";
-import DebugChartReactWrapper from "./DebugJsonDialogReactWrapper";
 import ViewDialogWrapper from "@/charts/dialogs/ViewDialogWrapper";
-import { useState } from "react";
-import DebugErrorComponent, { type DebugErrorComponentProps } from "@/charts/dialogs/DebugErrorComponent";
-import useBuildInfo from "@/catalog/hooks/useBuildInfo";
 import ChatButtons from "./ChatButtons";
-import ReusableAlertDialog from "@/charts/dialogs/ReusableAlertDialog";
 import CustomTooltip from "./CustomTooltip";
 import { LockIcon, LockOpenIcon } from "lucide-react";
+import { observer } from "mobx-react-lite";
+import { useChartManager } from "../hooks";
+import DebugButton from "./DebugButton";
 
-const MenuBarComponent = () => {
-    const [error, setError] = useState<DebugErrorComponentProps['error'] | null>(null);
-    const [open, setOpen] = useState(false);
-    const cm = window.mdv.chartManager;
-    const { viewManager, config, containerDiv } = cm;
-    const { root, mainApiRoute } = useProject();
-    const { buildInfo } = useBuildInfo();
+const MenuBarComponent = observer(() => {
+    const { viewManager, config } = useChartManager();
+    const { mainApiRoute } = useProject();
 
     const isEditable = config.permission === "edit";
     const ariaLabel = isEditable ? "editable" : "view only";
@@ -64,45 +55,6 @@ const MenuBarComponent = () => {
 
     const handleAddDataSourceClick = () => {
         new FileUploadDialogReact();
-    };
-
-    const handleDebugButtonClick = async () => {
-        setError(null);
-        setOpen(false);
-        try {
-            const datasources = await fetchJsonConfig(
-                `${root}/datasources.json`,
-                root,
-            );
-            const views = await fetchJsonConfig(`${root}/views.json`, root);
-            const state = await fetchJsonConfig(`${root}/state.json`, root);
-            const chartTypes = Object.entries(BaseChart.types).map(([k, v]) => {
-                const { class: omit, ...props } = v;
-                return [k, props];
-            });
-            const ve = window.mdv?.validationErrors;
-            const hasValidationErrors =
-                ve && ((ve.datasources?.length ?? 0) > 0 || (ve.charts?.length ?? 0) > 0);
-            new DebugChartReactWrapper({
-                chartTypes,
-                datasources,
-                views,
-                state,
-                buildInfo,
-                ...(hasValidationErrors && { validationErrors: ve }),
-            });
-        } catch (error) {
-            setError(error instanceof Error ? {
-                message: error.message,
-                stack: error?.stack,
-            } : {
-                message: "Error occurred while fetching JSON",
-                stack: `${error}`
-            });
-            setOpen(true);
-            console.error("Error occurred while fetching JSON: ", error);
-        }
-
     };
 
     return (
@@ -168,23 +120,13 @@ const MenuBarComponent = () => {
                         </CustomTooltip>
                         <ChatButtons />
                         <ToggleThemeWrapper />
-                        <IconWithTooltip tooltipText="Debug / Report issue" onClick={handleDebugButtonClick}>
-                            <PestControlIcon sx={{height: "1.5rem", width: "1.5rem"}} />
-                        </IconWithTooltip>
+                        <DebugButton />
                     </Box>
                 </Toolbar>
             </AppBar>
-            {error && (
-                <ReusableAlertDialog
-                    open={open}
-                    handleClose={() => setOpen(false)}
-                    component={<DebugErrorComponent error={error} />}
-                    isAlertErrorComponent
-                />
-            )}
         </>
     );
-};
+});
 
 const MenuBarWrapper = () => {
     return <MenuBarComponent />;


### PR DESCRIPTION
Maybe over-engineered, adding a store and GUI for chart and other schema validation results while we're in the mode of getting a sense of how well these reflect reality.

Currently, when creating a new chart with 'add chart dialog', the new entries don't have `id` or `size` set until after the validation happens... this means that we can at least see and familiarise ourselves with how the UI looks when there are errors, although of course this flow should be changed soon.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added validation findings tracking system that captures and displays validation issues encountered during chart and datasource operations.
  * Validation issues are now accessible in the debug panel, including counts aggregated by chart type.
  * Added ability to clear validation findings from the debug interface.

* **Refactor**
  * Restructured debug panel architecture for improved error reporting and organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->