### PR TITLE
Add X-based UMAP and Leiden options to AnnData and SpatialData conversion

### DIFF
--- a/python/mdvtools/cli.py
+++ b/python/mdvtools/cli.py
@@ -152,7 +152,12 @@ def merge_project(base_project, extra_project, prefix, view_prefix):
 @click.option('--obs-datasource-name', default='cells', show_default=True, help='Datasource name for observations.')
 @click.option('--var-datasource-name', default='genes', show_default=True, help='Datasource name for variables.')
 @click.option('--link-name-column', default=None, help='Variable datasource column used as the rows_as_columns name_column.')
-@click.option('--compute-x-umap', 'compute_x_umap', is_flag=True, help='Compute neighbors, UMAP, and Leiden clusters from merged adata.X before export.')
+@click.option(
+    '--compute-x-umap',
+    'compute_x_umap',
+    is_flag=True,
+    help='Compute neighbors, UMAP, and Leiden clusters separately for each source table from that table\'s adata.X before merge. These per-table helper embeddings are not globally comparable.',
+)
 @click.option('--leiden-resolution', default=1.0, type=float, show_default=True, help='Leiden resolution used with --compute-x-umap.')
 @click.option('--verbose', is_flag=True, help='Show detailed per-dataset conversion output, transform decisions, and merged summaries.')
 def convert_spatial(spatialdata_path, output_folder, batch, preserve_existing, link, output_geojson, density, serve, obs_datasource_name, var_datasource_name, link_name_column, compute_x_umap, leiden_resolution, verbose):

--- a/python/mdvtools/cli.py
+++ b/python/mdvtools/cli.py
@@ -35,18 +35,37 @@ def cli():
 @click.option('--max_dims', default=3, help='Maximum number of dimensions to include from dimensionality reductions.')
 @click.option('--delete_existing', is_flag=True, help='Delete existing project data.')
 @click.option('--label', default='', help='Prefix to add to datasource names and metadata columns.')
+@click.option('--obs-datasource-name', default='cells', show_default=True, help='Datasource name for observations.')
+@click.option('--var-datasource-name', default='genes', show_default=True, help='Datasource name for variables.')
 @click.option('--chunk_data', is_flag=True, help='Transpose and flatten in chunks to save memory.')
 @click.option('--add_layer_data', is_flag=True, default=True, help='Add layer data (log values etc.).')
 @click.option('--gene_identifier_column', default=None, help='Gene column for identification.')
+@click.option('--link-name-column', default=None, help='Variable datasource column used as the rows_as_columns name_column.')
+@click.option('--compute-x-umap', 'compute_x_umap', is_flag=True, help='Compute neighbors, UMAP, and Leiden clusters directly from adata.X before export.')
+@click.option('--leiden-resolution', default=1.0, type=float, show_default=True, help='Leiden resolution used with --compute-x-umap.')
 @click.option('--zip', 'zip_output', is_flag=True, help='Zip the output folder and delete the original.')
 @click.option('--chatmdv', is_flag=True, help='Include the original Scanpy .h5ad file in the zipped project.')
-def convert_scanpy(folder, scanpy_object, max_dims, delete_existing, label, chunk_data, add_layer_data, gene_identifier_column, zip_output, chatmdv):
+def convert_scanpy(folder, scanpy_object, max_dims, delete_existing, label, obs_datasource_name, var_datasource_name, chunk_data, add_layer_data, gene_identifier_column, link_name_column, compute_x_umap, leiden_resolution, zip_output, chatmdv):
     """Convert Scanpy AnnData object to MDV format."""
     import scanpy as sc
     from .conversions import convert_scanpy_to_mdv
 
     adata = sc.read_h5ad(scanpy_object)
-    convert_scanpy_to_mdv(folder, adata, max_dims, delete_existing, label, chunk_data, add_layer_data, gene_identifier_column)
+    convert_scanpy_to_mdv(
+        folder,
+        adata,
+        max_dims,
+        delete_existing,
+        label,
+        obs_datasource_name,
+        var_datasource_name,
+        chunk_data,
+        add_layer_data,
+        gene_identifier_column,
+        link_name_column=link_name_column,
+        compute_x_umap=compute_x_umap,
+        leiden_resolution=leiden_resolution,
+    )
 
     if chatmdv:
         dest_path = os.path.join(folder, basename(scanpy_object))
@@ -130,8 +149,13 @@ def merge_project(base_project, extra_project, prefix, view_prefix):
 @click.option('--output_geojson/--no-output_geojson', 'output_geojson', default=True, help='Write transformed GeoJSON region files into the project images directory.')
 @click.option('--density', is_flag=True, help='Include density fields for gene expression in the default spatial view.')
 @click.option('--serve', is_flag=True, help='Serve the generated project after conversion.')
+@click.option('--obs-datasource-name', default='cells', show_default=True, help='Datasource name for observations.')
+@click.option('--var-datasource-name', default='genes', show_default=True, help='Datasource name for variables.')
+@click.option('--link-name-column', default=None, help='Variable datasource column used as the rows_as_columns name_column.')
+@click.option('--compute-x-umap', 'compute_x_umap', is_flag=True, help='Compute neighbors, UMAP, and Leiden clusters from merged adata.X before export.')
+@click.option('--leiden-resolution', default=1.0, type=float, show_default=True, help='Leiden resolution used with --compute-x-umap.')
 @click.option('--verbose', is_flag=True, help='Show detailed per-dataset conversion output, transform decisions, and merged summaries.')
-def convert_spatial(spatialdata_path, output_folder, batch, preserve_existing, link, output_geojson, density, serve, verbose):
+def convert_spatial(spatialdata_path, output_folder, batch, preserve_existing, link, output_geojson, density, serve, obs_datasource_name, var_datasource_name, link_name_column, compute_x_umap, leiden_resolution, verbose):
     """Convert one SpatialData store to MDV format, or use --batch for a directory of stores."""
     import tempfile
     from .spatial.conversion import convert_spatialdata_to_mdv, SpatialDataConversionArgs
@@ -148,6 +172,11 @@ def convert_spatial(spatialdata_path, output_folder, batch, preserve_existing, l
             density=density,
             serve=serve,
             verbose=verbose,
+            obs_datasource_name=obs_datasource_name,
+            var_datasource_name=var_datasource_name,
+            link_name_column=link_name_column,
+            compute_x_umap=compute_x_umap,
+            leiden_resolution=leiden_resolution,
         )
         convert_spatialdata_to_mdv(args)
 

--- a/python/mdvtools/conversions.py
+++ b/python/mdvtools/conversions.py
@@ -244,10 +244,17 @@ def convert_scanpy_to_mdv(
         "name":"cell_id",
         "datatype":"unique"
     }]
-    if leiden_column in cell_table.columns:
+    leiden_like_columns = sorted(
+        {
+            column_name
+            for column_name in cell_table.columns
+            if column_name == leiden_column or column_name.endswith("__leiden")
+        }
+    )
+    for column_name in leiden_like_columns:
         columns.append({
-            "name": leiden_column,
-            "field": leiden_column,
+            "name": column_name,
+            "field": column_name,
             "datatype": "text",
         })
     mdv.add_datasource(obs_ds_name, cell_table,columns)

--- a/python/mdvtools/conversions.py
+++ b/python/mdvtools/conversions.py
@@ -104,7 +104,6 @@ def _prepare_x_umap_and_leiden(
     scanpy_object, _ = _coerce_x_to_csc_without_nonfinite(scanpy_object)
     sc.pp.neighbors(scanpy_object, use_rep="X")
     sc.tl.umap(scanpy_object)
-
     if umap_key != "X_umap":
         scanpy_object.obsm[umap_key] = scanpy_object.obsm["X_umap"].copy()
         del scanpy_object.obsm["X_umap"]

--- a/python/mdvtools/conversions.py
+++ b/python/mdvtools/conversions.py
@@ -1,4 +1,5 @@
 from scanpy import AnnData
+import scanpy as sc
 import scipy
 import pandas as pd
 from os.path import join, split, exists
@@ -21,16 +22,117 @@ from .mdvproject import MDVProject,create_bed_gz_file
 logger = logging.getLogger(__name__)
 
 
+def _coerce_x_to_csc_without_nonfinite(
+    scanpy_object: AnnData,
+) -> tuple[AnnData, bool]:
+    """
+    Ensure ``adata.X`` is CSC and contains no explicit non-finite entries.
+
+    Non-finite values are converted to 0 and removed from the sparse structure
+    so they become implicit missing values.
+    """
+    matrix = scanpy_object.X
+    if scipy.sparse.issparse(matrix):
+        sparse_matrix = scipy.sparse.csc_matrix(matrix, copy=True)
+        if sparse_matrix.data.size == 0:
+            scanpy_object.X = sparse_matrix
+            return scanpy_object, False
+        finite_mask = np.isfinite(sparse_matrix.data)
+        if finite_mask.all():
+            scanpy_object.X = sparse_matrix
+            return scanpy_object, False
+        non_finite = int((~finite_mask).sum())
+        sparse_matrix.data = np.nan_to_num(
+            sparse_matrix.data,
+            nan=0.0,
+            posinf=0.0,
+            neginf=0.0,
+        )
+        sparse_matrix.eliminate_zeros()
+        scanpy_object.X = sparse_matrix
+        logger.warning(
+            "Replacing %s non-finite values in adata.X and converting to CSC for UMAP/Leiden computation",
+            non_finite,
+        )
+        return scanpy_object, True
+
+    dense_matrix = np.asarray(matrix)
+    finite_mask = np.isfinite(dense_matrix)
+    non_finite = int((~finite_mask).sum())
+    sanitized = np.nan_to_num(
+        dense_matrix,
+        nan=0.0,
+        posinf=0.0,
+        neginf=0.0,
+        copy=True,
+    )
+    csc_matrix = scipy.sparse.csc_matrix(sanitized)
+    csc_matrix.eliminate_zeros()
+    scanpy_object.X = csc_matrix
+    if finite_mask.all():
+        return scanpy_object, False
+    logger.warning(
+        "Replacing %s non-finite values in adata.X and converting dense X to CSC for UMAP/Leiden computation",
+        non_finite,
+    )
+    return scanpy_object, True
+
+
+def _prepare_x_umap_and_leiden(
+    scanpy_object: AnnData,
+    compute_x_umap: bool,
+    leiden_resolution: float,
+    leiden_column: str,
+    umap_key: str = "X_umap",
+) -> AnnData:
+    """
+    Optionally compute a neighbor graph, UMAP embedding, and Leiden clusters from ``adata.X``.
+
+    The Leiden labels are coerced to pandas categorical strings so they are exported as text.
+    """
+    if not compute_x_umap:
+        if leiden_column in scanpy_object.obs.columns:
+            scanpy_object.obs[leiden_column] = pd.Categorical(
+                scanpy_object.obs[leiden_column].astype(str)
+            )
+        return scanpy_object
+
+    if hasattr(scanpy_object, "isbacked") and scanpy_object.isbacked:
+        logger.info("Loading backed AnnData into memory for X-based UMAP/Leiden computation")
+        scanpy_object = scanpy_object.to_memory()
+
+    scanpy_object, _ = _coerce_x_to_csc_without_nonfinite(scanpy_object)
+    sc.pp.neighbors(scanpy_object, use_rep="X")
+    sc.tl.umap(scanpy_object)
+
+    if umap_key != "X_umap":
+        scanpy_object.obsm[umap_key] = scanpy_object.obsm["X_umap"].copy()
+        del scanpy_object.obsm["X_umap"]
+
+    sc.tl.leiden(scanpy_object, resolution=leiden_resolution, key_added=leiden_column)
+    scanpy_object.obs[leiden_column] = pd.Categorical(
+        scanpy_object.obs[leiden_column].astype(str)
+    )
+    return scanpy_object
+
+
 def convert_scanpy_to_mdv(
     folder: str, 
     scanpy_object: AnnData, 
     max_dims: int = 3, 
     delete_existing: bool = False, 
     label: str = "",
+    obs_datasource_name: str = "cells",
+    var_datasource_name: str = "genes",
     chunk_data: bool = False,
     add_layer_data = True,
     gene_identifier_column = None,
+    link_name_column: str | None = None,
+    rows_as_columns_name_column: str | None = None,
     gene_columns: List[dict[str, Any]] | None = None,
+    compute_x_umap: bool = False,
+    leiden_resolution: float = 1.0,
+    leiden_column: str = "leiden",
 ) -> MDVProject:
     """
     Convert a Scanpy AnnData object to MDV (Multi-Dimensional Viewer) format.
@@ -48,6 +150,10 @@ def convert_scanpy_to_mdv(
             If False, merges with existing data. Defaults to False.
         label (str, optional): Prefix to add to datasource names and metadata columns
             when merging with existing data. Defaults to "".
+        obs_datasource_name (str, optional): Base name for the observation datasource.
+            Defaults to "cells".
+        var_datasource_name (str, optional): Base name for the variable datasource.
+            Defaults to "genes".
         chunk_data (bool, optional): For dense matrices, transposing and flattening
             will be performed in chunks. Saves memory but takes longer. Default is False.
         add_layer_data (bool, optional): If True (default) then the layer data (log values etc.)
@@ -55,7 +161,17 @@ def convert_scanpy_to_mdv(
         gene_identifier_column: (str, optional) This is the gene column that the user will use to
             identify the gene. If not specified (default) than a column 'name' will be added that is
             created from the index (which is usaully the unique gene name)
+        link_name_column (str, optional): Column in the variable datasource whose
+            values should be used as the dynamic column names for the ``rows_as_columns`` link.
+            Defaults to ``gene_identifier_column``.
+        rows_as_columns_name_column (str, optional): Deprecated alias for ``link_name_column``.
         gene_columns: (list[dict], optional) Column metadata overrides for the genes datasource.
+        compute_x_umap (bool, optional): If True, compute neighbors, UMAP and Leiden clusters
+            directly from ``adata.X`` before export. Defaults to False.
+        leiden_resolution (float, optional): Resolution passed to Leiden when
+            ``compute_x_umap`` is True. Defaults to 1.0.
+        leiden_column (str, optional): Observation column name used for Leiden labels.
+            The exported column is always coerced to text/categorical. Defaults to "leiden".
     Returns:
         MDVProject: The configured MDV project object with the converted data
 
@@ -91,6 +207,21 @@ def convert_scanpy_to_mdv(
     # Validate input AnnData
     if scanpy_object.n_obs == 0 or scanpy_object.n_vars == 0:
         raise ValueError("Cannot convert empty AnnData object (0 cells or 0 genes)")
+    if rows_as_columns_name_column is not None and link_name_column is not None:
+        raise ValueError(
+            "Specify only one of 'link_name_column' or 'rows_as_columns_name_column'"
+        )
+    if rows_as_columns_name_column is not None:
+        link_name_column = rows_as_columns_name_column
+    obs_ds_name = f"{label}{obs_datasource_name}"
+    var_ds_name = f"{label}{var_datasource_name}"
+
+    scanpy_object = _prepare_x_umap_and_leiden(
+        scanpy_object,
+        compute_x_umap=compute_x_umap,
+        leiden_resolution=leiden_resolution,
+        leiden_column=leiden_column,
+    )
     
     mdv = MDVProject(folder, delete_existing=delete_existing)
 
@@ -114,7 +245,13 @@ def convert_scanpy_to_mdv(
         "name":"cell_id",
         "datatype":"unique"
     }]
-    mdv.add_datasource(f"{label}cells", cell_table,columns)
+    if leiden_column in cell_table.columns:
+        columns.append({
+            "name": leiden_column,
+            "field": leiden_column,
+            "datatype": "text",
+        })
+    mdv.add_datasource(obs_ds_name, cell_table,columns)
 
     # create datasource 'genes'
     gene_table = scanpy_object.var
@@ -127,15 +264,21 @@ def convert_scanpy_to_mdv(
     if not gene_identifier_column:
         gene_identifier_column= f"{label}name"
         gene_table[gene_identifier_column] = gene_table.index
+    if link_name_column and link_name_column not in gene_table.columns:
+        raise ValueError(
+            f"link_name_column '{link_name_column}' not found in variable metadata"
+        )
+    if not link_name_column:
+        link_name_column = gene_identifier_column
     gene_table = _add_dims(gene_table, scanpy_object.varm, max_dims)
 
     #originally column had to be unique - but now is just text
     #need to coerce gene name column to unique
     #columns=[{"name":"name","datatype":"text16"}]
-    mdv.add_datasource(f"{label}genes", gene_table, columns=gene_columns)
+    mdv.add_datasource(var_ds_name, gene_table, columns=gene_columns)
 
     # link the two datasets
-    mdv.add_rows_as_columns_link(f"{label}cells", f"{label}genes", gene_identifier_column, "Gene Expr")
+    mdv.add_rows_as_columns_link(obs_ds_name, var_ds_name, link_name_column, "Gene Expr")
 
     #get the matrix in the correct format
     print("Getting Matrix")
@@ -147,7 +290,7 @@ def convert_scanpy_to_mdv(
         # add the gene expression
         print("Adding gene expression")
         mdv.add_rows_as_columns_subgroup(
-            f"{label}cells", f"{label}genes", "gs", matrix, name="gene_scores", label="Gene Scores",
+            obs_ds_name, var_ds_name, "gs", matrix, name="gene_scores", label="Gene Scores",
             # sparse=sparse, #this should be inferred from the matrix
             chunk_data=chunk_data
         )
@@ -158,12 +301,12 @@ def convert_scanpy_to_mdv(
             matrix,sparse = get_matrix(matrix)
             print(f"Adding layer {layer}")
             mdv.add_rows_as_columns_subgroup(
-                f"{label}cells", f"{label}genes", layer, matrix, chunk_data=chunk_data
+                obs_ds_name, var_ds_name, layer, matrix, chunk_data=chunk_data
             )
 
     if delete_existing:
         # If we're deleting existing, create new default view
-        mdv.set_view("default", {"initialCharts": {"cells": [], "genes": []}}, True)
+        mdv.set_view("default", {"initialCharts": {obs_ds_name: [], var_ds_name: []}}, True)
         mdv.set_editable(True)
     else:
         # If we're not deleting existing, update existing views with new datasources
@@ -176,16 +319,16 @@ def convert_scanpy_to_mdv(
                 new_view_data["initialCharts"] = {}
             
             # Add new datasources to initialCharts
-            new_view_data["initialCharts"][f"{label}cells"] = []
-            new_view_data["initialCharts"][f"{label}genes"] = []
+            new_view_data["initialCharts"][obs_ds_name] = []
+            new_view_data["initialCharts"][var_ds_name] = []
             
             # Initialize dataSources if they don't exist
             if "dataSources" not in new_view_data:
                 new_view_data["dataSources"] = {}
             
             # Add new datasources with panel widths
-            new_view_data["dataSources"][f"{label}cells"] = {"panelWidth": 50}
-            new_view_data["dataSources"][f"{label}genes"] = {"panelWidth": 50}
+            new_view_data["dataSources"][obs_ds_name] = {"panelWidth": 50}
+            new_view_data["dataSources"][var_ds_name] = {"panelWidth": 50}
             
             new_views[view_name] = new_view_data
         

--- a/python/mdvtools/convert_anndata.py
+++ b/python/mdvtools/convert_anndata.py
@@ -21,6 +21,8 @@ if __name__ == "__main__":
     parser.add_argument("input_h5ad", help="Input h5ad file")
     parser.add_argument("output_folder", help="Output folder for MDV project")
     parser.add_argument("--delete-existing", action="store_false", default=True, help="Delete existing project data")
+    parser.add_argument("--compute-x-umap", action="store_true", help="Compute neighbors, UMAP, and Leiden clusters directly from adata.X before export")
+    parser.add_argument("--leiden-resolution", type=float, default=1.0, help="Leiden resolution used with --compute-x-umap")
     # parser.add_argument("--add-layers", default=False, help="Add additional matrix layers (expensive)")
     
     args = parser.parse_args()
@@ -44,7 +46,9 @@ if __name__ == "__main__":
         adata, 
         chunk_data=True,
         add_layer_data=False,
-        delete_existing=args.delete_existing
+        delete_existing=args.delete_existing,
+        compute_x_umap=args.compute_x_umap,
+        leiden_resolution=args.leiden_resolution,
     )
     elapsed = time.time() - start_time
     minutes = int(elapsed // 60)

--- a/python/mdvtools/convert_anndata.py
+++ b/python/mdvtools/convert_anndata.py
@@ -21,6 +21,9 @@ if __name__ == "__main__":
     parser.add_argument("input_h5ad", help="Input h5ad file")
     parser.add_argument("output_folder", help="Output folder for MDV project")
     parser.add_argument("--delete-existing", action="store_false", default=True, help="Delete existing project data")
+    parser.add_argument("--obs-datasource-name", default="cells", help="Datasource name for observations")
+    parser.add_argument("--var-datasource-name", default="genes", help="Datasource name for variables")
+    parser.add_argument("--link-name-column", default=None, help="Variable datasource column used as the rows_as_columns name_column")
     parser.add_argument("--compute-x-umap", action="store_true", help="Compute neighbors, UMAP, and Leiden clusters directly from adata.X before export")
     parser.add_argument("--leiden-resolution", type=float, default=1.0, help="Leiden resolution used with --compute-x-umap")
     # parser.add_argument("--add-layers", default=False, help="Add additional matrix layers (expensive)")
@@ -44,9 +47,12 @@ if __name__ == "__main__":
     convert_scanpy_to_mdv(
         args.output_folder, 
         adata, 
+        obs_datasource_name=args.obs_datasource_name,
+        var_datasource_name=args.var_datasource_name,
         chunk_data=True,
         add_layer_data=False,
         delete_existing=args.delete_existing,
+        link_name_column=args.link_name_column,
         compute_x_umap=args.compute_x_umap,
         leiden_resolution=args.leiden_resolution,
     )

--- a/python/mdvtools/spatial/conversion.py
+++ b/python/mdvtools/spatial/conversion.py
@@ -919,23 +919,34 @@ def _allocate_table_prefix(table_name: str, used_prefixes: set[str]) -> str:
     return prefix
 
 
-def _compute_table_prefixed_x_umap_and_leiden(
+def _compute_table_x_umap_and_leiden(
     adata: "AnnData",
-    table_prefix: str,
     leiden_resolution: float,
-) -> tuple[str, str]:
+) -> str:
     from mdvtools.conversions import _prepare_x_umap_and_leiden
 
-    umap_key = f"{table_prefix}__X_umap"
-    leiden_column = f"{table_prefix}__leiden"
     _prepare_x_umap_and_leiden(
         adata,
         compute_x_umap=True,
         leiden_resolution=leiden_resolution,
-        leiden_column=leiden_column,
-        umap_key=umap_key,
+        leiden_column="leiden",
+        umap_key="X_umap",
     )
-    return umap_key, leiden_column
+    return "leiden"
+
+
+def _prefix_table_leiden_categories(
+    adata: "AnnData",
+    table_prefix: str,
+    leiden_column: str = "leiden",
+) -> None:
+    import pandas as pd
+
+    if leiden_column not in adata.obs.columns:
+        return
+    adata.obs[leiden_column] = pd.Categorical(
+        [f"{table_prefix}__{value}" for value in adata.obs[leiden_column].astype(str)]
+    )
 
 
 def _build_gene_source_column(
@@ -1018,7 +1029,7 @@ def convert_spatialdata_to_mdv(args: SpatialDataConversionArgs):
     gene_sources: dict[str, set[str]] = {}
     names: set[str] = set()
     used_table_prefixes: set[str] = set()
-    table_leiden_columns: list[str] = []
+    table_leiden_labels: list[tuple[AnnData, str]] = []
     
     # Process each SpatialData object sequentially
     # Removed ProcessPoolExecutor to avoid pickling issues with lazy zarr arrays in SpatialData objects
@@ -1050,14 +1061,13 @@ def convert_spatialdata_to_mdv(args: SpatialDataConversionArgs):
                 table_prefix = _allocate_table_prefix(table_name, used_prefixes=used_table_prefixes)
                 _progress(
                     f"Computing per-table X UMAP/Leiden for '{table_name}' "
-                    f"as '{table_prefix}__X_umap_*' and '{table_prefix}__leiden'"
+                    "into shared X_umap/leiden columns"
                 )
-                _, leiden_column = _compute_table_prefixed_x_umap_and_leiden(
+                leiden_column = _compute_table_x_umap_and_leiden(
                     adata,
-                    table_prefix=table_prefix,
                     leiden_resolution=args.leiden_resolution,
                 )
-                table_leiden_columns.append(leiden_column)
+                table_leiden_labels.append((adata, table_prefix))
             adata.obs["spatialdata_path"] = sdata_name
             adata.obs["table_name"] = table_name
             for gene_name in adata.var_names:
@@ -1099,6 +1109,10 @@ def convert_spatialdata_to_mdv(args: SpatialDataConversionArgs):
         elif not all_regions:
             raise ValueError("Spatial tables found but no regions could be resolved - this indicates a problem with the data")
 
+        if args.compute_x_umap and len(adata_objects) > 1:
+            for adata, table_prefix in table_leiden_labels:
+                _prefix_table_leiden_categories(adata, table_prefix)
+
         _progress(f"Merging {len(adata_objects)} table(s) with outer gene union")
         merged_adata = _concat_spatial_tables(adata_objects)
         gene_columns = _build_gene_source_column(merged_adata, gene_sources)
@@ -1115,12 +1129,6 @@ def convert_spatialdata_to_mdv(args: SpatialDataConversionArgs):
             compute_x_umap=False,
             leiden_resolution=args.leiden_resolution,
         )
-        if table_leiden_columns:
-            obs_metadata = mdv.get_datasource_metadata(args.obs_datasource_name)
-            for column in obs_metadata["columns"]:
-                if column.get("field") in table_leiden_columns:
-                    column["datatype"] = "text"
-            mdv.set_datasource_metadata(obs_metadata)
     if args.link:
         if single_source_input:
             os.makedirs(os.path.join(mdv.dir, "spatial"), exist_ok=True)

--- a/python/mdvtools/spatial/conversion.py
+++ b/python/mdvtools/spatial/conversion.py
@@ -3,6 +3,7 @@ import contextlib
 import io
 import logging
 import os
+import re
 import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional
@@ -176,6 +177,11 @@ def add_readme_to_project(mdv: "MDVProject", adata: Optional["AnnData"], convers
         markdown += f"- **Compute X UMAP/Leiden**: {conversion_args.compute_x_umap}\n"
         markdown += f"- **Leiden resolution**: {conversion_args.leiden_resolution}\n"
         markdown += "\n"
+        if conversion_args.compute_x_umap:
+            markdown += (
+                "Per-table X-based UMAP/Leiden annotations were computed before table merging. "
+                "These helper embeddings are not globally comparable across tables.\n\n"
+            )
     
     markdown += "## SpatialData objects:\n\n"
     spatial_dir = os.path.join(mdv.dir, "spatial")
@@ -228,7 +234,8 @@ def add_readme_to_project(mdv: "MDVProject", adata: Optional["AnnData"], convers
     _emit(f"README.md written to {os.path.join(mdv.dir, 'README.md')}", verbose_only=True)
     textbox = TextBox(title="SpatialData conversion information", param=[], size=[792, 472], position=[10, 10])
     textbox.set_text(markdown)
-    mdv.set_view("Data summary", {"initialCharts": {conversion_args.obs_datasource_name if conversion_args is not None else "cells": [textbox.plot_data]}})
+    obs_ds_name = conversion_args.obs_datasource_name if conversion_args is not None else "cells"
+    mdv.set_view("Data summary", {"initialCharts": {obs_ds_name: [textbox.plot_data]}})
 
 def _shape_to_geojson(shape: "GeoDataFrame", transform_to_image: "BaseTransformation") -> str:
     """
@@ -862,7 +869,6 @@ def _try_read_zarr(
             _emit(f"WARNING: Failed to read SpatialData object from {path}: '{e}'")
         return None
 
-
 def _ensure_unique_var_names(adata: "AnnData", table_name: str, sdata_name: str) -> None:
     if adata.var_names.is_unique:
         return
@@ -895,6 +901,41 @@ def _concat_spatial_tables(adata_objects: list["AnnData"]) -> "AnnData":
             category=UserWarning,
         )
         return ad_concat(adata_objects, index_unique="_", join="outer", fill_value=0)
+
+
+def _sanitize_table_prefix(table_name: str) -> str:
+    sanitized = re.sub(r"[^0-9A-Za-z]+", "_", table_name).strip("_")
+    return sanitized or "table"
+
+
+def _allocate_table_prefix(table_name: str, used_prefixes: set[str]) -> str:
+    base_prefix = _sanitize_table_prefix(table_name)
+    prefix = base_prefix
+    suffix = 2
+    while prefix in used_prefixes:
+        prefix = f"{base_prefix}_{suffix}"
+        suffix += 1
+    used_prefixes.add(prefix)
+    return prefix
+
+
+def _compute_table_prefixed_x_umap_and_leiden(
+    adata: "AnnData",
+    table_prefix: str,
+    leiden_resolution: float,
+) -> tuple[str, str]:
+    from mdvtools.conversions import _prepare_x_umap_and_leiden
+
+    umap_key = f"{table_prefix}__X_umap"
+    leiden_column = f"{table_prefix}__leiden"
+    _prepare_x_umap_and_leiden(
+        adata,
+        compute_x_umap=True,
+        leiden_resolution=leiden_resolution,
+        leiden_column=leiden_column,
+        umap_key=umap_key,
+    )
+    return umap_key, leiden_column
 
 
 def _build_gene_source_column(
@@ -976,6 +1017,8 @@ def convert_spatialdata_to_mdv(args: SpatialDataConversionArgs):
     all_regions: dict[str, dict] = {}
     gene_sources: dict[str, set[str]] = {}
     names: set[str] = set()
+    used_table_prefixes: set[str] = set()
+    table_leiden_columns: list[str] = []
     
     # Process each SpatialData object sequentially
     # Removed ProcessPoolExecutor to avoid pickling issues with lazy zarr arrays in SpatialData objects
@@ -1003,6 +1046,18 @@ def convert_spatialdata_to_mdv(args: SpatialDataConversionArgs):
         for table_name, adata in sdata.tables.items():
             _resolve_regions_for_table(sdata, table_name, sdata_name, args)
             _ensure_unique_var_names(adata, table_name, sdata_name)
+            if args.compute_x_umap:
+                table_prefix = _allocate_table_prefix(table_name, used_prefixes=used_table_prefixes)
+                _progress(
+                    f"Computing per-table X UMAP/Leiden for '{table_name}' "
+                    f"as '{table_prefix}__X_umap_*' and '{table_prefix}__leiden'"
+                )
+                _, leiden_column = _compute_table_prefixed_x_umap_and_leiden(
+                    adata,
+                    table_prefix=table_prefix,
+                    leiden_resolution=args.leiden_resolution,
+                )
+                table_leiden_columns.append(leiden_column)
             adata.obs["spatialdata_path"] = sdata_name
             adata.obs["table_name"] = table_name
             for gene_name in adata.var_names:
@@ -1026,6 +1081,8 @@ def convert_spatialdata_to_mdv(args: SpatialDataConversionArgs):
             args.output_folder,
             delete_existing=not args.preserve_existing,
             region_field=REGION_FIELD,
+            obs_datasource_name=args.obs_datasource_name,
+            var_datasource_name=args.var_datasource_name,
         )
         merged_adata = None
         has_spatial_tables = False
@@ -1055,9 +1112,15 @@ def convert_spatialdata_to_mdv(args: SpatialDataConversionArgs):
             var_datasource_name=args.var_datasource_name,
             link_name_column=args.link_name_column,
             gene_columns=gene_columns,
-            compute_x_umap=args.compute_x_umap,
+            compute_x_umap=False,
             leiden_resolution=args.leiden_resolution,
         )
+        if table_leiden_columns:
+            obs_metadata = mdv.get_datasource_metadata(args.obs_datasource_name)
+            for column in obs_metadata["columns"]:
+                if column.get("field") in table_leiden_columns:
+                    column["datatype"] = "text"
+            mdv.set_datasource_metadata(obs_metadata)
     if args.link:
         if single_source_input:
             os.makedirs(os.path.join(mdv.dir, "spatial"), exist_ok=True)
@@ -1119,14 +1182,16 @@ def convert_spatialdata_to_mdv(args: SpatialDataConversionArgs):
 
     if all_regions:
         # instead, we will set the region metadata directly.
-        cells_md = mdv.get_datasource_metadata("cells")
-        cells_md["regions"] = build_spatial_regions_metadata(all_regions, REGION_FIELD)
-        mdv.set_datasource_metadata(cells_md)
+        obs_md = mdv.get_datasource_metadata(args.obs_datasource_name)
+        obs_md["regions"] = build_spatial_regions_metadata(all_regions, REGION_FIELD)
+        mdv.set_datasource_metadata(obs_md)
         set_default_spatial_image_view(
             mdv,
             os.path.join(os.path.dirname(__file__), "spatial_view_template.json"),
             args.density,
             _emit,
+            obs_datasource_name=args.obs_datasource_name,
+            var_datasource_name=args.var_datasource_name,
         )
     if merged_adata is not None:
         _emit(f"## Merged AnnData object representation:\n\n```\n{merged_adata}\n```\n", verbose_only=True)
@@ -1162,7 +1227,15 @@ if __name__ == "__main__":
     parser.add_argument("--obs-datasource-name", default="cells", help="Datasource name for observations")
     parser.add_argument("--var-datasource-name", default="genes", help="Datasource name for variables")
     parser.add_argument("--link-name-column", default=None, help="Variable datasource column used as the rows_as_columns name_column")
-    parser.add_argument("--compute-x-umap", action="store_true", help="Compute neighbors, UMAP, and Leiden clusters from merged adata.X before export")
+    parser.add_argument(
+        "--compute-x-umap",
+        action="store_true",
+        help=(
+            "Compute neighbors, UMAP, and Leiden clusters separately for each source table "
+            "from that table's adata.X before merge. These per-table helper embeddings are "
+            "not globally comparable across tables."
+        ),
+    )
     parser.add_argument("--leiden-resolution", type=float, default=1.0, help="Leiden resolution used with --compute-x-umap")
     parser.add_argument("--verbose", action="store_true", help="Show detailed per-dataset conversion output, transform decisions, and merged summaries")
     parser.add_argument(

--- a/python/mdvtools/spatial/conversion.py
+++ b/python/mdvtools/spatial/conversion.py
@@ -32,6 +32,11 @@ class SpatialDataConversionArgs:
     density: bool = False
     point_transform: str = "auto"
     verbose: bool = False
+    obs_datasource_name: str = "cells"
+    var_datasource_name: str = "genes"
+    link_name_column: str | None = None
+    compute_x_umap: bool = False
+    leiden_resolution: float = 1.0
 
 
 REGION_FIELD = "spatial_region"
@@ -165,6 +170,11 @@ def add_readme_to_project(mdv: "MDVProject", adata: Optional["AnnData"], convers
         markdown += f"- **Link spatial data**: {conversion_args.link}\n"
         markdown += f"- **Batch mode**: {conversion_args.batch}\n"
         markdown += f"- **SpatialData source**: `{conversion_args.spatialdata_path}`\n"
+        markdown += f"- **Obs datasource name**: `{conversion_args.obs_datasource_name}`\n"
+        markdown += f"- **Var datasource name**: `{conversion_args.var_datasource_name}`\n"
+        markdown += f"- **rows_as_columns name column**: `{conversion_args.link_name_column}`\n"
+        markdown += f"- **Compute X UMAP/Leiden**: {conversion_args.compute_x_umap}\n"
+        markdown += f"- **Leiden resolution**: {conversion_args.leiden_resolution}\n"
         markdown += "\n"
     
     markdown += "## SpatialData objects:\n\n"
@@ -218,7 +228,7 @@ def add_readme_to_project(mdv: "MDVProject", adata: Optional["AnnData"], convers
     _emit(f"README.md written to {os.path.join(mdv.dir, 'README.md')}", verbose_only=True)
     textbox = TextBox(title="SpatialData conversion information", param=[], size=[792, 472], position=[10, 10])
     textbox.set_text(markdown)
-    mdv.set_view("Data summary", {"initialCharts": {"cells": [textbox.plot_data]}})
+    mdv.set_view("Data summary", {"initialCharts": {conversion_args.obs_datasource_name if conversion_args is not None else "cells": [textbox.plot_data]}})
 
 def _shape_to_geojson(shape: "GeoDataFrame", transform_to_image: "BaseTransformation") -> str:
     """
@@ -1041,8 +1051,13 @@ def convert_spatialdata_to_mdv(args: SpatialDataConversionArgs):
             args.output_folder,
             merged_adata,
             delete_existing=not args.preserve_existing,
+            obs_datasource_name=args.obs_datasource_name,
+            var_datasource_name=args.var_datasource_name,
+            link_name_column=args.link_name_column,
             gene_columns=gene_columns,
-    )
+            compute_x_umap=args.compute_x_umap,
+            leiden_resolution=args.leiden_resolution,
+        )
     if args.link:
         if single_source_input:
             os.makedirs(os.path.join(mdv.dir, "spatial"), exist_ok=True)
@@ -1144,6 +1159,11 @@ if __name__ == "__main__":
     )
     parser.add_argument("--density", action="store_true", help="Include density fields for gene expression in the default spatial view")
     parser.add_argument("--serve", action="store_true", help="Serve the generated project after conversion")
+    parser.add_argument("--obs-datasource-name", default="cells", help="Datasource name for observations")
+    parser.add_argument("--var-datasource-name", default="genes", help="Datasource name for variables")
+    parser.add_argument("--link-name-column", default=None, help="Variable datasource column used as the rows_as_columns name_column")
+    parser.add_argument("--compute-x-umap", action="store_true", help="Compute neighbors, UMAP, and Leiden clusters from merged adata.X before export")
+    parser.add_argument("--leiden-resolution", type=float, default=1.0, help="Leiden resolution used with --compute-x-umap")
     parser.add_argument("--verbose", action="store_true", help="Show detailed per-dataset conversion output, transform decisions, and merged summaries")
     parser.add_argument(
         "--point-transform",

--- a/python/mdvtools/spatial/project_helpers.py
+++ b/python/mdvtools/spatial/project_helpers.py
@@ -31,8 +31,10 @@ def set_default_spatial_image_view(
     template_path: str,
     density: bool,
     emit,
+    obs_datasource_name: str = "cells",
+    var_datasource_name: str = "genes",
 ) -> None:
-    for region_name, region_data in mdv.get_datasource_metadata("cells")["regions"]["all_regions"].items():
+    for region_name, region_data in mdv.get_datasource_metadata(obs_datasource_name)["regions"]["all_regions"].items():
         if "viv_image" in region_data:
             break
     else:
@@ -41,11 +43,13 @@ def set_default_spatial_image_view(
     emit(f"Using region '{region_name}' for default view", verbose_only=True)
     with open(template_path, "r") as f:
         view_str = f.read().replace("<SPATIAL_REGION_NAME>", region_name)
+        view_str = view_str.replace('"cells"', f'"{obs_datasource_name}"')
+        view_str = view_str.replace('"genes"', f'"{var_datasource_name}"')
         density_block = """
         {
-            "linkedDsName": "genes", "maxItems": 15, "type": "RowsAsColsQuery"
+            "linkedDsName": "%s", "maxItems": 15, "type": "RowsAsColsQuery"
         }
-        """
+        """ % var_datasource_name
         view_str = view_str.replace('"<DENSITY_FIELDS>"', density_block if density else "")
         mdv.set_view("default", json.loads(view_str), True)
 
@@ -54,6 +58,8 @@ def create_empty_spatial_mdv_project(
     output_folder: str,
     delete_existing: bool,
     region_field: str,
+    obs_datasource_name: str = "cells",
+    var_datasource_name: str = "genes",
 ) -> "MDVProject":
     import pandas
     from mdvtools.mdvproject import MDVProject
@@ -68,7 +74,7 @@ def create_empty_spatial_mdv_project(
         }
     )
     mdv.add_datasource(
-        "cells",
+        obs_datasource_name,
         cells_df,
         columns=[
             {"name": "x", "field": "x", "datatype": "double"},
@@ -85,7 +91,7 @@ def create_empty_spatial_mdv_project(
         }
     )
     mdv.add_datasource(
-        "genes",
+        var_datasource_name,
         genes_df,
         columns=[
             {"name": "name", "field": "name", "datatype": "text"},

--- a/python/mdvtools/spatial/project_helpers.py
+++ b/python/mdvtools/spatial/project_helpers.py
@@ -42,15 +42,24 @@ def set_default_spatial_image_view(
 
     emit(f"Using region '{region_name}' for default view", verbose_only=True)
     with open(template_path, "r") as f:
-        view_str = f.read().replace("<SPATIAL_REGION_NAME>", region_name)
-        view_str = view_str.replace('"cells"', f'"{obs_datasource_name}"')
-        view_str = view_str.replace('"genes"', f'"{var_datasource_name}"')
-        density_block = """
-        {
-            "linkedDsName": "%s", "maxItems": 15, "type": "RowsAsColsQuery"
-        }
-        """ % var_datasource_name
-        view_str = view_str.replace('"<DENSITY_FIELDS>"', density_block if density else "")
+        view_str = f.read()
+        view_str = view_str.replace('"<SPATIAL_REGION_NAME>"', json.dumps(region_name))
+        view_str = view_str.replace('"cells"', '"__OBS_DS__"')
+        view_str = view_str.replace('"genes"', '"__VAR_DS__"')
+        density_block = (
+            json.dumps(
+                {
+                    "linkedDsName": var_datasource_name,
+                    "maxItems": 15,
+                    "type": "RowsAsColsQuery",
+                }
+            )
+            if density
+            else ""
+        )
+        view_str = view_str.replace('"<DENSITY_FIELDS>"', density_block)
+        view_str = view_str.replace('"__OBS_DS__"', json.dumps(obs_datasource_name))
+        view_str = view_str.replace('"__VAR_DS__"', json.dumps(var_datasource_name))
         mdv.set_view("default", json.loads(view_str), True)
 
 

--- a/python/mdvtools/tests/test_conversion_cli_options.py
+++ b/python/mdvtools/tests/test_conversion_cli_options.py
@@ -1,18 +1,21 @@
 from click.testing import CliRunner
 
 import mdvtools.cli as cli_module
+import mdvtools.conversions as conversions_module
+import mdvtools.spatial.conversion as spatial_conversion_module
+import scanpy as sc
 
 
 def test_convert_scanpy_cli_forwards_x_umap_options(monkeypatch):
     captured = {}
 
-    monkeypatch.setattr(cli_module.sc, "read_h5ad", lambda path: object())
+    monkeypatch.setattr(sc, "read_h5ad", lambda path: object())
 
     def fake_convert_scanpy_to_mdv(*args, **kwargs):
         captured["args"] = args
         captured["kwargs"] = kwargs
 
-    monkeypatch.setattr(cli_module, "convert_scanpy_to_mdv", fake_convert_scanpy_to_mdv)
+    monkeypatch.setattr(conversions_module, "convert_scanpy_to_mdv", fake_convert_scanpy_to_mdv)
 
     runner = CliRunner()
     result = runner.invoke(
@@ -21,6 +24,12 @@ def test_convert_scanpy_cli_forwards_x_umap_options(monkeypatch):
             "convert-scanpy",
             "out",
             "input.h5ad",
+            "--obs-datasource-name",
+            "observations",
+            "--var-datasource-name",
+            "features",
+            "--link-name-column",
+            "display_name",
             "--compute-x-umap",
             "--leiden-resolution",
             "0.75",
@@ -28,6 +37,9 @@ def test_convert_scanpy_cli_forwards_x_umap_options(monkeypatch):
     )
 
     assert result.exit_code == 0, result.output
+    assert captured["args"][5] == "observations"
+    assert captured["args"][6] == "features"
+    assert captured["kwargs"]["link_name_column"] == "display_name"
     assert captured["kwargs"]["compute_x_umap"] is True
     assert captured["kwargs"]["leiden_resolution"] == 0.75
 
@@ -38,7 +50,7 @@ def test_convert_spatial_cli_forwards_x_umap_options(monkeypatch):
     def fake_convert_spatialdata_to_mdv(args):
         captured["args"] = args
 
-    monkeypatch.setattr(cli_module, "convert_spatialdata_to_mdv", fake_convert_spatialdata_to_mdv)
+    monkeypatch.setattr(spatial_conversion_module, "convert_spatialdata_to_mdv", fake_convert_spatialdata_to_mdv)
 
     runner = CliRunner()
     result = runner.invoke(
@@ -47,6 +59,12 @@ def test_convert_spatial_cli_forwards_x_umap_options(monkeypatch):
             "convert-spatial",
             "out",
             "spatial",
+            "--obs-datasource-name",
+            "observations",
+            "--var-datasource-name",
+            "features",
+            "--link-name-column",
+            "display_name",
             "--compute-x-umap",
             "--leiden-resolution",
             "1.25",
@@ -54,5 +72,8 @@ def test_convert_spatial_cli_forwards_x_umap_options(monkeypatch):
     )
 
     assert result.exit_code == 0, result.output
+    assert captured["args"].obs_datasource_name == "observations"
+    assert captured["args"].var_datasource_name == "features"
+    assert captured["args"].link_name_column == "display_name"
     assert captured["args"].compute_x_umap is True
     assert captured["args"].leiden_resolution == 1.25

--- a/python/mdvtools/tests/test_conversion_cli_options.py
+++ b/python/mdvtools/tests/test_conversion_cli_options.py
@@ -1,0 +1,58 @@
+from click.testing import CliRunner
+
+import mdvtools.cli as cli_module
+
+
+def test_convert_scanpy_cli_forwards_x_umap_options(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(cli_module.sc, "read_h5ad", lambda path: object())
+
+    def fake_convert_scanpy_to_mdv(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(cli_module, "convert_scanpy_to_mdv", fake_convert_scanpy_to_mdv)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_module.cli,
+        [
+            "convert-scanpy",
+            "out",
+            "input.h5ad",
+            "--compute-x-umap",
+            "--leiden-resolution",
+            "0.75",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["kwargs"]["compute_x_umap"] is True
+    assert captured["kwargs"]["leiden_resolution"] == 0.75
+
+
+def test_convert_spatial_cli_forwards_x_umap_options(monkeypatch):
+    captured = {}
+
+    def fake_convert_spatialdata_to_mdv(args):
+        captured["args"] = args
+
+    monkeypatch.setattr(cli_module, "convert_spatialdata_to_mdv", fake_convert_spatialdata_to_mdv)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_module.cli,
+        [
+            "convert-spatial",
+            "out",
+            "spatial",
+            "--compute-x-umap",
+            "--leiden-resolution",
+            "1.25",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["args"].compute_x_umap is True
+    assert captured["args"].leiden_resolution == 1.25

--- a/python/mdvtools/tests/test_conversion_edge_cases.py
+++ b/python/mdvtools/tests/test_conversion_edge_cases.py
@@ -234,6 +234,9 @@ class TestConversionWithEdgeCases:
         """Test optional X-based UMAP/Leiden computation during conversion."""
         factory = MockAnnDataFactory(random_seed=42)
         adata = factory.create_minimal(50, 20)
+        adata.X = np.asarray(adata.X, dtype=np.float32)
+        adata.X[0, 0] = np.nan
+        adata.X[1, 1] = np.inf
 
         assert "X_umap" not in adata.obsm
         assert "leiden" not in adata.obs.columns
@@ -247,6 +250,9 @@ class TestConversionWithEdgeCases:
                     compute_x_umap=True,
                     leiden_resolution=0.5,
                 )
+
+            assert sp.isspmatrix_csc(adata.X)
+            assert np.isfinite(adata.X.data).all()
 
             cells_metadata = mdv.get_datasource_metadata("cells")
             columns = {col["field"]: col for col in cells_metadata["columns"]}

--- a/python/mdvtools/tests/test_conversion_edge_cases.py
+++ b/python/mdvtools/tests/test_conversion_edge_cases.py
@@ -21,8 +21,9 @@ from pandas import DataFrame
 from mdvtools.conversions import convert_scanpy_to_mdv
 from mdvtools.mdvproject import MDVProject
 from mdvtools.spatial.conversion import (
-    _compute_table_prefixed_x_umap_and_leiden,
+    _compute_table_x_umap_and_leiden,
     _concat_spatial_tables,
+    _prefix_table_leiden_categories,
 )
 from .mock_anndata import (
     MockAnnDataFactory,
@@ -296,22 +297,20 @@ class TestConversionWithEdgeCases:
             link_metadata = obs_metadata["links"]["features"]["rows_as_columns"]
             assert link_metadata["name_column"] == "display_name"
 
-    def test_spatial_single_table_x_umap_is_prefixed_and_text(self):
-        """Spatial helper should compute per-table prefixed UMAP/Leiden columns."""
+    def test_spatial_single_table_x_umap_uses_plain_columns(self):
+        """Single-table spatial helper should keep plain X_umap/leiden column names."""
         factory = MockAnnDataFactory(random_seed=42)
         adata = factory.create_minimal(40, 16)
 
-        _compute_table_prefixed_x_umap_and_leiden(
+        _compute_table_x_umap_and_leiden(
             adata,
-            table_prefix="sample_table",
             leiden_resolution=0.6,
         )
 
-        assert "sample_table__X_umap" in adata.obsm
-        assert "sample_table__leiden" in adata.obs.columns
-        assert "leiden" not in adata.obs.columns
-        assert isinstance(adata.obs["sample_table__leiden"].dtype, pd.CategoricalDtype)
-        assert all(isinstance(value, str) for value in adata.obs["sample_table__leiden"].astype(str))
+        assert "X_umap" in adata.obsm
+        assert "leiden" in adata.obs.columns
+        assert isinstance(adata.obs["leiden"].dtype, pd.CategoricalDtype)
+        assert all(isinstance(value, str) for value in adata.obs["leiden"].astype(str))
 
         with temp_mdv_project() as test_dir:
             with suppress_anndata_warnings():
@@ -319,44 +318,40 @@ class TestConversionWithEdgeCases:
 
             cells_metadata = mdv.get_datasource_metadata("cells")
             columns = {col["field"]: col for col in cells_metadata["columns"]}
-            assert "sample_table__X_umap_1" in columns
-            assert "sample_table__X_umap_2" in columns
-            assert "sample_table__leiden" in columns
-            assert columns["sample_table__leiden"]["datatype"] in ["text", "text16"]
+            assert "X_umap_1" in columns
+            assert "X_umap_2" in columns
+            assert "leiden" in columns
+            assert columns["leiden"]["datatype"] in ["text", "text16"]
 
-    def test_spatial_multi_table_x_umap_stays_per_table_after_merge(self):
-        """Merged spatial tables should keep separate per-table UMAP/Leiden columns."""
+    def test_spatial_multi_table_x_umap_shares_columns_and_prefixes_leiden_values(self):
+        """Merged spatial tables should share X_umap/leiden columns while prefixing Leiden labels."""
         factory = MockAnnDataFactory(random_seed=42)
         adata_a = factory.create_minimal(24, 12)
         adata_b = factory.create_minimal(18, 9)
 
-        _compute_table_prefixed_x_umap_and_leiden(
+        _compute_table_x_umap_and_leiden(
             adata_a,
-            table_prefix="table_a",
             leiden_resolution=0.5,
         )
-        _compute_table_prefixed_x_umap_and_leiden(
+        _compute_table_x_umap_and_leiden(
             adata_b,
-            table_prefix="table_b",
             leiden_resolution=0.5,
         )
+        _prefix_table_leiden_categories(adata_a, "table_a")
+        _prefix_table_leiden_categories(adata_b, "table_b")
         adata_a.obs["table_name"] = "table_a"
         adata_b.obs["table_name"] = "table_b"
 
         merged = _concat_spatial_tables([adata_a, adata_b])
 
-        assert "leiden" not in merged.obs.columns
-        assert "table_a__leiden" in merged.obs.columns
-        assert "table_b__leiden" in merged.obs.columns
+        assert "leiden" in merged.obs.columns
 
         merged_obs = cast(DataFrame, merged.obs)
         table_a_rows = merged_obs["table_name"] == "table_a"
         table_b_rows = merged_obs["table_name"] == "table_b"
 
-        assert merged_obs.loc[table_a_rows, "table_a__leiden"].notna().all()
-        assert merged_obs.loc[table_b_rows, "table_b__leiden"].notna().all()
-        assert merged_obs.loc[table_a_rows, "table_b__leiden"].isna().all()
-        assert merged_obs.loc[table_b_rows, "table_a__leiden"].isna().all()
+        assert merged_obs.loc[table_a_rows, "leiden"].str.startswith("table_a__").all()
+        assert merged_obs.loc[table_b_rows, "leiden"].str.startswith("table_b__").all()
 
         with temp_mdv_project() as test_dir:
             with suppress_anndata_warnings():
@@ -364,12 +359,9 @@ class TestConversionWithEdgeCases:
 
             cells_metadata = mdv.get_datasource_metadata("cells")
             columns = {col["field"]: col for col in cells_metadata["columns"]}
-            assert "table_a__X_umap_1" in columns
-            assert "table_a__X_umap_2" in columns
-            assert "table_b__X_umap_1" in columns
-            assert "table_b__X_umap_2" in columns
-            assert columns["table_a__leiden"]["datatype"] in ["text", "text16"]
-            assert columns["table_b__leiden"]["datatype"] in ["text", "text16"]
+            assert "X_umap_1" in columns
+            assert "X_umap_2" in columns
+            assert columns["leiden"]["datatype"] in ["text", "text16"]
 
 
 class TestConversionErrorHandling:

--- a/python/mdvtools/tests/test_conversion_edge_cases.py
+++ b/python/mdvtools/tests/test_conversion_edge_cases.py
@@ -9,12 +9,14 @@ edge cases, ensuring that adata.X is properly handled and validated.
 import os
 import tempfile
 import shutil
+from typing import cast
 import pytest
 import numpy as np
 import pandas as pd
 import scanpy as sc
 import scipy.sparse as sp
 from contextlib import contextmanager
+from pandas import DataFrame
 
 from mdvtools.conversions import convert_scanpy_to_mdv
 from mdvtools.mdvproject import MDVProject
@@ -347,13 +349,14 @@ class TestConversionWithEdgeCases:
         assert "table_a__leiden" in merged.obs.columns
         assert "table_b__leiden" in merged.obs.columns
 
-        table_a_rows = merged.obs["table_name"] == "table_a"
-        table_b_rows = merged.obs["table_name"] == "table_b"
+        merged_obs = cast(DataFrame, merged.obs)
+        table_a_rows = merged_obs["table_name"] == "table_a"
+        table_b_rows = merged_obs["table_name"] == "table_b"
 
-        assert merged.obs.loc[table_a_rows, "table_a__leiden"].notna().all()
-        assert merged.obs.loc[table_b_rows, "table_b__leiden"].notna().all()
-        assert merged.obs.loc[table_a_rows, "table_b__leiden"].isna().all()
-        assert merged.obs.loc[table_b_rows, "table_a__leiden"].isna().all()
+        assert merged_obs.loc[table_a_rows, "table_a__leiden"].notna().all()
+        assert merged_obs.loc[table_b_rows, "table_b__leiden"].notna().all()
+        assert merged_obs.loc[table_a_rows, "table_b__leiden"].isna().all()
+        assert merged_obs.loc[table_b_rows, "table_a__leiden"].isna().all()
 
         with temp_mdv_project() as test_dir:
             with suppress_anndata_warnings():

--- a/python/mdvtools/tests/test_conversion_edge_cases.py
+++ b/python/mdvtools/tests/test_conversion_edge_cases.py
@@ -230,6 +230,36 @@ class TestConversionWithEdgeCases:
             
             assert isinstance(mdv, MDVProject)
 
+    def test_conversion_can_compute_x_umap_and_leiden_as_text(self):
+        """Test optional X-based UMAP/Leiden computation during conversion."""
+        factory = MockAnnDataFactory(random_seed=42)
+        adata = factory.create_minimal(50, 20)
+
+        assert "X_umap" not in adata.obsm
+        assert "leiden" not in adata.obs.columns
+
+        with temp_mdv_project() as test_dir:
+            with suppress_anndata_warnings():
+                mdv = convert_scanpy_to_mdv(
+                    test_dir,
+                    adata,
+                    delete_existing=True,
+                    compute_x_umap=True,
+                    leiden_resolution=0.5,
+                )
+
+            cells_metadata = mdv.get_datasource_metadata("cells")
+            columns = {col["field"]: col for col in cells_metadata["columns"]}
+
+            assert "X_umap_1" in columns
+            assert "X_umap_2" in columns
+            assert "leiden" in columns
+            assert columns["leiden"]["datatype"] in ["text", "text16"]
+
+            leiden_values = mdv.get_column("cells", "leiden")
+            assert len(leiden_values) == adata.n_obs
+            assert all(isinstance(value, str) for value in leiden_values)
+
 
 class TestConversionErrorHandling:
     """Test class for error handling during conversion."""

--- a/python/mdvtools/tests/test_conversion_edge_cases.py
+++ b/python/mdvtools/tests/test_conversion_edge_cases.py
@@ -18,6 +18,10 @@ from contextlib import contextmanager
 
 from mdvtools.conversions import convert_scanpy_to_mdv
 from mdvtools.mdvproject import MDVProject
+from mdvtools.spatial.conversion import (
+    _compute_table_prefixed_x_umap_and_leiden,
+    _concat_spatial_tables,
+)
 from .mock_anndata import (
     MockAnnDataFactory,
     create_edge_case_anndata,
@@ -265,6 +269,104 @@ class TestConversionWithEdgeCases:
             leiden_values = mdv.get_column("cells", "leiden")
             assert len(leiden_values) == adata.n_obs
             assert all(isinstance(value, str) for value in leiden_values)
+
+    def test_conversion_can_override_link_name_column_and_datasource_names(self):
+        """Test explicit selection of the rows_as_columns link column and datasource names."""
+        factory = MockAnnDataFactory(random_seed=42)
+        adata = factory.create_minimal(20, 10)
+        adata.var["display_name"] = [f"Gene {i}" for i in range(adata.n_vars)]
+
+        with temp_mdv_project() as test_dir:
+            with suppress_anndata_warnings():
+                mdv = convert_scanpy_to_mdv(
+                    test_dir,
+                    adata,
+                    delete_existing=True,
+                    obs_datasource_name="observations",
+                    var_datasource_name="features",
+                    link_name_column="display_name",
+                )
+
+            assert "observations" in mdv.get_datasource_names()
+            assert "features" in mdv.get_datasource_names()
+
+            obs_metadata = mdv.get_datasource_metadata("observations")
+            link_metadata = obs_metadata["links"]["features"]["rows_as_columns"]
+            assert link_metadata["name_column"] == "display_name"
+
+    def test_spatial_single_table_x_umap_is_prefixed_and_text(self):
+        """Spatial helper should compute per-table prefixed UMAP/Leiden columns."""
+        factory = MockAnnDataFactory(random_seed=42)
+        adata = factory.create_minimal(40, 16)
+
+        _compute_table_prefixed_x_umap_and_leiden(
+            adata,
+            table_prefix="sample_table",
+            leiden_resolution=0.6,
+        )
+
+        assert "sample_table__X_umap" in adata.obsm
+        assert "sample_table__leiden" in adata.obs.columns
+        assert "leiden" not in adata.obs.columns
+        assert isinstance(adata.obs["sample_table__leiden"].dtype, pd.CategoricalDtype)
+        assert all(isinstance(value, str) for value in adata.obs["sample_table__leiden"].astype(str))
+
+        with temp_mdv_project() as test_dir:
+            with suppress_anndata_warnings():
+                mdv = convert_scanpy_to_mdv(test_dir, adata, delete_existing=True)
+
+            cells_metadata = mdv.get_datasource_metadata("cells")
+            columns = {col["field"]: col for col in cells_metadata["columns"]}
+            assert "sample_table__X_umap_1" in columns
+            assert "sample_table__X_umap_2" in columns
+            assert "sample_table__leiden" in columns
+            assert columns["sample_table__leiden"]["datatype"] in ["text", "text16"]
+
+    def test_spatial_multi_table_x_umap_stays_per_table_after_merge(self):
+        """Merged spatial tables should keep separate per-table UMAP/Leiden columns."""
+        factory = MockAnnDataFactory(random_seed=42)
+        adata_a = factory.create_minimal(24, 12)
+        adata_b = factory.create_minimal(18, 9)
+
+        _compute_table_prefixed_x_umap_and_leiden(
+            adata_a,
+            table_prefix="table_a",
+            leiden_resolution=0.5,
+        )
+        _compute_table_prefixed_x_umap_and_leiden(
+            adata_b,
+            table_prefix="table_b",
+            leiden_resolution=0.5,
+        )
+        adata_a.obs["table_name"] = "table_a"
+        adata_b.obs["table_name"] = "table_b"
+
+        merged = _concat_spatial_tables([adata_a, adata_b])
+
+        assert "leiden" not in merged.obs.columns
+        assert "table_a__leiden" in merged.obs.columns
+        assert "table_b__leiden" in merged.obs.columns
+
+        table_a_rows = merged.obs["table_name"] == "table_a"
+        table_b_rows = merged.obs["table_name"] == "table_b"
+
+        assert merged.obs.loc[table_a_rows, "table_a__leiden"].notna().all()
+        assert merged.obs.loc[table_b_rows, "table_b__leiden"].notna().all()
+        assert merged.obs.loc[table_a_rows, "table_b__leiden"].isna().all()
+        assert merged.obs.loc[table_b_rows, "table_a__leiden"].isna().all()
+
+        with temp_mdv_project() as test_dir:
+            with suppress_anndata_warnings():
+                mdv = convert_scanpy_to_mdv(test_dir, merged, delete_existing=True)
+
+            cells_metadata = mdv.get_datasource_metadata("cells")
+            columns = {col["field"]: col for col in cells_metadata["columns"]}
+            assert "table_a__X_umap_1" in columns
+            assert "table_a__X_umap_2" in columns
+            assert "table_b__X_umap_1" in columns
+            assert "table_b__X_umap_2" in columns
+            assert columns["table_a__leiden"]["datatype"] in ["text", "text16"]
+            assert columns["table_b__leiden"]["datatype"] in ["text", "text16"]
 
 
 class TestConversionErrorHandling:


### PR DESCRIPTION
## Summary
- add `--compute-x-umap` and `--leiden-resolution` options to AnnData and SpatialData conversion CLIs
- compute neighbors, UMAP, and Leiden clusters from `adata.X` during conversion when requested
- coerce the Leiden output column to categorical text and mark it as `text` in MDV datasource metadata
- thread the new options through SpatialData conversion args and README metadata
- add tests for X-based UMAP/Leiden conversion and CLI option forwarding

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI flags to set observation/variable datasource names, link-name column, optional X→UMAP/Leiden preprocessing, and Leiden resolution (defaults preserved).

* **Documentation**
  * README updated to include new conversion settings and conditional notes when X-based computation is enabled.

* **Tests**
  * Added CLI forwarding tests and unit tests for X→UMAP/Leiden computation, per-table handling, and export.

* **Refactor**
  * Spatial view/project setup now uses configurable datasource names instead of hardcoded ones.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->