### PR TITLE
Fix home navigation to avoid implicit dir URLs

### DIFF
--- a/src/react/components/IconWithTooltip.tsx
+++ b/src/react/components/IconWithTooltip.tsx
@@ -5,20 +5,46 @@ import CustomTooltip from "./CustomTooltip";
 export type IconWithTooltipProps = {
     children: React.ReactElement;
     tooltipText: string;
-    onClick: React.MouseEventHandler<HTMLButtonElement>;
+    onClick?: IconButtonProps["onClick"];
+    href?: string;
     tooltipProps?: TooltipProps;
     iconButtonProps?: IconButtonProps;
 };
 
-const IconWithTooltip = ({ children, tooltipText, onClick, tooltipProps, iconButtonProps }: IconWithTooltipProps) => {
+const IconWithTooltip = ({
+    children,
+    tooltipText,
+    onClick,
+    href,
+    tooltipProps,
+    iconButtonProps,
+}: IconWithTooltipProps) => {
     return (
         <CustomTooltip
             tooltipText={tooltipText}
             {...tooltipProps}
         >
-            <IconButton color="inherit" size="medium" onClick={onClick} {...iconButtonProps}>
-                {children}
-            </IconButton>
+            {href ? (
+                <IconButton
+                    color="inherit"
+                    size="medium"
+                    component="a"
+                    onClick={onClick}
+                    href={href}
+                    {...iconButtonProps}
+                    style={{
+                        color: "inherit",
+                        textDecoration: "none",
+                        ...iconButtonProps?.style,
+                    }}
+                >
+                    {children}
+                </IconButton>
+            ) : (
+                <IconButton color="inherit" size="medium" onClick={onClick} {...iconButtonProps}>
+                    {children}
+                </IconButton>
+            )}
         </CustomTooltip>
     );
 };

--- a/src/react/components/MenuBarComponent.tsx
+++ b/src/react/components/MenuBarComponent.tsx
@@ -28,15 +28,9 @@ const MenuBarComponent = observer(() => {
 
     const isEditable = config.permission === "edit";
     const ariaLabel = isEditable ? "editable" : "view only";
-
-    const handleHomeButtonClick = () => {
-        // todo: uncomment when we fix state issues
-        // viewManager.checkUnsavedState(() => {
-            window.location.href = buildDashboardUrl(
-                mainApiRoute === "/" ? getApiRootFromDir(root) : mainApiRoute,
-            );
-        // });
-    };
+    const homeHref = buildDashboardUrl(
+        mainApiRoute === "/" ? getApiRootFromDir(root) : mainApiRoute,
+    );
 
     const handleSaveButtonClick = async () => {
         await viewManager.saveView();
@@ -63,7 +57,11 @@ const MenuBarComponent = observer(() => {
             <AppBar position="static" color="default" sx={{ boxShadow: "none" }}>
                 <Toolbar className="ciview-main-menu-bar" sx={{ padding: 2 }} disableGutters>
                     <Box sx={{ display: "flex", alignItems: "center", justifyContent: "flex-start" }}>
-                        <IconWithTooltip tooltipText="Back to Catalog" onClick={handleHomeButtonClick}>
+                        <IconWithTooltip
+                            tooltipText="Back to Catalog"
+                            href={homeHref}
+                            iconButtonProps={{ "aria-label": "Back to Catalog" }}
+                        >
                             <HomeIcon />
                         </IconWithTooltip>
                         {config.all_views && (

--- a/src/tests/mdvRouting.spec.ts
+++ b/src/tests/mdvRouting.spec.ts
@@ -51,10 +51,15 @@ describe("mdvRouting", () => {
     test("keeps mounted shell path when building explicit dir urls", () => {
         setUrl("/mdv/");
 
+        expect(buildDashboardUrl("/prefix/")).toBe("/mdv/");
+        expect(buildProjectUrl("174", "/prefix/")).toBe("/mdv/project/174");
+    });
+
+    test("preserves explicit dir routing when user supplied dir", () => {
+        setUrl("/mdv/?dir=%2Fprefix%2F");
+
         expect(buildDashboardUrl("/prefix/")).toBe("/mdv/?dir=%2Fprefix%2F");
-        expect(buildProjectUrl("174", "/prefix/")).toBe(
-            "/mdv/?dir=%2Fprefix%2Fproject%2F174",
-        );
+        expect(buildProjectUrl("174", "/prefix/")).toBe("/mdv/?dir=%2Fprefix%2Fproject%2F174");
     });
 
     test("detects project routes from pathname and query-dir routes", () => {

--- a/src/utils/mdvRouting.ts
+++ b/src/utils/mdvRouting.ts
@@ -45,6 +45,10 @@ export function getDirParam() {
     return new URLSearchParams(window.location.search).get("dir");
 }
 
+export function hasExplicitDirParam() {
+    return new URLSearchParams(window.location.search).has("dir");
+}
+
 export function isProjectDir(dir: string) {
     return /\/project\/[^/]+\/?$/.test(asUrl(dir).pathname);
 }
@@ -140,18 +144,13 @@ export function apiFetch(input: string, init?: RequestInit) {
 }
 
 export function buildDashboardUrl(apiRoot = getDashboardApiRoot()) {
-    if (!getDirParam() && isHostedPreviewHost() && isDefaultPreviewApiRoot(apiRoot)) {
-        return "/";
-    }
+    if (!hasExplicitDirParam()) return getAppMountPath();
     if (apiRoot === "/") return getAppMountPath();
     return buildAppShellUrl(`?dir=${encodeURIComponent(ensureTrailingSlash(apiRoot))}`);
 }
 
 export function buildProjectUrl(projectId: string | number, apiRoot = getDashboardApiRoot()) {
-    if (!getDirParam() && isHostedPreviewHost() && isDefaultPreviewApiRoot(apiRoot)) {
-        return `/project/${projectId}`;
-    }
-    if (apiRoot === "/") {
+    if (!hasExplicitDirParam() || apiRoot === "/") {
         return `${getAppMountPath()}project/${projectId}`;
     }
 


### PR DESCRIPTION
## Summary
- update routing helpers to only preserve `dir` when it was explicitly supplied in the current URL
- keep default project and dashboard navigation on path-based URLs instead of generating implicit `?dir=` links
- render the home control as an anchor-backed icon button for native link behavior and add an explicit accessible label
- preserve toolbar styling for link-backed icon buttons and extend routing tests for both explicit and non-explicit `dir` cases

## Testing
- `npx tsc --noEmit --pretty false`
- `npm test -- src/tests/mdvRouting.spec.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Icon components can now function as navigable links via `href` attribute.

* **Bug Fixes**
  * Improved URL routing to correctly handle directory parameters in query strings and app mount paths.

* **Tests**
  * Added test coverage for URL-building behavior with explicit directory parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->