### PR TITLE
Add a SpatialData conversion report runner, fix bugs encountered with example data

### DIFF
--- a/python/mdvtools/cli.py
+++ b/python/mdvtools/cli.py
@@ -1,20 +1,8 @@
 import click
-import scanpy as sc
-import mudata as mu
 import shutil
 import zipfile
 import os
 from os.path import exists, join, basename
-from .conversions import (
-    convert_scanpy_to_mdv,
-    convert_mudata_to_mdv,
-    convert_vcf_to_mdv,
-    merge_projects,
-)
-from .spatial.conversion import (
-    convert_spatialdata_to_mdv,
-    SpatialDataConversionArgs,
-)
 
 def zip_and_remove(folder):
     """Zip a directory and delete the original."""
@@ -54,6 +42,9 @@ def cli():
 @click.option('--chatmdv', is_flag=True, help='Include the original Scanpy .h5ad file in the zipped project.')
 def convert_scanpy(folder, scanpy_object, max_dims, delete_existing, label, chunk_data, add_layer_data, gene_identifier_column, zip_output, chatmdv):
     """Convert Scanpy AnnData object to MDV format."""
+    import scanpy as sc
+    from .conversions import convert_scanpy_to_mdv
+
     adata = sc.read_h5ad(scanpy_object)
     convert_scanpy_to_mdv(folder, adata, max_dims, delete_existing, label, chunk_data, add_layer_data, gene_identifier_column)
 
@@ -74,6 +65,9 @@ def convert_scanpy(folder, scanpy_object, max_dims, delete_existing, label, chun
 @click.option('--zip', 'zip_output', is_flag=True, help='Zip the output folder and delete the original.')
 def convert_mudata(folder, mudata_object, max_dims, delete_existing, chunk_data, zip_output):
     """Convert MuData object to MDV format."""
+    import mudata as mu
+    from .conversions import convert_mudata_to_mdv
+
     mdata = mu.read(mudata_object)
     convert_mudata_to_mdv(folder, mdata, max_dims, delete_existing, chunk_data)
     if zip_output:
@@ -85,6 +79,8 @@ def convert_mudata(folder, mudata_object, max_dims, delete_existing, chunk_data,
 @click.option('--zip', 'zip_output', is_flag=True, help='Zip the output folder and delete the original.')
 def convert_vcf(folder, vcf_filename, zip_output):
     """Convert VCF file to MDV format."""
+    from .conversions import convert_vcf_to_mdv
+
     convert_vcf_to_mdv(folder, vcf_filename)
     if zip_output:
         zip_and_remove(folder)
@@ -120,19 +116,25 @@ def serve(folder, port):
 )
 def merge_project(base_project, extra_project, prefix, view_prefix):
     """Merge an existing MDV project into another project."""
+    from .conversions import merge_projects
+
     merge_projects(base_project, extra_project, prefix=prefix, view_prefix=view_prefix)
     click.echo(f"Merged '{extra_project}' into '{base_project}'.")
 
 @cli.command("convert-spatial")
 @click.argument('output_folder')
 @click.argument('spatialdata_path')
-@click.option('--preserve-existing', 'preserve_existing', is_flag=True, help='Preserve existing project data.')
-@click.option('--link', is_flag=True, help='Symlink to the original SpatialData objects.')
-@click.option('--output_geojson', is_flag=True, help='Output geojson for each region (this feature to be deprecated in favour of spatialdata.js layers with shapes).')
-@click.option('--serve', is_flag=True, help='Serve the project after conversion.')
-def convert_spatial(spatialdata_path, output_folder, preserve_existing, link, output_geojson, serve):
+@click.option('--preserve-existing', 'preserve_existing', is_flag=True, help='Preserve existing project data in the output folder instead of recreating it.')
+@click.option('--link', is_flag=True, help='Symlink the original SpatialData inputs into the project instead of copying them.')
+@click.option('--output_geojson/--no-output_geojson', 'output_geojson', default=True, help='Write transformed GeoJSON region files into the project images directory.')
+@click.option('--density', is_flag=True, help='Include density fields for gene expression in the default spatial view.')
+@click.option('--serve', is_flag=True, help='Serve the generated project after conversion.')
+@click.option('--verbose', is_flag=True, help='Show detailed per-dataset conversion output, transform decisions, and merged summaries.')
+def convert_spatial(spatialdata_path, output_folder, preserve_existing, link, output_geojson, density, serve, verbose):
     """Convert SpatialData objects to MDV format."""
     import tempfile
+    from .spatial.conversion import convert_spatialdata_to_mdv, SpatialDataConversionArgs
+
     with tempfile.TemporaryDirectory() as temp_folder:
         args = SpatialDataConversionArgs(
             spatialdata_path=spatialdata_path,
@@ -141,7 +143,9 @@ def convert_spatial(spatialdata_path, output_folder, preserve_existing, link, ou
             temp_folder=temp_folder,
             link=link,
             output_geojson=output_geojson,
+            density=density,
             serve=serve,
+            verbose=verbose,
         )
         convert_spatialdata_to_mdv(args)
 

--- a/python/mdvtools/cli.py
+++ b/python/mdvtools/cli.py
@@ -124,14 +124,15 @@ def merge_project(base_project, extra_project, prefix, view_prefix):
 @cli.command("convert-spatial")
 @click.argument('output_folder')
 @click.argument('spatialdata_path')
+@click.option('--batch', is_flag=True, help='Convert all child SpatialData stores in the given directory.')
 @click.option('--preserve-existing', 'preserve_existing', is_flag=True, help='Preserve existing project data in the output folder instead of recreating it.')
 @click.option('--link', is_flag=True, help='Symlink the original SpatialData source into the project instead of copying it.')
 @click.option('--output_geojson/--no-output_geojson', 'output_geojson', default=True, help='Write transformed GeoJSON region files into the project images directory.')
 @click.option('--density', is_flag=True, help='Include density fields for gene expression in the default spatial view.')
 @click.option('--serve', is_flag=True, help='Serve the generated project after conversion.')
 @click.option('--verbose', is_flag=True, help='Show detailed per-dataset conversion output, transform decisions, and merged summaries.')
-def convert_spatial(spatialdata_path, output_folder, preserve_existing, link, output_geojson, density, serve, verbose):
-    """Convert one SpatialData store, or a directory of SpatialData stores, to MDV format."""
+def convert_spatial(spatialdata_path, output_folder, batch, preserve_existing, link, output_geojson, density, serve, verbose):
+    """Convert one SpatialData store to MDV format, or use --batch for a directory of stores."""
     import tempfile
     from .spatial.conversion import convert_spatialdata_to_mdv, SpatialDataConversionArgs
 
@@ -139,6 +140,7 @@ def convert_spatial(spatialdata_path, output_folder, preserve_existing, link, ou
         args = SpatialDataConversionArgs(
             spatialdata_path=spatialdata_path,
             output_folder=output_folder,
+            batch=batch,
             preserve_existing=preserve_existing,
             temp_folder=temp_folder,
             link=link,

--- a/python/mdvtools/cli.py
+++ b/python/mdvtools/cli.py
@@ -125,13 +125,13 @@ def merge_project(base_project, extra_project, prefix, view_prefix):
 @click.argument('output_folder')
 @click.argument('spatialdata_path')
 @click.option('--preserve-existing', 'preserve_existing', is_flag=True, help='Preserve existing project data in the output folder instead of recreating it.')
-@click.option('--link', is_flag=True, help='Symlink the original SpatialData inputs into the project instead of copying them.')
+@click.option('--link', is_flag=True, help='Symlink the original SpatialData source into the project instead of copying it.')
 @click.option('--output_geojson/--no-output_geojson', 'output_geojson', default=True, help='Write transformed GeoJSON region files into the project images directory.')
 @click.option('--density', is_flag=True, help='Include density fields for gene expression in the default spatial view.')
 @click.option('--serve', is_flag=True, help='Serve the generated project after conversion.')
 @click.option('--verbose', is_flag=True, help='Show detailed per-dataset conversion output, transform decisions, and merged summaries.')
 def convert_spatial(spatialdata_path, output_folder, preserve_existing, link, output_geojson, density, serve, verbose):
-    """Convert SpatialData objects to MDV format."""
+    """Convert one SpatialData store, or a directory of SpatialData stores, to MDV format."""
     import tempfile
     from .spatial.conversion import convert_spatialdata_to_mdv, SpatialDataConversionArgs
 

--- a/python/mdvtools/conversions.py
+++ b/python/mdvtools/conversions.py
@@ -29,7 +29,8 @@ def convert_scanpy_to_mdv(
     label: str = "",
     chunk_data: bool = False,
     add_layer_data = True,
-    gene_identifier_column = None
+    gene_identifier_column = None,
+    gene_columns: List[dict[str, Any]] | None = None,
 ) -> MDVProject:
     """
     Convert a Scanpy AnnData object to MDV (Multi-Dimensional Viewer) format.
@@ -54,6 +55,7 @@ def convert_scanpy_to_mdv(
         gene_identifier_column: (str, optional) This is the gene column that the user will use to
             identify the gene. If not specified (default) than a column 'name' will be added that is
             created from the index (which is usaully the unique gene name)
+        gene_columns: (list[dict], optional) Column metadata overrides for the genes datasource.
     Returns:
         MDVProject: The configured MDV project object with the converted data
 
@@ -130,7 +132,7 @@ def convert_scanpy_to_mdv(
     #originally column had to be unique - but now is just text
     #need to coerce gene name column to unique
     #columns=[{"name":"name","datatype":"text16"}]
-    mdv.add_datasource(f"{label}genes", gene_table)
+    mdv.add_datasource(f"{label}genes", gene_table, columns=gene_columns)
 
     # link the two datasets
     mdv.add_rows_as_columns_link(f"{label}cells", f"{label}genes", gene_identifier_column, "Gene Expr")

--- a/python/mdvtools/mdvproject.py
+++ b/python/mdvtools/mdvproject.py
@@ -2466,7 +2466,10 @@ def add_column_to_group(
         )  # this is slooooow?
         if col["datatype"] == "integer" and col.get("original_dtype") == "uint32":
             try:
-                numeric = pandas.to_numeric(clean, errors="coerce")
+                numeric = numpy.asarray(
+                    pandas.to_numeric(clean, errors="coerce"),
+                    dtype=numpy.float64,
+                )
                 finite_numeric = numeric[numpy.isfinite(numeric)]
                 out_of_range = finite_numeric[finite_numeric > 16_777_216]
                 if len(out_of_range) != 0:
@@ -2648,12 +2651,14 @@ def add_column_to_group_from_polars(col_info, polars_series, h5_group, num_rows,
             if col_info["datatype"] == "integer" and col_info.get("original_dtype") == "UInt32":
                 try:
                     numeric = polars_series.cast(pl.Float64, strict=False).drop_nulls()
-                    out_of_range = numeric.filter(pl.col(numeric.name) > 16_777_216)
-                    if out_of_range.len() != 0:
+                    arr = numeric.to_numpy()
+                    finite = arr[np.isfinite(arr)]
+                    out_of_range = finite[finite > 16_777_216]
+                    if len(out_of_range) != 0:
                         col_info.setdefault("storage_warnings", []).append(
                             "uint32 -> float32 (integer): "
-                            f"{out_of_range.len()} value(s) exceed exact-integer range "
-                            f"(max={numeric.max():.0f}); precision loss possible."
+                            f"{len(out_of_range)} value(s) exceed exact-integer range "
+                            f"(max={float(finite.max()):.0f}); precision loss possible."
                         )
                 except Exception:
                     pass

--- a/python/mdvtools/mdvproject.py
+++ b/python/mdvtools/mdvproject.py
@@ -37,6 +37,11 @@ ColumnName = str  # NewType("ColumnName", str)
 Cols = Union[List[str], NewType("Params", List[ColumnName])]
 
 datatype_mappings = {
+    "int8": "integer",
+    "int16": "integer",
+    "uint8": "integer",
+    "uint16": "integer",
+    "uint32": "integer",
     "int64": "integer",
     "float64": "double",
     "float32": "double",

--- a/python/mdvtools/mdvproject.py
+++ b/python/mdvtools/mdvproject.py
@@ -2364,6 +2364,7 @@ def add_column_to_group(
     group (h5py.Group): The group to add the data to
     length (int): The length of the data
     """
+    col.setdefault("original_dtype", str(data.dtype))
 
     if (
         col["datatype"] == "text"
@@ -2463,6 +2464,19 @@ def add_column_to_group(
                     errors="coerce"
                 )
         )  # this is slooooow?
+        if col["datatype"] == "integer" and col.get("original_dtype") == "uint32":
+            try:
+                numeric = pandas.to_numeric(clean, errors="coerce")
+                finite_numeric = numeric[numpy.isfinite(numeric)]
+                out_of_range = finite_numeric[finite_numeric > 16_777_216]
+                if len(out_of_range) != 0:
+                    col.setdefault("storage_warnings", []).append(
+                        "uint32 -> float32 (integer): "
+                        f"{len(out_of_range)} value(s) exceed exact-integer range "
+                        f"(max={float(finite_numeric.max()):.0f}); precision loss possible."
+                    )
+            except Exception:
+                pass
         # faster but non=numeric values have to be certain values
         # clean=data.replace("?",numpy.NaN).replace("ND",numpy.NaN).replace("None",numpy.NaN)
         ds = group.create_dataset(col["field"], length, data=clean, dtype=dt)
@@ -2491,7 +2505,12 @@ def get_column_info(columns, dataframe, supplied_columns_only):
 
     if not supplied_columns_only:
         cols = [
-            {"datatype": datatype_mappings[d.name], "name": c, "field": c}
+            {
+                "datatype": datatype_mappings[d.name],
+                "name": c,
+                "field": c,
+                "original_dtype": d.name,
+            }
             for d, c in zip(dataframe.dtypes, dataframe.columns)
         ]
         # replace with user given column metadata
@@ -2554,6 +2573,7 @@ def add_column_to_group_from_polars(col_info, polars_series, h5_group, num_rows,
     import numpy as np
     
     field = col_info["field"]
+    col_info.setdefault("original_dtype", str(polars_series.dtype))
     
     # Handle different column types
     if col_info["datatype"] in ["text", "text16", "multitext"]:
@@ -2625,6 +2645,19 @@ def add_column_to_group_from_polars(col_info, polars_series, h5_group, num_rows,
                 # fillna is necessary because NaN cannot be cast to int
                 data = polars_series.fill_null(np.nan).to_numpy(zero_copy_only=False).astype(np.float32)
 
+            if col_info["datatype"] == "integer" and col_info.get("original_dtype") == "UInt32":
+                try:
+                    numeric = polars_series.cast(pl.Float64, strict=False).drop_nulls()
+                    out_of_range = numeric.filter(pl.col(numeric.name) > 16_777_216)
+                    if out_of_range.len() != 0:
+                        col_info.setdefault("storage_warnings", []).append(
+                            "uint32 -> float32 (integer): "
+                            f"{out_of_range.len()} value(s) exceed exact-integer range "
+                            f"(max={numeric.max():.0f}); precision loss possible."
+                        )
+                except Exception:
+                    pass
+
             # Create dataset
             h5_group.create_dataset(field, data=data)
 
@@ -2672,7 +2705,8 @@ def get_column_info_polars(columns, dataframe: "pl.DataFrame | pl.LazyFrame", su
             cols.append({
                 "datatype": mdv_dtype,
                 "name": col_name,
-                "field": col_name
+                "field": col_name,
+                "original_dtype": str(polars_dtype),
             })
         
         # Replace with user given column metadata

--- a/python/mdvtools/mdvproject.py
+++ b/python/mdvtools/mdvproject.py
@@ -2436,7 +2436,7 @@ def add_column_to_group(
         for i in range(0, length):
             b = i * maxv
             try:
-                v = data[i]  # may raise KeyError if data is None at this index
+                v = data.iloc[i] if hasattr(data, "iloc") else data[i]
                 if not isinstance(v, str) or v == "":
                     continue
                 vs = v.split(delim)
@@ -2469,6 +2469,10 @@ def add_column_to_group(
         # remove NaNs for min/max and quantiles - this needs to be tested with 'inf' as well.
         na = numpy.array(ds)
         na = na[numpy.isfinite(na)]
+        if na.size == 0:
+            col["minMax"] = [0.0, 0.0]
+            col["quantiles"] = {}
+            return
         col["minMax"] = [float(str(numpy.amin(na))), float(str(numpy.amax(na)))]
         quantiles = [0.001, 0.01, 0.05]
         col["quantiles"] = {}

--- a/python/mdvtools/spatial/conversion.py
+++ b/python/mdvtools/spatial/conversion.py
@@ -76,6 +76,31 @@ def _call_with_optional_stdout_suppressed(func, *args, **kwargs):
             logging.getLogger(logger_name).setLevel(original_level)
 
 
+def _discover_spatialdata_paths(spatialdata_path: str) -> list[str]:
+    source_path = os.path.abspath(spatialdata_path)
+
+    if not os.path.exists(source_path):
+        raise FileNotFoundError(f"SpatialData source does not exist: '{spatialdata_path}'")
+
+    if _try_read_zarr(source_path, emit_warning=False) is not None:
+        return [source_path]
+
+    if not os.path.isdir(source_path):
+        raise ValueError(
+            f"SpatialData source '{spatialdata_path}' is neither a readable SpatialData store nor a directory of stores."
+        )
+
+    sdata_paths = [
+        os.path.join(source_path, child)
+        for child in os.listdir(source_path)
+        if not child.startswith(".")
+    ]
+    sdata_paths = sorted(sdata_paths)
+    if len(sdata_paths) == 0:
+        raise ValueError(f"No SpatialData objects found in the folder '{spatialdata_path}'")
+    return sdata_paths
+
+
 @dataclass
 class ImageEntry:
     """
@@ -111,16 +136,24 @@ def add_readme_to_project(mdv: "MDVProject", adata: Optional["AnnData"], convers
         markdown += f"- **Preserve existing**: {conversion_args.preserve_existing}\n"
         markdown += f"- **Output GeoJSON**: {conversion_args.output_geojson}\n"
         markdown += f"- **Link spatial data**: {conversion_args.link}\n"
-        markdown += f"- **SpatialData path**: `{conversion_args.spatialdata_path}`\n"
+        markdown += f"- **SpatialData source**: `{conversion_args.spatialdata_path}`\n"
         markdown += "\n"
     
     markdown += "## SpatialData objects:\n\n"
     spatial_dir = os.path.join(mdv.dir, "spatial")
-    
-    for sdata_name in os.listdir(spatial_dir):
+
+    if _try_read_zarr(spatial_dir, emit_warning=False) is not None:
+        sdata_candidates = [(os.path.basename(os.path.normpath(spatial_dir)), spatial_dir)]
+    else:
+        sdata_candidates = [
+            (sdata_name, os.path.join(spatial_dir, sdata_name))
+            for sdata_name in os.listdir(spatial_dir)
+            if not sdata_name.startswith(".")
+        ]
+
+    for sdata_name, sdata_path in sdata_candidates:
         if sdata_name.startswith("."):
             continue
-        sdata_path = os.path.join(spatial_dir, sdata_name)
         if not os.path.exists(sdata_path):
             continue
         sdata = _try_read_zarr(sdata_path)
@@ -727,7 +760,7 @@ def _resolve_regions_for_table(sdata: "SpatialData", table_name: str, sdata_name
 
 
 
-def _try_read_zarr(path: str):# -> sd.SpatialData | None:
+def _try_read_zarr(path: str, emit_warning: bool = True):# -> sd.SpatialData | None:
     """
     Attempts to read arbitrary path string as a SpatialData object, falling back to None if it fails.
     """
@@ -750,7 +783,8 @@ def _try_read_zarr(path: str):# -> sd.SpatialData | None:
             if not _VERBOSE_OUTPUT:
                 ome_logger.setLevel(original_level)
     except Exception as e:
-        _emit(f"WARNING: Failed to read SpatialData object from {path}: '{e}'")
+        if emit_warning:
+            _emit(f"WARNING: Failed to read SpatialData object from {path}: '{e}'")
         return None
 
 
@@ -875,17 +909,7 @@ def convert_spatialdata_to_mdv(args: SpatialDataConversionArgs):
         date_str = build_info["git_commit_date"] or build_info["build_date"] or "unknown"
         _progress(f"MDV conversion (commit: {commit_short}, date: {date_str})")
     
-
-    sdata_paths = [
-        os.path.join(args.spatialdata_path, f)
-        for f in os.listdir(args.spatialdata_path)
-        if not f.startswith(".")
-    ]
-    sdata_paths = sorted(sdata_paths)
-    if len(sdata_paths) == 0:
-        # we haven't actually yet determined whether any of the paths are really sdata...
-        # this happens when the folder is totally empty.
-        raise ValueError(f"No SpatialData objects found in the folder '{args.spatialdata_path}'")
+    sdata_paths = _discover_spatialdata_paths(args.spatialdata_path)
 
     _progress(
         f"Converting {len(sdata_paths)} SpatialData entr{'y' if len(sdata_paths) == 1 else 'ies'} "
@@ -1058,7 +1082,11 @@ def convert_spatialdata_to_mdv(args: SpatialDataConversionArgs):
 if __name__ == "__main__":
     # take an array of spatialdata objects from a folder and convert them to mdv.
     parser = argparse.ArgumentParser(description="Convert SpatialData to MDV format")
-    parser.add_argument("spatialdata_path", type=str, help="Folder containing SpatialData objects")
+    parser.add_argument(
+        "spatialdata_path",
+        type=str,
+        help="Path to a SpatialData store or to a directory containing multiple SpatialData stores",
+    )
     parser.add_argument("output_folder", type=str, help="Output folder for MDV project")
     parser.add_argument("--link", action="store_true", help="Symlink the original SpatialData inputs into the project instead of copying them")
     parser.add_argument("--preserve-existing", action="store_true", help="Preserve existing project data in the output folder instead of recreating it")

--- a/python/mdvtools/spatial/conversion.py
+++ b/python/mdvtools/spatial/conversion.py
@@ -1,5 +1,9 @@
 import argparse
+import contextlib
+import io
+import logging
 import os
+import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional
 import numpy as np
@@ -21,14 +25,57 @@ class SpatialDataConversionArgs:
     output_folder: str
     temp_folder: str
     preserve_existing: bool = False
-    output_geojson: bool = False
+    output_geojson: bool = True
     serve: bool = False
     link: bool = False
     density: bool = False
     point_transform: str = "auto"
+    verbose: bool = False
 
 
 REGION_FIELD = "spatial_region"
+_VERBOSE_OUTPUT = True
+
+
+def _set_verbose_output(verbose: bool) -> None:
+    global _VERBOSE_OUTPUT
+    _VERBOSE_OUTPUT = verbose
+
+
+def _emit(message: str, *, verbose_only: bool = False) -> None:
+    if verbose_only and not _VERBOSE_OUTPUT:
+        return
+    print(message)
+
+
+def _progress(message: str) -> None:
+    print(message, flush=True)
+
+
+def _call_with_optional_stdout_suppressed(func, *args, **kwargs):
+    if _VERBOSE_OUTPUT:
+        return func(*args, **kwargs)
+
+    original_levels: dict[str, int] = {}
+    quiet_loggers = {
+        "mdvtools.mdvproject": logging.WARNING,
+        "mdvtools.conversions": logging.WARNING,
+        "ome_zarr.reader": logging.ERROR,
+    }
+
+    for logger_name, quiet_level in quiet_loggers.items():
+        logger = logging.getLogger(logger_name)
+        original_levels[logger_name] = logger.level
+        logger.setLevel(quiet_level)
+
+    try:
+        with contextlib.redirect_stdout(io.StringIO()):
+            return func(*args, **kwargs)
+    finally:
+        for logger_name, original_level in original_levels.items():
+            logging.getLogger(logger_name).setLevel(original_level)
+
+
 @dataclass
 class ImageEntry:
     """
@@ -71,6 +118,8 @@ def add_readme_to_project(mdv: "MDVProject", adata: Optional["AnnData"], convers
     spatial_dir = os.path.join(mdv.dir, "spatial")
     
     for sdata_name in os.listdir(spatial_dir):
+        if sdata_name.startswith("."):
+            continue
         sdata_path = os.path.join(spatial_dir, sdata_name)
         if not os.path.exists(sdata_path):
             continue
@@ -105,7 +154,7 @@ def add_readme_to_project(mdv: "MDVProject", adata: Optional["AnnData"], convers
     #     markdown += f"\n{create_anndata_markdown(adata)}"
     with open(os.path.join(mdv.dir, "README.md"), "w") as f:
         f.write(markdown)
-    print(f"README.md written to {os.path.join(mdv.dir, 'README.md')}")
+    _emit(f"README.md written to {os.path.join(mdv.dir, 'README.md')}", verbose_only=True)
     textbox = TextBox(title="SpatialData conversion information", param=[], size=[792, 472], position=[10, 10])
     textbox.set_text(markdown)
     mdv.set_view("Data summary", {"initialCharts": {"cells": [textbox.plot_data]}})
@@ -137,7 +186,7 @@ def _get_transformation_between_coordinate_systems_safe(
     Safely get transformation between coordinate systems, handling multiple equal paths.
     
     When multiple equal-length shortest paths are found, this function automatically
-    selects the first path and logs a warning, rather than raising an error.
+    selects the first path and logs an informational message, rather than raising an error.
     
     Args:
         sdata: SpatialData object
@@ -163,10 +212,11 @@ def _get_transformation_between_coordinate_systems_safe(
             # Re-raise if it's a different error
             raise
         
-        # Log warning about auto-selecting path
-        print(
-            f"WARNING: Multiple equal transformation paths found. "
-            f"Automatically selecting the first path. Error details: {error_msg}"
+        # This is benign for current behavior: we only need one shortest path.
+        _emit(
+            "INFO: Multiple equal transformation paths found. "
+            f"Automatically selecting the first shortest path. Details: {error_msg}",
+            verbose_only=True,
         )
         
         # Manually build graph and select first shortest path
@@ -232,8 +282,11 @@ def _transform_table_coordinates(adata: "AnnData", region_to_image: dict[str, Im
     from spatialdata.transformations import Identity
     if "spatial" not in adata.obsm:
         # todo: proper support for non-spatial tables, add tests.
-        print("WARNING: No spatial coordinates found in obsm['spatial']")
-        print("We should be able to handle this case, but it is not supported or tested yet, results may be undesired.")
+        _emit("WARNING: No spatial coordinates found in obsm['spatial']")
+        _emit(
+            "WARNING: This table is being treated as non-spatial for now; "
+            "results may be incomplete.",
+        )
         return adata
     # todo: support non-2d cases...
     axes = ("x", "y")
@@ -241,7 +294,7 @@ def _transform_table_coordinates(adata: "AnnData", region_to_image: dict[str, Im
     coords_homogeneous = np.column_stack([adata.obsm["spatial"], np.ones(adata.obsm["spatial"].shape[0], dtype=float)])
     _r, region_element, _instance_key = get_table_keys(adata)
 
-    transformed_coords = np.full_like(adata.obsm["spatial"], fill_value=np.nan)
+    transformed_coords = np.full(adata.obsm["spatial"].shape, fill_value=np.nan, dtype=float)
     region_ids = np.empty(adata.n_obs, dtype=object)
 
     for r, entry in region_to_image.items():
@@ -493,7 +546,10 @@ def _resolve_regions_for_table(sdata: "SpatialData", table_name: str, sdata_name
     adata.uns.setdefault("mdv", {})
     # Early return for non-spatial tables
     if "spatial" not in adata.obsm:
-        print(f"INFO: Skipping region resolution for non-spatial table '{table_name}' in '{sdata_name}'")
+        _emit(
+            f"INFO: Skipping region resolution for non-spatial table '{table_name}' in '{sdata_name}'",
+            verbose_only=True,
+        )
         # Mark as non-spatial for downstream handling
         adata.uns["mdv"]["is_spatial"] = False
         return adata
@@ -590,7 +646,7 @@ def _resolve_regions_for_table(sdata: "SpatialData", table_name: str, sdata_name
 
         if not img_entries:
             # raise ValueError(f"No images found for region '{r}' in '{sdata_name}'")
-            print(f"WARNING: No images found for region '{r}' in '{sdata_name}'")
+            _emit(f"WARNING: No images found for region '{r}' in '{sdata_name}'")
             continue
         
         for j, entry in enumerate(img_entries):
@@ -605,10 +661,11 @@ def _resolve_regions_for_table(sdata: "SpatialData", table_name: str, sdata_name
             transform_provenance[region_id] = best_transform_metadata
             # Log the transform decision
             xenium_note = " (Xenium detected)" if best_transform_metadata.get("xenium_detected", False) else ""
-            print(
+            _emit(
                 f"INFO: Table '{table_name}' region '{r}' using point_transform mode '{best_transform_metadata['mode']}'"
                 f"{xenium_note}: {best_transform_metadata['source_element']} -> {best_transform_metadata['target_element']} "
-                f"({best_transform_metadata['transform_type']})"
+                f"({best_transform_metadata['transform_type']})",
+                verbose_only=True,
             )
         all_regions[region_id] = {
             "spatial": {
@@ -634,7 +691,10 @@ def _resolve_regions_for_table(sdata: "SpatialData", table_name: str, sdata_name
             from geopandas import GeoDataFrame
             # xenium hack... we want cell_boundaries, not cell_circles which is the annotated element...
             if "cell_boundaries" in sdata.shapes:
-                print(f"Xenium hack... using cell_boundaries for geojson output for region '{r}' in '{sdata_name}'")
+                _emit(
+                    f"INFO: Using cell_boundaries for geojson output for region '{r}' in '{sdata_name}'",
+                    verbose_only=True,
+                )
                 annotated = sdata["cell_boundaries"]
             
             if isinstance(annotated, GeoDataFrame):
@@ -646,9 +706,12 @@ def _resolve_regions_for_table(sdata: "SpatialData", table_name: str, sdata_name
                 all_regions[region_id]["json"] = f"images/{name}"
                 with open(path, "w") as f:
                     f.write(geojson)
-                    print(f"Wrote geojson for region '{region_id}' to {path}")
+                    _emit(f"Wrote geojson for region '{region_id}' to {path}", verbose_only=True)
             else:
-                print(f"WARNING: No geojson output for region '{r}' in '{sdata_name}' because it is not a GeoDataFrame")
+                _emit(
+                    f"INFO: No geojson output for region '{r}' in '{sdata_name}' because it is not a GeoDataFrame",
+                    verbose_only=True,
+                )
         
         region_to_image[r] = best_img
 
@@ -670,9 +733,24 @@ def _try_read_zarr(path: str):# -> sd.SpatialData | None:
     """
     try:
         import spatialdata as sd
-        return sd.read_zarr(path)
+        ome_logger = logging.getLogger("ome_zarr.reader")
+        original_level = ome_logger.level
+        if not _VERBOSE_OUTPUT:
+            ome_logger.setLevel(logging.ERROR)
+
+        try:
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "ignore",
+                    message="Variable names are not unique.*",
+                    category=UserWarning,
+                )
+                return sd.read_zarr(path)
+        finally:
+            if not _VERBOSE_OUTPUT:
+                ome_logger.setLevel(original_level)
     except Exception as e:
-        print(f"Warning: Failed to read SpatialData object from {path}: '{e}'")
+        _emit(f"WARNING: Failed to read SpatialData object from {path}: '{e}'")
         return None
 
 
@@ -681,9 +759,10 @@ def _ensure_unique_var_names(adata: "AnnData", table_name: str, sdata_name: str)
         return
 
     duplicate_count = int(adata.var_names.duplicated().sum())
-    print(
-        f"WARNING: Table '{table_name}' in '{sdata_name}' has "
-        f"{duplicate_count} duplicate var_names. Making them unique before concatenation."
+    _emit(
+        f"INFO: Table '{table_name}' in '{sdata_name}' has "
+        f"{duplicate_count} duplicate var_names. Making them unique before concatenation.",
+        verbose_only=True,
     )
     adata.var_names_make_unique()
 
@@ -693,7 +772,37 @@ def _concat_spatial_tables(adata_objects: list["AnnData"]) -> "AnnData":
 
     # Tables from different technologies often have disjoint gene sets, so an
     # inner join can collapse the merged object down to zero genes.
-    return ad_concat(adata_objects, index_unique="_", join="outer", fill_value=0)
+    has_raw_flags = [adata.raw is not None for adata in adata_objects]
+    if any(has_raw_flags) and not all(has_raw_flags):
+        _emit(
+            "INFO: Some input tables have .raw while others do not; merged .raw is omitted.",
+            verbose_only=True,
+        )
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=r"Only some AnnData objects have `.raw` attribute, not concatenating `.raw` attributes\.",
+            category=UserWarning,
+        )
+        return ad_concat(adata_objects, index_unique="_", join="outer", fill_value=0)
+
+
+def _build_gene_source_column(
+    merged_adata: "AnnData",
+    gene_sources: dict[str, set[str]],
+) -> list[dict[str, str]]:
+    merged_adata.var["object_source"] = [
+        "|".join(sorted(gene_sources.get(str(gene_name), set())))
+        for gene_name in merged_adata.var_names
+    ]
+    return [
+        {
+            "name": "object_source",
+            "datatype": "multitext",
+            "delimiter": "|",
+        }
+    ]
 
 def _set_default_image_view(mdv: "MDVProject", args: SpatialDataConversionArgs):
     """
@@ -710,7 +819,7 @@ def _set_default_image_view(mdv: "MDVProject", args: SpatialDataConversionArgs):
     else:
         raise ValueError("No region with a viv_image found")
 
-    print(f"Using region '{region_name}' for default view")
+    _emit(f"Using region '{region_name}' for default view", verbose_only=True)
     with open(os.path.join(os.path.dirname(__file__), "spatial_view_template.json"), "r") as f:
         view_str = f.read().replace("<SPATIAL_REGION_NAME>", region_name)
         density = """
@@ -756,36 +865,44 @@ def convert_spatialdata_to_mdv(args: SpatialDataConversionArgs):
     from mdvtools.markdown_utils import create_project_markdown
     from mdvtools.build_info import get_build_info
     from mdvtools.spatial.mermaid import sdata_to_mermaid
+
+    _set_verbose_output(args.verbose)
     
     # Print version banner if build info is available
     build_info = get_build_info()
     if build_info["source"] != "unknown" and build_info["git_commit_hash"]:
         commit_short = build_info["git_commit_hash"][:8]
         date_str = build_info["git_commit_date"] or build_info["build_date"] or "unknown"
-        print(f"MDV conversion (commit: {commit_short}, date: {date_str})")
+        _progress(f"MDV conversion (commit: {commit_short}, date: {date_str})")
     
 
-    # we could do a nicer glob thing here, but I don't want to test that right now.
     sdata_paths = [
         os.path.join(args.spatialdata_path, f)
         for f in os.listdir(args.spatialdata_path)
+        if not f.startswith(".")
     ]
-    # sdata_paths = [f for f in sdata_paths if f.endswith(".zarr")]
     sdata_paths = sorted(sdata_paths)
     if len(sdata_paths) == 0:
         # we haven't actually yet determined whether any of the paths are really sdata...
         # this happens when the folder is totally empty.
         raise ValueError(f"No SpatialData objects found in the folder '{args.spatialdata_path}'")
+
+    _progress(
+        f"Converting {len(sdata_paths)} SpatialData entr{'y' if len(sdata_paths) == 1 else 'ies'} "
+        f"from '{args.spatialdata_path}' to '{args.output_folder}'"
+    )
     
     sdata_objects: dict[str, SpatialData] = {}
     adata_objects: list[AnnData] = []
     all_regions: dict[str, dict] = {}
+    gene_sources: dict[str, set[str]] = {}
     names: set[str] = set()
     
     # Process each SpatialData object sequentially
     # Removed ProcessPoolExecutor to avoid pickling issues with lazy zarr arrays in SpatialData objects
-    for sdata_path in sdata_paths:
+    for index, sdata_path in enumerate(sdata_paths, start=1):
         sdata_name = os.path.basename(sdata_path)
+        _progress(f"[{index}/{len(sdata_paths)}] Processing {sdata_name}")
         sdata = _try_read_zarr(sdata_path)
         if sdata is None:
             continue
@@ -796,8 +913,8 @@ def convert_spatialdata_to_mdv(args: SpatialDataConversionArgs):
             )
         names.add(sdata_name)
         
-        print(f"## SpatialData object representation:\n\n```\n{sdata}\n```\n")
-        print(f"## Mermaid diagram:\n\n{sdata_to_mermaid(sdata)}\n")
+        _emit(f"## SpatialData object representation:\n\n```\n{sdata}\n```\n", verbose_only=True)
+        _emit(f"## Mermaid diagram:\n\n{sdata_to_mermaid(sdata)}\n", verbose_only=True)
         
         # Process tables and modify them in-place
         # These modifications will be:
@@ -809,6 +926,8 @@ def convert_spatialdata_to_mdv(args: SpatialDataConversionArgs):
             _ensure_unique_var_names(adata, table_name, sdata_name)
             adata.obs["spatialdata_path"] = sdata_name
             adata.obs["table_name"] = table_name
+            for gene_name in adata.var_names:
+                gene_sources.setdefault(str(gene_name), set()).add(sdata_name)
             adata_objects.append(adata)
             if "regions" in adata.uns.get("mdv", {}):
                 all_regions.update(adata.uns["mdv"]["regions"])
@@ -823,11 +942,20 @@ def convert_spatialdata_to_mdv(args: SpatialDataConversionArgs):
     spatial_tables = [ad for ad in adata_objects if ad.uns.get("mdv", {}).get("is_spatial", False)]
 
     if len(spatial_tables) == 0:
-        print("WARNING: No spatial tables found. Skipping spatial-specific metadata and view setup.")
+        _emit(
+            "INFO: No spatial tables found. Creating a merged project without spatial metadata or a default image view."
+        )
         # Still merge and convert, but skip spatial operations
+        _progress(f"Merging {len(adata_objects)} table(s) with outer gene union")
         merged_adata = _concat_spatial_tables(adata_objects)
-        mdv = convert_scanpy_to_mdv(
-            args.output_folder, merged_adata, delete_existing=not args.preserve_existing
+        gene_columns = _build_gene_source_column(merged_adata, gene_sources)
+        _progress("Writing MDV project")
+        mdv = _call_with_optional_stdout_suppressed(
+            convert_scanpy_to_mdv,
+            args.output_folder,
+            merged_adata,
+            delete_existing=not args.preserve_existing,
+            gene_columns=gene_columns,
         )
         # ... write sdata objects but skip region metadata and _set_default_image_view
         return mdv
@@ -837,20 +965,33 @@ def convert_spatialdata_to_mdv(args: SpatialDataConversionArgs):
         raise ValueError("Spatial tables found but no regions could be resolved - this indicates a problem with the data")
 
     ## todo - try to make sure we have sparse CSC matrices if possible.
+    _progress(f"Merging {len(adata_objects)} table(s) with outer gene union")
     merged_adata = _concat_spatial_tables(adata_objects)
-    mdv = convert_scanpy_to_mdv(
-        args.output_folder, merged_adata, delete_existing=not args.preserve_existing
+    gene_columns = _build_gene_source_column(merged_adata, gene_sources)
+    _progress("Writing MDV project")
+    mdv = _call_with_optional_stdout_suppressed(
+        convert_scanpy_to_mdv,
+        args.output_folder,
+        merged_adata,
+        delete_existing=not args.preserve_existing,
+        gene_columns=gene_columns,
     )
     if args.link:
-        print(f"Linking spatialdata object path '{args.spatialdata_path}' to '{mdv.dir}/spatial'")
-        print("NOTE: Original SpatialData files are not modified. Table modifications exist only in the merged MDV project.")
+        _progress(f"Linking spatial inputs into '{mdv.dir}/spatial'")
+        _emit(
+            "NOTE: Original SpatialData files are not modified. Table modifications exist only in the merged MDV project.",
+            verbose_only=True,
+        )
         os.symlink(
             os.path.abspath(args.spatialdata_path), 
             os.path.join(mdv.dir, "spatial"), target_is_directory=True
         )
     else:
-        print(f"Copying spatialdata object path '{args.spatialdata_path}' to '{mdv.dir}/spatial'")
-        print("NOTE: SpatialData objects are written with modified tables (added obs columns and uns metadata).")
+        _progress(f"Copying spatial inputs into '{mdv.dir}/spatial'")
+        _emit(
+            "NOTE: SpatialData objects are written with modified tables (added obs columns and uns metadata).",
+            verbose_only=True,
+        )
         os.makedirs(
             f"{mdv.dir}/spatial", exist_ok=True
         )  # pretty sure sdata.write will do this anyway
@@ -865,6 +1006,8 @@ def convert_spatialdata_to_mdv(args: SpatialDataConversionArgs):
         import shutil
         dest_dir = os.path.join(mdv.dir, "images")
         os.makedirs(dest_dir, exist_ok=True)
+        geojson_files = [f for f in os.listdir(args.temp_folder) if f.endswith(".geo.json")]
+        _progress(f"Writing {len(geojson_files)} GeoJSON file{'s' if len(geojson_files) != 1 else ''}")
         for f in os.listdir(args.temp_folder):
             shutil.move(os.path.join(args.temp_folder, f), os.path.join(dest_dir, f))
 
@@ -902,26 +1045,32 @@ def convert_spatialdata_to_mdv(args: SpatialDataConversionArgs):
     }
     mdv.set_datasource_metadata(cells_md)
     _set_default_image_view(mdv, args)
-    print(f"## Merged AnnData object representation:\n\n```\n{merged_adata}\n```\n")
-    print(f"## Project markdown:\n\n{create_project_markdown(mdv, False)}\n\n---")
+    _emit(f"## Merged AnnData object representation:\n\n```\n{merged_adata}\n```\n", verbose_only=True)
+    _emit(f"## Project markdown:\n\n{create_project_markdown(mdv, False)}\n\n---", verbose_only=True)
     add_readme_to_project(mdv, merged_adata, args)
     if args.serve:
-        print(f"Serving project at {args.output_folder}")
+        _progress(f"Serving project at {args.output_folder}")
         serve_project(mdv)
     else:
-        print(f"Project saved to {args.output_folder}")
+        _progress(f"Project saved to {args.output_folder}")
 
     return mdv
 if __name__ == "__main__":
     # take an array of spatialdata objects from a folder and convert them to mdv.
     parser = argparse.ArgumentParser(description="Convert SpatialData to MDV format")
-    parser.add_argument("spatialdata_path", type=str, help="Path to SpatialData data")
+    parser.add_argument("spatialdata_path", type=str, help="Folder containing SpatialData objects")
     parser.add_argument("output_folder", type=str, help="Output folder for MDV project")
-    parser.add_argument("--link", action="store_true", help="Symlink to the original SpatialData objects")
-    parser.add_argument("--preserve-existing", action="store_true", help="Preserve existing project data")
-    parser.add_argument("--output_geojson", action="store_true", help="Output geojson for each region (this feature to be deprecated in favour of spatialdata.js layers with shapes)")
-    parser.add_argument("--density", action="store_true", help="Include density fields for gene expression in default view")
-    parser.add_argument("--serve", action="store_true", help="Serve the project after conversion")
+    parser.add_argument("--link", action="store_true", help="Symlink the original SpatialData inputs into the project instead of copying them")
+    parser.add_argument("--preserve-existing", action="store_true", help="Preserve existing project data in the output folder instead of recreating it")
+    parser.add_argument(
+        "--output_geojson",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Write transformed GeoJSON region files into the project images directory",
+    )
+    parser.add_argument("--density", action="store_true", help="Include density fields for gene expression in the default spatial view")
+    parser.add_argument("--serve", action="store_true", help="Serve the generated project after conversion")
+    parser.add_argument("--verbose", action="store_true", help="Show detailed per-dataset conversion output, transform decisions, and merged summaries")
     parser.add_argument(
         "--point-transform",
         type=str,
@@ -937,10 +1086,6 @@ if __name__ == "__main__":
         )
     )
     args = parser.parse_args()
-    print(f"Converting SpatialData from '{args.spatialdata_path}' to {args.output_folder}")
-    print(f"Preserving existing project data: {args.preserve_existing}")
-    print(f"Serving the project after conversion: {args.serve}")
-    print(f"Converting {len(os.listdir(args.spatialdata_path))} potential SpatialData objects")
     import tempfile
     with tempfile.TemporaryDirectory() as temp_folder:
         args.temp_folder = temp_folder

--- a/python/mdvtools/spatial/conversion.py
+++ b/python/mdvtools/spatial/conversion.py
@@ -1057,7 +1057,7 @@ def convert_spatialdata_to_mdv(args: SpatialDataConversionArgs):
         os.makedirs(dest_dir, exist_ok=True)
         geojson_files = [f for f in os.listdir(args.temp_folder) if f.endswith(".geo.json")]
         _progress(f"Writing {len(geojson_files)} GeoJSON file{'s' if len(geojson_files) != 1 else ''}")
-        for f in os.listdir(args.temp_folder):
+        for f in geojson_files:
             shutil.move(os.path.join(args.temp_folder, f), os.path.join(dest_dir, f))
 
     mdv.set_editable()

--- a/python/mdvtools/spatial/conversion.py
+++ b/python/mdvtools/spatial/conversion.py
@@ -1026,13 +1026,17 @@ def convert_spatialdata_to_mdv(args: SpatialDataConversionArgs):
             merged_adata,
             delete_existing=not args.preserve_existing,
             gene_columns=gene_columns,
-        )
+    )
     if args.link:
-        os.makedirs(os.path.join(mdv.dir, "spatial"), exist_ok=True)
         if single_source_input:
+            os.makedirs(os.path.join(mdv.dir, "spatial"), exist_ok=True)
             link_target = os.path.join(mdv.dir, "spatial", os.path.basename(sdata_paths[0]))
         else:
             link_target = os.path.join(mdv.dir, "spatial")
+        if os.path.lexists(link_target):
+            raise FileExistsError(
+                f"Cannot create symlink at '{link_target}' because the path already exists."
+            )
         _progress(f"Linking spatial inputs into '{link_target}'")
         _emit(
             "NOTE: Original SpatialData files are not modified. Table modifications exist only in the merged MDV project.",

--- a/python/mdvtools/spatial/conversion.py
+++ b/python/mdvtools/spatial/conversion.py
@@ -675,6 +675,18 @@ def _try_read_zarr(path: str):# -> sd.SpatialData | None:
         print(f"Warning: Failed to read SpatialData object from {path}: '{e}'")
         return None
 
+
+def _ensure_unique_var_names(adata: "AnnData", table_name: str, sdata_name: str) -> None:
+    if adata.var_names.is_unique:
+        return
+
+    duplicate_count = int(adata.var_names.duplicated().sum())
+    print(
+        f"WARNING: Table '{table_name}' in '{sdata_name}' has "
+        f"{duplicate_count} duplicate var_names. Making them unique before concatenation."
+    )
+    adata.var_names_make_unique()
+
 def _set_default_image_view(mdv: "MDVProject", args: SpatialDataConversionArgs):
     """
     Uses a template view for the default view of the spatial data.
@@ -787,6 +799,7 @@ def convert_spatialdata_to_mdv(args: SpatialDataConversionArgs):
         # - NOT written to original files (when args.link is True, files are symlinked)
         for table_name, adata in sdata.tables.items():
             _resolve_regions_for_table(sdata, table_name, sdata_name, args)
+            _ensure_unique_var_names(adata, table_name, sdata_name)
             adata.obs["spatialdata_path"] = sdata_name
             adata.obs["table_name"] = table_name
             adata_objects.append(adata)

--- a/python/mdvtools/spatial/conversion.py
+++ b/python/mdvtools/spatial/conversion.py
@@ -24,6 +24,7 @@ class SpatialDataConversionArgs:
     spatialdata_path: str
     output_folder: str
     temp_folder: str
+    batch: bool = False
     preserve_existing: bool = False
     output_geojson: bool = True
     serve: bool = False
@@ -76,7 +77,7 @@ def _call_with_optional_stdout_suppressed(func, *args, **kwargs):
             logging.getLogger(logger_name).setLevel(original_level)
 
 
-def _discover_spatialdata_paths(spatialdata_path: str) -> list[str]:
+def _discover_spatialdata_paths(spatialdata_path: str, batch: bool = False) -> list[str]:
     source_path = os.path.abspath(spatialdata_path)
 
     if not os.path.exists(source_path):
@@ -85,9 +86,18 @@ def _discover_spatialdata_paths(spatialdata_path: str) -> list[str]:
     try:
         root_sdata = _try_read_zarr(source_path, emit_warning=False, raise_on_error=True)
     except Exception as error:
-        raise ValueError(
-            f"Failed to read SpatialData source '{spatialdata_path}' at '{source_path}': {error}"
-        ) from error
+        try:
+            from zarr.errors import GroupNotFoundError
+        except Exception:
+            GroupNotFoundError = None  # type: ignore
+
+        if not os.path.isdir(source_path) or (
+            GroupNotFoundError is not None and not isinstance(error, GroupNotFoundError)
+        ):
+            raise ValueError(
+                f"Failed to read SpatialData source '{spatialdata_path}' at '{source_path}': {error}"
+            ) from error
+        root_sdata = None
 
     if root_sdata is not None:
         return [source_path]
@@ -95,6 +105,11 @@ def _discover_spatialdata_paths(spatialdata_path: str) -> list[str]:
     if not os.path.isdir(source_path):
         raise ValueError(
             f"SpatialData source '{spatialdata_path}' is neither a readable SpatialData store nor a directory of stores."
+        )
+
+    if not batch:
+        raise ValueError(
+            f"SpatialData source '{spatialdata_path}' is a directory. Pass --batch to convert all child SpatialData stores."
         )
 
     sdata_paths = [
@@ -148,6 +163,7 @@ def add_readme_to_project(mdv: "MDVProject", adata: Optional["AnnData"], convers
         markdown += f"- **Preserve existing**: {conversion_args.preserve_existing}\n"
         markdown += f"- **Output GeoJSON**: {conversion_args.output_geojson}\n"
         markdown += f"- **Link spatial data**: {conversion_args.link}\n"
+        markdown += f"- **Batch mode**: {conversion_args.batch}\n"
         markdown += f"- **SpatialData source**: `{conversion_args.spatialdata_path}`\n"
         markdown += "\n"
     
@@ -937,7 +953,7 @@ def convert_spatialdata_to_mdv(args: SpatialDataConversionArgs):
         date_str = build_info["git_commit_date"] or build_info["build_date"] or "unknown"
         _progress(f"MDV conversion (commit: {commit_short}, date: {date_str})")
     
-    sdata_paths = _discover_spatialdata_paths(args.spatialdata_path)
+    sdata_paths = _discover_spatialdata_paths(args.spatialdata_path, batch=args.batch)
     single_source_input = _is_single_spatialdata_source(args.spatialdata_path, sdata_paths)
 
     _progress(
@@ -1114,9 +1130,10 @@ if __name__ == "__main__":
     parser.add_argument(
         "spatialdata_path",
         type=str,
-        help="Path to a SpatialData store or to a directory containing multiple SpatialData stores",
+        help="Path to a SpatialData store, or with --batch a directory containing multiple SpatialData stores",
     )
     parser.add_argument("output_folder", type=str, help="Output folder for MDV project")
+    parser.add_argument("--batch", action="store_true", help="Convert all child SpatialData stores in the given directory")
     parser.add_argument("--link", action="store_true", help="Symlink the original SpatialData inputs into the project instead of copying them")
     parser.add_argument("--preserve-existing", action="store_true", help="Preserve existing project data in the output folder instead of recreating it")
     parser.add_argument(

--- a/python/mdvtools/spatial/conversion.py
+++ b/python/mdvtools/spatial/conversion.py
@@ -101,6 +101,11 @@ def _discover_spatialdata_paths(spatialdata_path: str) -> list[str]:
     return sdata_paths
 
 
+def _is_single_spatialdata_source(spatialdata_path: str, sdata_paths: list[str]) -> bool:
+    source_path = os.path.abspath(spatialdata_path)
+    return len(sdata_paths) == 1 and os.path.abspath(sdata_paths[0]) == source_path
+
+
 @dataclass
 class ImageEntry:
     """
@@ -910,6 +915,7 @@ def convert_spatialdata_to_mdv(args: SpatialDataConversionArgs):
         _progress(f"MDV conversion (commit: {commit_short}, date: {date_str})")
     
     sdata_paths = _discover_spatialdata_paths(args.spatialdata_path)
+    single_source_input = _is_single_spatialdata_source(args.spatialdata_path, sdata_paths)
 
     _progress(
         f"Converting {len(sdata_paths)} SpatialData entr{'y' if len(sdata_paths) == 1 else 'ies'} "
@@ -1001,14 +1007,20 @@ def convert_spatialdata_to_mdv(args: SpatialDataConversionArgs):
         gene_columns=gene_columns,
     )
     if args.link:
-        _progress(f"Linking spatial inputs into '{mdv.dir}/spatial'")
+        os.makedirs(os.path.join(mdv.dir, "spatial"), exist_ok=True)
+        if single_source_input:
+            link_target = os.path.join(mdv.dir, "spatial", os.path.basename(sdata_paths[0]))
+        else:
+            link_target = os.path.join(mdv.dir, "spatial")
+        _progress(f"Linking spatial inputs into '{link_target}'")
         _emit(
             "NOTE: Original SpatialData files are not modified. Table modifications exist only in the merged MDV project.",
             verbose_only=True,
         )
         os.symlink(
-            os.path.abspath(args.spatialdata_path), 
-            os.path.join(mdv.dir, "spatial"), target_is_directory=True
+            os.path.abspath(args.spatialdata_path if not single_source_input else sdata_paths[0]),
+            link_target,
+            target_is_directory=True,
         )
     else:
         _progress(f"Copying spatial inputs into '{mdv.dir}/spatial'")

--- a/python/mdvtools/spatial/conversion.py
+++ b/python/mdvtools/spatial/conversion.py
@@ -687,6 +687,14 @@ def _ensure_unique_var_names(adata: "AnnData", table_name: str, sdata_name: str)
     )
     adata.var_names_make_unique()
 
+
+def _concat_spatial_tables(adata_objects: list["AnnData"]) -> "AnnData":
+    from anndata import concat as ad_concat
+
+    # Tables from different technologies often have disjoint gene sets, so an
+    # inner join can collapse the merged object down to zero genes.
+    return ad_concat(adata_objects, index_unique="_", join="outer", fill_value=0)
+
 def _set_default_image_view(mdv: "MDVProject", args: SpatialDataConversionArgs):
     """
     Uses a template view for the default view of the spatial data.
@@ -744,7 +752,6 @@ def convert_spatialdata_to_mdv(args: SpatialDataConversionArgs):
             - The written SpatialData objects contain the modified tables
     """
     # imports can be slow, so doing them here rather than at the top of the file
-    from anndata import concat as ad_concat
     from mdvtools.conversions import convert_scanpy_to_mdv
     from mdvtools.markdown_utils import create_project_markdown
     from mdvtools.build_info import get_build_info
@@ -818,7 +825,7 @@ def convert_spatialdata_to_mdv(args: SpatialDataConversionArgs):
     if len(spatial_tables) == 0:
         print("WARNING: No spatial tables found. Skipping spatial-specific metadata and view setup.")
         # Still merge and convert, but skip spatial operations
-        merged_adata = ad_concat(adata_objects, index_unique="_")
+        merged_adata = _concat_spatial_tables(adata_objects)
         mdv = convert_scanpy_to_mdv(
             args.output_folder, merged_adata, delete_existing=not args.preserve_existing
         )
@@ -830,7 +837,7 @@ def convert_spatialdata_to_mdv(args: SpatialDataConversionArgs):
         raise ValueError("Spatial tables found but no regions could be resolved - this indicates a problem with the data")
 
     ## todo - try to make sure we have sparse CSC matrices if possible.
-    merged_adata = ad_concat(adata_objects, index_unique="_")
+    merged_adata = _concat_spatial_tables(adata_objects)
     mdv = convert_scanpy_to_mdv(
         args.output_folder, merged_adata, delete_existing=not args.preserve_existing
     )

--- a/python/mdvtools/spatial/conversion.py
+++ b/python/mdvtools/spatial/conversion.py
@@ -772,6 +772,37 @@ def _resolve_regions_for_table(sdata: "SpatialData", table_name: str, sdata_name
 
 
 
+def _resolve_image_only_regions(sdata: "SpatialData", sdata_name: str) -> dict[str, dict]:
+    all_regions: dict[str, dict] = {}
+
+    for cs in sdata.coordinate_systems:
+        img_candidates = [img for img in sdata.images.items() if cs in _get_transform_keys(img[1])]
+        img_candidates.sort(key=lambda img: (0 if "morphology_focus" in str(img[0]) else 1, img[0]))
+        if not img_candidates:
+            continue
+
+        img_path, _img_obj = img_candidates[0]
+        region_id = f"{sdata_name}_{cs}"
+        all_regions[region_id] = {
+            "spatial": {
+                "coordinate_system": cs,
+                "file": sdata_name,
+            },
+            "viv_image": {
+                "file": f"{sdata_name}/images/{img_path}",
+            },
+            "roi": {
+                "min_x": 0,
+                "min_y": 0,
+                "max_x": 1000,
+                "max_y": 1000,
+            },
+            "images": {},
+        }
+
+    return all_regions
+
+
 def _try_read_zarr(
     path: str,
     emit_warning: bool = True,
@@ -856,32 +887,6 @@ def _build_gene_source_column(
         }
     ]
 
-def _set_default_image_view(mdv: "MDVProject", args: SpatialDataConversionArgs):
-    """
-    Uses a template view for the default view of the spatial data.
-    In future it would be good to make this user-configurable.
-    """
-    import json
-    import os
-
-    # find a region with a viv_image and use key from that...
-    for region_name, region_data in mdv.get_datasource_metadata("cells")["regions"]["all_regions"].items():
-        if "viv_image" in region_data:
-            break
-    else:
-        raise ValueError("No region with a viv_image found")
-
-    _emit(f"Using region '{region_name}' for default view", verbose_only=True)
-    with open(os.path.join(os.path.dirname(__file__), "spatial_view_template.json"), "r") as f:
-        view_str = f.read().replace("<SPATIAL_REGION_NAME>", region_name)
-        density = """
-        {
-            "linkedDsName": "genes", "maxItems": 15, "type": "RowsAsColsQuery"
-        }
-        """
-        view_str = view_str.replace('"<DENSITY_FIELDS>"', density if args.density else "")
-        mdv.set_view("default", json.loads(view_str), True)
-
 def convert_spatialdata_to_mdv(args: SpatialDataConversionArgs):
     """
     Convert all SpatialData objects in a folder to MDV format.
@@ -917,6 +922,11 @@ def convert_spatialdata_to_mdv(args: SpatialDataConversionArgs):
     from mdvtools.markdown_utils import create_project_markdown
     from mdvtools.build_info import get_build_info
     from mdvtools.spatial.mermaid import sdata_to_mermaid
+    from mdvtools.spatial.project_helpers import (
+        build_spatial_regions_metadata,
+        create_empty_spatial_mdv_project,
+        set_default_spatial_image_view,
+    )
 
     _set_verbose_output(args.verbose)
     
@@ -979,16 +989,33 @@ def convert_spatialdata_to_mdv(args: SpatialDataConversionArgs):
         sdata_objects[sdata_name] = sdata
 
     if len(adata_objects) == 0:
-        raise ValueError("No tables found in any SpatialData objects - this is not yet supported.")
-    
-    # Check if we have at least one spatial table - maybe this is unnecessary noise?
-    spatial_tables = [ad for ad in adata_objects if ad.uns.get("mdv", {}).get("is_spatial", False)]
-
-    if len(spatial_tables) == 0:
-        _emit(
-            "INFO: No spatial tables found. Creating a merged project without spatial metadata or a default image view."
+        for sdata_name, sdata in sdata_objects.items():
+            all_regions.update(_resolve_image_only_regions(sdata, sdata_name))
+        if not all_regions:
+            raise ValueError("No tables or image-backed regions found in any SpatialData objects.")
+        _emit("INFO: No tables found. Creating an image-only project with empty datasources.")
+        _progress("Writing MDV project")
+        mdv = _call_with_optional_stdout_suppressed(
+            create_empty_spatial_mdv_project,
+            args.output_folder,
+            delete_existing=not args.preserve_existing,
+            region_field=REGION_FIELD,
         )
-        # Still merge and convert, but skip spatial operations
+        merged_adata = None
+        has_spatial_tables = False
+    else:
+        # Check if we have at least one spatial table - maybe this is unnecessary noise?
+        spatial_tables = [ad for ad in adata_objects if ad.uns.get("mdv", {}).get("is_spatial", False)]
+
+        has_spatial_tables = len(spatial_tables) != 0
+
+        if not has_spatial_tables:
+            _emit(
+                "INFO: No spatial tables found. Creating a merged project without spatial metadata or a default image view."
+            )
+        elif not all_regions:
+            raise ValueError("Spatial tables found but no regions could be resolved - this indicates a problem with the data")
+
         _progress(f"Merging {len(adata_objects)} table(s) with outer gene union")
         merged_adata = _concat_spatial_tables(adata_objects)
         gene_columns = _build_gene_source_column(merged_adata, gene_sources)
@@ -1000,25 +1027,6 @@ def convert_spatialdata_to_mdv(args: SpatialDataConversionArgs):
             delete_existing=not args.preserve_existing,
             gene_columns=gene_columns,
         )
-        # ... write sdata objects but skip region metadata and _set_default_image_view
-        return mdv
-
-    # Proceed with normal spatial workflow if we have spatial tables
-    if not all_regions:
-        raise ValueError("Spatial tables found but no regions could be resolved - this indicates a problem with the data")
-
-    ## todo - try to make sure we have sparse CSC matrices if possible.
-    _progress(f"Merging {len(adata_objects)} table(s) with outer gene union")
-    merged_adata = _concat_spatial_tables(adata_objects)
-    gene_columns = _build_gene_source_column(merged_adata, gene_sources)
-    _progress("Writing MDV project")
-    mdv = _call_with_optional_stdout_suppressed(
-        convert_scanpy_to_mdv,
-        args.output_folder,
-        merged_adata,
-        delete_existing=not args.preserve_existing,
-        gene_columns=gene_columns,
-    )
     if args.link:
         os.makedirs(os.path.join(mdv.dir, "spatial"), exist_ok=True)
         if single_source_input:
@@ -1074,27 +1082,19 @@ def convert_spatialdata_to_mdv(args: SpatialDataConversionArgs):
     # }
     # mdv.add_viv_images("cells", viv_data, link_images=False)
 
-    # instead, we will set the region metadata directly.
-    cells_md = mdv.get_datasource_metadata("cells")
-    cells_md["regions"] = {
-        # non-2d cases are one thing... but mixtures are another.
-        # this metadata format won't work for that, we expect to move more towards spatialdata.js.
-        "position_fields": ["x", "y"],
-        "region_field": REGION_FIELD,
-        "default_color": "x",  # todo: figure out a better way to determine this.
-        "scale_unit": "µm",
-        # scale will be baked during conversion from spatialdata to mdv.
-        # in future we will use spatialdata.js to handle transforms at runtime.
-        "scale": 1.0,
-        "avivator": {
-            "default_channels": [],
-            "base_url": "spatial/",
-        },
-        "all_regions": all_regions,
-    }
-    mdv.set_datasource_metadata(cells_md)
-    _set_default_image_view(mdv, args)
-    _emit(f"## Merged AnnData object representation:\n\n```\n{merged_adata}\n```\n", verbose_only=True)
+    if all_regions:
+        # instead, we will set the region metadata directly.
+        cells_md = mdv.get_datasource_metadata("cells")
+        cells_md["regions"] = build_spatial_regions_metadata(all_regions, REGION_FIELD)
+        mdv.set_datasource_metadata(cells_md)
+        set_default_spatial_image_view(
+            mdv,
+            os.path.join(os.path.dirname(__file__), "spatial_view_template.json"),
+            args.density,
+            _emit,
+        )
+    if merged_adata is not None:
+        _emit(f"## Merged AnnData object representation:\n\n```\n{merged_adata}\n```\n", verbose_only=True)
     _emit(f"## Project markdown:\n\n{create_project_markdown(mdv, False)}\n\n---", verbose_only=True)
     add_readme_to_project(mdv, merged_adata, args)
     if args.serve:

--- a/python/mdvtools/spatial/conversion.py
+++ b/python/mdvtools/spatial/conversion.py
@@ -82,7 +82,14 @@ def _discover_spatialdata_paths(spatialdata_path: str) -> list[str]:
     if not os.path.exists(source_path):
         raise FileNotFoundError(f"SpatialData source does not exist: '{spatialdata_path}'")
 
-    if _try_read_zarr(source_path, emit_warning=False) is not None:
+    try:
+        root_sdata = _try_read_zarr(source_path, emit_warning=False, raise_on_error=True)
+    except Exception as error:
+        raise ValueError(
+            f"Failed to read SpatialData source '{spatialdata_path}' at '{source_path}': {error}"
+        ) from error
+
+    if root_sdata is not None:
         return [source_path]
 
     if not os.path.isdir(source_path):
@@ -765,7 +772,11 @@ def _resolve_regions_for_table(sdata: "SpatialData", table_name: str, sdata_name
 
 
 
-def _try_read_zarr(path: str, emit_warning: bool = True):# -> sd.SpatialData | None:
+def _try_read_zarr(
+    path: str,
+    emit_warning: bool = True,
+    raise_on_error: bool = False,
+):# -> sd.SpatialData | None:
     """
     Attempts to read arbitrary path string as a SpatialData object, falling back to None if it fails.
     """
@@ -788,6 +799,8 @@ def _try_read_zarr(path: str, emit_warning: bool = True):# -> sd.SpatialData | N
             if not _VERBOSE_OUTPUT:
                 ome_logger.setLevel(original_level)
     except Exception as e:
+        if raise_on_error:
+            raise
         if emit_warning:
             _emit(f"WARNING: Failed to read SpatialData object from {path}: '{e}'")
         return None

--- a/python/mdvtools/spatial/conversion_report.py
+++ b/python/mdvtools/spatial/conversion_report.py
@@ -74,27 +74,38 @@ def _parse_args() -> argparse.Namespace:
         "--point-transform",
         choices=POINT_TRANSFORM_CHOICES,
         default="auto",
-        help="Point transform mode passed through to the conversion entrypoint.",
+        help="Choose how table coordinates are transformed into image coordinates.",
     )
     parser.add_argument(
         "--output-geojson",
-        action="store_true",
-        help="Pass --output_geojson to the conversion entrypoint.",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Write transformed GeoJSON region files into the generated project.",
     )
     parser.add_argument(
         "--preserve-existing",
         action="store_true",
-        help="Pass --preserve-existing to the conversion entrypoint.",
+        help="Preserve existing project data in the output folder instead of recreating it.",
     )
     parser.add_argument(
         "--no-link",
         action="store_true",
-        help="Copy data into outputs instead of using --link.",
+        help="Copy the SpatialData inputs into outputs instead of linking them.",
     )
     parser.add_argument(
         "--keep-failures",
         action="store_true",
         help="Keep the per-dataset input/output temp directories for failed runs.",
+    )
+    parser.add_argument(
+        "--density",
+        action="store_true",
+        help="Include density fields for gene expression in the default spatial view.",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Show detailed per-dataset conversion output, transform decisions, and merged summaries.",
     )
     return parser.parse_args()
 
@@ -139,8 +150,14 @@ def _command_for_dataset(
         command.append("--link")
     if args.output_geojson:
         command.append("--output_geojson")
+    else:
+        command.append("--no-output_geojson")
     if args.preserve_existing:
         command.append("--preserve-existing")
+    if args.density:
+        command.append("--density")
+    if args.verbose:
+        command.append("--verbose")
     return command
 
 

--- a/python/mdvtools/spatial/conversion_report.py
+++ b/python/mdvtools/spatial/conversion_report.py
@@ -150,6 +150,7 @@ def _command_for_dataset(
         "mdvtools.spatial.conversion",
         str(input_dir),
         str(output_dir),
+        "--batch",
         "--point-transform",
         args.point_transform,
     ]

--- a/python/mdvtools/spatial/conversion_report.py
+++ b/python/mdvtools/spatial/conversion_report.py
@@ -1,0 +1,469 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import traceback
+from collections import Counter
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+POINT_TRANSFORM_CHOICES = [
+    "image",
+    "auto",
+    "xenium",
+    "identity",
+    "annotated-element",
+]
+
+
+@dataclass
+class ConversionResult:
+    dataset_name: str
+    dataset_path: str
+    status: str
+    returncode: int
+    duration_seconds: float
+    command: list[str]
+    stdout_log: str
+    stderr_log: str
+    warning_count: int
+    warning_samples: list[str]
+    error_type: str | None
+    error_message: str | None
+    error_signature: str | None
+    traceback_excerpt: str | None
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run mdvtools spatial conversion against each SpatialData dataset "
+            "in a directory and write a Markdown plus JSON report."
+        )
+    )
+    parser.add_argument(
+        "datasets_root",
+        type=Path,
+        help="Directory containing one SpatialData dataset per child entry.",
+    )
+    parser.add_argument(
+        "report_dir",
+        type=Path,
+        help="Directory where the report, logs, and optional failure artifacts will be written.",
+    )
+    parser.add_argument(
+        "--python-executable",
+        type=Path,
+        default=Path(sys.executable),
+        help="Python executable used to invoke the conversion module.",
+    )
+    parser.add_argument(
+        "--dataset",
+        action="append",
+        default=[],
+        help="Specific dataset directory name to include. Repeat to include multiple.",
+    )
+    parser.add_argument(
+        "--point-transform",
+        choices=POINT_TRANSFORM_CHOICES,
+        default="auto",
+        help="Point transform mode passed through to the conversion entrypoint.",
+    )
+    parser.add_argument(
+        "--output-geojson",
+        action="store_true",
+        help="Pass --output_geojson to the conversion entrypoint.",
+    )
+    parser.add_argument(
+        "--preserve-existing",
+        action="store_true",
+        help="Pass --preserve-existing to the conversion entrypoint.",
+    )
+    parser.add_argument(
+        "--no-link",
+        action="store_true",
+        help="Copy data into outputs instead of using --link.",
+    )
+    parser.add_argument(
+        "--keep-failures",
+        action="store_true",
+        help="Keep the per-dataset input/output temp directories for failed runs.",
+    )
+    return parser.parse_args()
+
+
+def _discover_datasets(datasets_root: Path, selected_names: set[str]) -> list[Path]:
+    datasets = []
+    for child in sorted(datasets_root.iterdir()):
+        if child.name.startswith("."):
+            continue
+        if selected_names and child.name not in selected_names:
+            continue
+        if child.is_dir():
+            datasets.append(child)
+    return datasets
+
+
+def _ensure_dirs(report_dir: Path) -> tuple[Path, Path, Path]:
+    logs_dir = report_dir / "logs"
+    failures_dir = report_dir / "failures"
+    cache_dir = report_dir / ".runtime-cache"
+    for path in [report_dir, logs_dir, failures_dir, cache_dir]:
+        path.mkdir(parents=True, exist_ok=True)
+    return logs_dir, failures_dir, cache_dir
+
+
+def _command_for_dataset(
+    python_executable: Path,
+    input_dir: Path,
+    output_dir: Path,
+    args: argparse.Namespace,
+) -> list[str]:
+    command = [
+        str(python_executable),
+        "-m",
+        "mdvtools.spatial.conversion",
+        str(input_dir),
+        str(output_dir),
+        "--point-transform",
+        args.point_transform,
+    ]
+    if not args.no_link:
+        command.append("--link")
+    if args.output_geojson:
+        command.append("--output_geojson")
+    if args.preserve_existing:
+        command.append("--preserve-existing")
+    return command
+
+
+def _collect_warning_lines(stdout_text: str, stderr_text: str) -> list[str]:
+    warnings: list[str] = []
+    for line in [*stdout_text.splitlines(), *stderr_text.splitlines()]:
+        if "warning" in line.lower():
+            warnings.append(line.strip())
+    return warnings
+
+
+def _extract_traceback_excerpt(text: str) -> str | None:
+    lines = text.splitlines()
+    traceback_start = next(
+        (index for index, line in enumerate(lines) if line.startswith("Traceback")),
+        None,
+    )
+    if traceback_start is None:
+        return None
+    return "\n".join(lines[traceback_start:])
+
+
+def _extract_error_details(
+    returncode: int, stdout_text: str, stderr_text: str
+) -> tuple[str | None, str | None, str | None, str | None]:
+    if returncode == 0:
+        return None, None, None, None
+
+    traceback_excerpt = _extract_traceback_excerpt(stderr_text)
+    if traceback_excerpt is None:
+        traceback_excerpt = _extract_traceback_excerpt(stdout_text)
+    if traceback_excerpt is not None:
+        traceback_lines = [line.strip() for line in traceback_excerpt.splitlines() if line.strip()]
+        last_traceback_line = traceback_lines[-1]
+        error_type, separator, error_message = last_traceback_line.partition(":")
+        if separator:
+            signature = f"{error_type.strip()}: {error_message.strip()}"
+            return (
+                error_type.strip(),
+                error_message.strip(),
+                signature,
+                traceback_excerpt,
+            )
+        return last_traceback_line, last_traceback_line, last_traceback_line, traceback_excerpt
+
+    preferred_text = stderr_text.strip() or stdout_text.strip()
+    non_empty_lines = [line.strip() for line in preferred_text.splitlines() if line.strip()]
+    if not non_empty_lines:
+        fallback = f"Process exited with code {returncode}"
+        return None, fallback, fallback, None
+
+    last_line = non_empty_lines[-1]
+    error_type = None
+    error_message = last_line
+    signature = last_line
+    if ":" in last_line:
+        prefix, _, suffix = last_line.partition(":")
+        if prefix.endswith("Error") or prefix.endswith("Exception"):
+            error_type = prefix.strip()
+            error_message = suffix.strip()
+            signature = f"{error_type}: {error_message}"
+    return error_type, error_message, signature, None
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _truncate_text(text: str, max_chars: int = 6000) -> str:
+    if len(text) <= max_chars:
+        return text
+    return text[:max_chars].rstrip() + "\n...<traceback truncated>..."
+
+
+def _run_dataset(
+    dataset_path: Path,
+    args: argparse.Namespace,
+    logs_dir: Path,
+    failures_dir: Path,
+    cache_dir: Path,
+) -> ConversionResult:
+    dataset_name = dataset_path.name
+    stdout_path = logs_dir / f"{dataset_name}.stdout.log"
+    stderr_path = logs_dir / f"{dataset_name}.stderr.log"
+    temp_root_path = Path(tempfile.mkdtemp(prefix=f"mdv-sdata-{dataset_name}-"))
+    kept_failure_root = False
+    try:
+        input_dir = temp_root_path / "input"
+        output_dir = temp_root_path / "output"
+        input_dir.mkdir()
+        output_dir.mkdir()
+        os.symlink(dataset_path.resolve(), input_dir / dataset_name, target_is_directory=True)
+
+        env = os.environ.copy()
+        env["MPLCONFIGDIR"] = str(cache_dir / "matplotlib")
+        env["XDG_CACHE_HOME"] = str(cache_dir / "xdg-cache")
+        Path(env["MPLCONFIGDIR"]).mkdir(parents=True, exist_ok=True)
+        Path(env["XDG_CACHE_HOME"]).mkdir(parents=True, exist_ok=True)
+
+        command = _command_for_dataset(
+            args.python_executable, input_dir, output_dir, args
+        )
+
+        start = datetime.now(tz=UTC)
+        completed = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+        )
+        end = datetime.now(tz=UTC)
+
+        stdout_text = completed.stdout
+        stderr_text = completed.stderr
+        _write_text(stdout_path, stdout_text)
+        _write_text(stderr_path, stderr_text)
+
+        if completed.returncode != 0 and args.keep_failures:
+            kept_root = failures_dir / dataset_name
+            if kept_root.exists():
+                shutil.rmtree(kept_root)
+            shutil.move(str(temp_root_path), kept_root)
+            kept_failure_root = True
+    finally:
+        if temp_root_path.exists() and not kept_failure_root:
+            shutil.rmtree(temp_root_path)
+
+    warning_lines = _collect_warning_lines(stdout_text, stderr_text)
+    error_type, error_message, error_signature, traceback_excerpt = _extract_error_details(
+        completed.returncode,
+        stdout_text,
+        stderr_text,
+    )
+
+    return ConversionResult(
+        dataset_name=dataset_name,
+        dataset_path=str(dataset_path),
+        status="success" if completed.returncode == 0 else "failed",
+        returncode=completed.returncode,
+        duration_seconds=round((end - start).total_seconds(), 2),
+        command=command,
+        stdout_log=str(stdout_path),
+        stderr_log=str(stderr_path),
+        warning_count=len(warning_lines),
+        warning_samples=warning_lines[:5],
+        error_type=error_type,
+        error_message=error_message,
+        error_signature=error_signature,
+        traceback_excerpt=traceback_excerpt,
+    )
+
+
+def _format_markdown_report(
+    datasets_root: Path,
+    report_dir: Path,
+    args: argparse.Namespace,
+    results: list[ConversionResult],
+) -> str:
+    generated_at = datetime.now(tz=UTC).isoformat()
+    success_count = sum(result.status == "success" for result in results)
+    failure_count = len(results) - success_count
+    failure_signatures = [
+        result.error_signature
+        for result in results
+        if result.status == "failed" and result.error_signature is not None
+    ]
+    grouped_failures = Counter(failure_signatures)
+
+    lines = [
+        "# SpatialData conversion report",
+        "",
+        f"- Generated at: `{generated_at}`",
+        f"- Datasets root: `{datasets_root}`",
+        f"- Report directory: `{report_dir}`",
+        f"- Python executable: `{args.python_executable}`",
+        f"- Point transform: `{args.point_transform}`",
+        f"- Link mode: `{not args.no_link}`",
+        f"- Output geojson: `{args.output_geojson}`",
+        f"- Datasets attempted: `{len(results)}`",
+        f"- Successes: `{success_count}`",
+        f"- Failures: `{failure_count}`",
+        "",
+        "## Summary",
+        "",
+        "| Dataset | Status | Seconds | Warnings | Error |",
+        "| --- | --- | ---: | ---: | --- |",
+    ]
+
+    for result in results:
+        error_summary = result.error_signature or ""
+        lines.append(
+            f"| `{result.dataset_name}` | `{result.status}` | `{result.duration_seconds}` | "
+            f"`{result.warning_count}` | {error_summary} |"
+        )
+
+    if grouped_failures:
+        lines.extend(
+            [
+                "",
+                "## Failure groups",
+                "",
+            ]
+        )
+        for signature, count in grouped_failures.most_common():
+            lines.append(f"- `{count}x` {signature}")
+
+    lines.extend(["", "## Details", ""])
+    for result in results:
+        lines.extend(
+            [
+                f"### {result.dataset_name}",
+                "",
+                f"- Status: `{result.status}`",
+                f"- Dataset path: `{result.dataset_path}`",
+                f"- Duration seconds: `{result.duration_seconds}`",
+                f"- Return code: `{result.returncode}`",
+                f"- Command: `{shlex_join(result.command)}`",
+                f"- Stdout log: `{result.stdout_log}`",
+                f"- Stderr log: `{result.stderr_log}`",
+            ]
+        )
+        if result.warning_samples:
+            lines.append("- Warning samples:")
+            for warning in result.warning_samples:
+                lines.append(f"  - `{warning}`")
+        if result.error_signature is not None:
+            lines.append(f"- Error: `{result.error_signature}`")
+        if result.traceback_excerpt is not None:
+            lines.extend(
+                [
+                    "",
+                    "```text",
+                    _truncate_text(result.traceback_excerpt),
+                    "```",
+                ]
+            )
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def shlex_join(parts: list[str]) -> str:
+    return " ".join(_quote_shell_part(part) for part in parts)
+
+
+def _quote_shell_part(part: str) -> str:
+    if part == "":
+        return "''"
+    safe_characters = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._/:=")
+    if all(character in safe_characters for character in part):
+        return part
+    return "'" + part.replace("'", "'\"'\"'") + "'"
+
+
+def main() -> int:
+    args = _parse_args()
+    datasets_root = args.datasets_root.expanduser().resolve()
+    report_dir = args.report_dir.expanduser().resolve()
+    selected_names = set(args.dataset)
+
+    if not datasets_root.exists():
+        raise FileNotFoundError(f"Datasets root does not exist: {datasets_root}")
+    if not datasets_root.is_dir():
+        raise NotADirectoryError(f"Datasets root is not a directory: {datasets_root}")
+
+    logs_dir, failures_dir, cache_dir = _ensure_dirs(report_dir)
+    datasets = _discover_datasets(datasets_root, selected_names)
+    if not datasets:
+        raise ValueError(f"No datasets found under {datasets_root}")
+
+    results: list[ConversionResult] = []
+    for dataset in datasets:
+        print(f"[run] {dataset.name}", flush=True)
+        try:
+            results.append(_run_dataset(dataset, args, logs_dir, failures_dir, cache_dir))
+        except Exception as error:
+            stdout_path = logs_dir / f"{dataset.name}.stdout.log"
+            stderr_path = logs_dir / f"{dataset.name}.stderr.log"
+            _write_text(stdout_path, "")
+            _write_text(stderr_path, traceback.format_exc())
+            results.append(
+                ConversionResult(
+                    dataset_name=dataset.name,
+                    dataset_path=str(dataset),
+                    status="failed",
+                    returncode=-1,
+                    duration_seconds=0.0,
+                    command=[],
+                    stdout_log=str(stdout_path),
+                    stderr_log=str(stderr_path),
+                    warning_count=0,
+                    warning_samples=[],
+                    error_type=type(error).__name__,
+                    error_message=str(error),
+                    error_signature=f"{type(error).__name__}: {error}",
+                    traceback_excerpt=traceback.format_exc(),
+                )
+            )
+
+    report_json_path = report_dir / "report.json"
+    report_md_path = report_dir / "report.md"
+    _write_text(
+        report_json_path,
+        json.dumps([asdict(result) for result in results], indent=2),
+    )
+    _write_text(
+        report_md_path,
+        _format_markdown_report(datasets_root, report_dir, args, results),
+    )
+
+    success_count = sum(result.status == "success" for result in results)
+    failure_count = len(results) - success_count
+    print(f"Report written to {report_md_path}")
+    print(f"JSON written to {report_json_path}")
+    print(f"Successes: {success_count}, failures: {failure_count}")
+    return 0 if failure_count == 0 else 1
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception:
+        traceback.print_exc()
+        raise

--- a/python/mdvtools/spatial/conversion_report.py
+++ b/python/mdvtools/spatial/conversion_report.py
@@ -110,12 +110,19 @@ def _parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def _discover_datasets(datasets_root: Path, selected_names: set[str]) -> list[Path]:
+def _discover_datasets(
+    datasets_root: Path,
+    selected_names: set[str],
+    report_dir: Path | None = None,
+) -> list[Path]:
     datasets = []
+    resolved_report_dir = report_dir.resolve() if report_dir is not None else None
     for child in sorted(datasets_root.iterdir()):
         if child.name.startswith("."):
             continue
         if selected_names and child.name not in selected_names:
+            continue
+        if resolved_report_dir is not None and child.resolve() == resolved_report_dir:
             continue
         if child.is_dir():
             datasets.append(child)
@@ -426,7 +433,7 @@ def main() -> int:
         raise NotADirectoryError(f"Datasets root is not a directory: {datasets_root}")
 
     logs_dir, failures_dir, cache_dir = _ensure_dirs(report_dir)
-    datasets = _discover_datasets(datasets_root, selected_names)
+    datasets = _discover_datasets(datasets_root, selected_names, report_dir)
     if not datasets:
         raise ValueError(f"No datasets found under {datasets_root}")
 

--- a/python/mdvtools/spatial/project_helpers.py
+++ b/python/mdvtools/spatial/project_helpers.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from mdvtools.mdvproject import MDVProject
+
+
+def build_spatial_regions_metadata(
+    all_regions: dict[str, dict],
+    region_field: str,
+) -> dict:
+    return {
+        "position_fields": ["x", "y"],
+        "region_field": region_field,
+        "default_color": "x",
+        "scale_unit": "µm",
+        "scale": 1.0,
+        "avivator": {
+            "default_channels": [],
+            "base_url": "spatial/",
+        },
+        "all_regions": all_regions,
+    }
+
+
+def set_default_spatial_image_view(
+    mdv: "MDVProject",
+    template_path: str,
+    density: bool,
+    emit,
+) -> None:
+    for region_name, region_data in mdv.get_datasource_metadata("cells")["regions"]["all_regions"].items():
+        if "viv_image" in region_data:
+            break
+    else:
+        raise ValueError("No region with a viv_image found")
+
+    emit(f"Using region '{region_name}' for default view", verbose_only=True)
+    with open(template_path, "r") as f:
+        view_str = f.read().replace("<SPATIAL_REGION_NAME>", region_name)
+        density_block = """
+        {
+            "linkedDsName": "genes", "maxItems": 15, "type": "RowsAsColsQuery"
+        }
+        """
+        view_str = view_str.replace('"<DENSITY_FIELDS>"', density_block if density else "")
+        mdv.set_view("default", json.loads(view_str), True)
+
+
+def create_empty_spatial_mdv_project(
+    output_folder: str,
+    delete_existing: bool,
+    region_field: str,
+) -> "MDVProject":
+    import pandas
+    from mdvtools.mdvproject import MDVProject
+
+    mdv = MDVProject(output_folder, delete_existing=delete_existing)
+
+    cells_df = pandas.DataFrame(
+        {
+            "x": pandas.Series(dtype="float64"),
+            "y": pandas.Series(dtype="float64"),
+            region_field: pandas.Series(dtype="object"),
+        }
+    )
+    mdv.add_datasource(
+        "cells",
+        cells_df,
+        columns=[
+            {"name": "x", "field": "x", "datatype": "double"},
+            {"name": "y", "field": "y", "datatype": "double"},
+            {"name": region_field, "field": region_field, "datatype": "text"},
+        ],
+        supplied_columns_only=True,
+    )
+
+    genes_df = pandas.DataFrame(
+        {
+            "name": pandas.Series(dtype="object"),
+            "object_source": pandas.Series(dtype="object"),
+        }
+    )
+    mdv.add_datasource(
+        "genes",
+        genes_df,
+        columns=[
+            {"name": "name", "field": "name", "datatype": "text"},
+            {"name": "object_source", "field": "object_source", "datatype": "multitext", "delimiter": "|"},
+        ],
+        supplied_columns_only=True,
+    )
+
+    return mdv

--- a/python/mdvtools/spatial/spatial_view_template.json
+++ b/python/mdvtools/spatial/spatial_view_template.json
@@ -107,7 +107,7 @@
         "param": [
           "name"
         ],
-        "type": "table_chart",
+        "type": "table_chart_react",
         "id": "lFuDYZ",
         "size": [
           375,


### PR DESCRIPTION
## Summary
- add a `conversion_report` CLI helper to run `mdvtools.spatial.conversion` against each dataset in a directory
- capture per-dataset status, timing, warnings, logs, and traceback excerpts in JSON and Markdown reports
- stage inputs with symlinks, preserve failed workspaces on request, and harden error extraction so reports show actual conversion failures

## Testing
- `./venv/bin/python -m py_compile python/mdvtools/spatial/conversion_report.py`
- `./venv/bin/python -m mdvtools.spatial.conversion_report /Users/ptodd/data/spatialdata/sdata_inputs /Users/ptodd/code/www/MDV/data/spatialdata_conversion_report_20260409 --keep-failures`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Broader integer detection and safer numeric stats for empty/non-finite data.
  * Track original column data types and warn about potential precision loss for unsigned 32-bit integers.

* **New Features**
  * Batch conversion/reporting tool with per-dataset logs, warnings, failure grouping, and runtimes.
  * Verbose output control and quieter default conversion output; new CLI flags for batch, verbose, density, and toggled GeoJSON output.
  * Spatial project helpers and default image-view setup; updated spatial view template chart type.

* **Enhancement**
  * Genes datasource accepts external column metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->