### PR TITLE
Fix add-chart param state for multi-column selections

### DIFF
--- a/src/charts/dialogs/AddChartDialogReact.tsx
+++ b/src/charts/dialogs/AddChartDialogReact.tsx
@@ -460,15 +460,16 @@ const Wrapper = (props: { dataStore: DataStore, modal: boolean, onDone: () => vo
     // then we could use zustand without bothering with faff of multiple store contexts
     // the only consequence of allowing multiple dialogs to be open would be that they'd share state
     // but that could actually be bad in that they are all associated with a particular dataStore
-    const initialConfig: ChartConfig = {
-        title: "",
-        legend: "",
-        type: "",
-        param: [],
-        extra: {},
-        _updated: new Date(),
-    };
-    const config = useMemo(() => observable.object(initialConfig), []);
+    const [config] = useState(() =>
+        observable.object({
+            title: "",
+            legend: "",
+            type: "",
+            param: [],
+            extra: {},
+            _updated: new Date(),
+        } satisfies ChartConfig),
+    );
     const [open, setOpen] = useState(true);
     useEffect(() => {
         if (!props.modal) return;


### PR DESCRIPTION
## Summary
- replace the add-chart dialog's loose param draft state with explicit single vs multi param slots
- initialize and preserve multi-column params as arrays, then flatten them only when building chart props
- route column selection through single and multi-specific branches so `ColumnSelectionComponent` receives consistent value shapes
- remove the local zod-based draft config shape and derive defaults from matching column fields instead of display names

## Testing
- `npx tsgo --noEmit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved chart configuration parameter handling and validation system
  * Enhanced column parameter selection logic with better compatibility detection
  * Optimized chart type switching behavior with more intelligent default slot assignment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->