### PR TITLE
wider brush handles so they don't disappear and are easier to click

### DIFF
--- a/src/react/components/HistogramWidget.tsx
+++ b/src/react/components/HistogramWidget.tsx
@@ -81,7 +81,7 @@ const useBrushX = (
         const svg = d3.select(ref.current);
         const xScale = createScale(xScaleType, minMax, [0, histoWidth]);
         const brush = d3.brushX()
-            .handleSize(0.5)
+            .handleSize(1.25)
             .extent([[0, -2], [histoWidth, histoHeight + 2]])
             .on("brush end", (event) => {
                 if (!event.sourceEvent) return;


### PR DESCRIPTION
Particularly in colour-channel histograms and when the extent of the brush range is close to the whole domain, the brush handles can disappear or almost disappear, and in general they are a bit fiddly to hit.

This is a fairly crude change – started trying to have something a bit more sophisticated that would be more consistent with selection vs colour-channel and while resizing etc, but internal state was getting into very bad glitchy behaviour and hopefully this tweak is enough to be a marginal UX improvement pending potential revisit later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the histogram widget's brush handle dimensions for improved usability and visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->