### PR TITLE
Fix missing-value handling on grey scatter layers

### DIFF
--- a/src/datastore/DataStore.js
+++ b/src/datastore/DataStore.js
@@ -1502,11 +1502,8 @@ class DataStore {
             const max = ov.max == null ? c.minMax[1] : ov.max;
             const bins = config.bins || 100;
             const interval_size = (max - min) / bins;
-            // not ideal way of getting theme - also, won't update dynamically.
-            const dark = window.mdv?.chartManager.theme === "dark";
-            const white = config.asArray ? [255, 255, 255] : "#ffffff";
-            const black = config.asArray ? [0, 0, 0] : "#000000";
-            const fallbackColor = ov.hideMissing ? undefined : (dark ? black : white);
+            const gray = config.asArray ? [128, 128, 128] : "#808080";
+            const fallbackColor = ov.hideMissing ? undefined : gray;
             //the actual function - bins the value and returns the color for that bin
             function getColor(v) {
                 if (isFallback(v)) return fallbackColor;

--- a/src/react/components/DeckScatterComponent.tsx
+++ b/src/react/components/DeckScatterComponent.tsx
@@ -12,7 +12,7 @@ import type { DataColumn, FieldName, LoadedDataColumn, NumberDataType } from "@/
 import { allNumeric } from "@/lib/columnTypeHelpers";
 import { SpatialAnnotationProvider, useSpatialLayers } from "../spatial_context";
 import SelectionOverlay from "./SelectionOverlay";
-import { useScatterRadius } from "../scatter_state";
+import { getMissingColorFilterValue, useScatterRadius, useShouldFilterNaN } from "../scatter_state";
 import AxisComponent from "./AxisComponent";
 import { useOuterContainer } from "../screen_state";
 import { rebindMouseEvents } from "@/lib/deckMonkeypatch";
@@ -179,6 +179,7 @@ const DeckScatter = observer(function DeckScatterComponent({
     const { scatterplotLayer, getTooltip, setScatterKeyboardActive } = scatterProps;
 
     const filterValue = useFilterArray();
+    const { shouldFilter: shouldFilterMissing, colorColumn, fallbackOnZero } = useShouldFilterNaN();
 
     const {
         gateLabelLayer,
@@ -222,17 +223,33 @@ const DeckScatter = observer(function DeckScatterComponent({
                         // type: "spring",
                     },
                 },
-                getFilterValue: (_: any, { index }: { index: number }) => filterValue[index] || 0, //how do we just pass the buffer?
+                getFilterValue: (_: unknown, { index }: { index: number }) => {
+                    if (!filterValue[index]) return 0;
+                    return getMissingColorFilterValue(index, colorColumn, shouldFilterMissing, fallbackOnZero);
+                },
                 filterRange: [0.5, 1],
                 updateTriggers: {
                     //! using `data` as a trigger as `filterValue` was behind by one frame or something
-                    getFilterValue: data,
+                    getFilterValue: [data, filterValue, colorColumn, shouldFilterMissing, fallbackOnZero],
                     getPosition: [cx.data, cy.data, cz?.data],
                 },
                 extensions: [new DataFilterExtension()],
                 visible: greyOnFilter,
             }),
-        [cx, cy, cz, opacity, radiusScale, id, filterValue, data, greyOnFilter],
+        [
+            cx,
+            cy,
+            cz,
+            opacity,
+            radiusScale,
+            id,
+            filterValue,
+            data,
+            greyOnFilter,
+            colorColumn,
+            shouldFilterMissing,
+            fallbackOnZero,
+        ],
     );
 
     const axisLinesLayer = useMemo(() => {

--- a/src/react/scatter_state.ts
+++ b/src/react/scatter_state.ts
@@ -22,7 +22,7 @@ import { DataFilterExtension } from "@deck.gl/extensions";
 import { isDatatypeCategorical } from "@/lib/utils";
 import { useHighlightedIndices, useHighlightRows } from "./selectionHooks";
 import { type DualContourLegacyConfig, useLegacyDualContour } from "./contour_state";
-import type { ColumnName, DataColumn, FieldName } from "@/charts/charts";
+import type { ColumnName, DataColumn, DataType, FieldName } from "@/charts/charts";
 import type { FeatureCollection } from "@turf/helpers";
 import type { BaseConfig } from "@/charts/BaseChart";
 import type { FieldSpec, FieldSpecs } from "@/lib/columnTypeHelpers";
@@ -290,7 +290,7 @@ export function useScatterRadius() {
 // type Tooltip = (PickingInfo) => string;
 export type P = [number, number];
 
-function useShouldFilterNaN() {
+export function useShouldFilterNaN() {
     const chart = useChart();
     const colorBySpec = chart.config.color_by;
     const colorByField: FieldSpec | undefined = colorBySpec
@@ -309,6 +309,19 @@ function useShouldFilterNaN() {
     // inside the filter (zeros as well as NaN/Inf), but does not by itself trigger filtering.
     const shouldFilter = hideMissing && isNumericColor;
     return { shouldFilter, colorColumn, fallbackOnZero };
+}
+
+export function getMissingColorFilterValue(
+    index: number,
+    colorColumn: DataColumn<DataType> | undefined,
+    shouldFilterMissing: boolean,
+    fallbackOnZero: boolean,
+): 0 | 1 {
+    if (!shouldFilterMissing || !colorColumn?.data) return 1;
+    const value = colorColumn.data[index];
+    if (!Number.isFinite(value)) return 0;
+    if (fallbackOnZero && value === 0) return 0;
+    return 1;
 }
 
 /**
@@ -511,15 +524,8 @@ export function useScatterplotLayer(modelMatrix: Matrix4, hoveredFieldId?: Field
                 // future work https://deck.gl/docs/developer-guide/performance#use-binary-data
                 //currently useFieldSpec is typed as DataColumn|undefined,
                 //if not undefined is guaranteed to be loaded but we may change how we manage lazy-loading.
-                getFilterValue:
-                    shouldFilterMissing && colorColumn?.data
-                        ? (i: number) => {
-                              const v = colorColumn.data[i];
-                              if (!Number.isFinite(v)) return 0;
-                              if (fallbackOnZero && v === 0) return 0;
-                              return 1;
-                          }
-                        : (_: number) => 1,
+                getFilterValue: (i: number) =>
+                    getMissingColorFilterValue(i, colorColumn, shouldFilterMissing, fallbackOnZero),
                 filterRange: [0.5, 1],
             } as any),
             updateTriggers: {


### PR DESCRIPTION
## Summary
- reuse the shared numeric missing-value filter logic in scatter state
- hide missing numeric color values on the grey scatter layer when filtered points are greyed out
- use a consistent grey fallback color instead of theme-dependent black or white for non-hidden missing values

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Missing and hidden values in numeric columns now display with consistent coloring, independent of the current theme (dark/light mode).

* **Improvements**
  * Enhanced handling of missing and NaN values in scatter plots with improved filtering logic for more reliable data visualization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->