### PR TITLE
Fix Python test commands for dev-only environments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,7 @@
-- use `npx tsgo` for type-checking
+- only run `npx tsgo` when TypeScript files or TS-facing configs changed
+- for Python checks in worktrees, prefer the local `venv`:
+- tests: `./venv/bin/python -m pytest python/mdvtools/tests -m "not performance"`
+- pyright: from `python/`, run `../venv/bin/pyright`
 - avoid `as` casts where possible
 - prefer follow-up PRs for wider type-system cleanups
 - when composing commit messages, avoid words like "enhance" and favour conciseness and clarity

--- a/python/Makefile
+++ b/python/Makefile
@@ -1,8 +1,14 @@
 test:
-	poetry run pytest mdvtools/ -m "not performance"
+	poetry run pytest mdvtools/tests -m "not performance"
 
 test-performance:
 	poetry run pytest mdvtools/tests/test_stress_performance.py -v
+
+test-backend:
+	poetry run pytest mdvtools/dbutils/test -v
+
+test-auth:
+	poetry run pytest mdvtools/auth/tests -v
 
 type:
 	poetry run pyright

--- a/python/PERFORMANCE_TESTING.md
+++ b/python/PERFORMANCE_TESTING.md
@@ -82,8 +82,14 @@ make test
 # Performance tests (slow, resource-intensive)
 make test-performance
 
-# All tests
-poetry run pytest mdvtools/
+# Backend tests
+make test-backend
+
+# Auth tests
+make test-auth
+
+# All core tests
+poetry run pytest mdvtools/tests
 ```
 
 ### Test Markers
@@ -93,7 +99,7 @@ poetry run pytest mdvtools/
 poetry run pytest -m performance
 
 # Run everything except performance tests
-poetry run pytest -m "not performance"
+poetry run pytest mdvtools/tests -m "not performance"
 
 # Run slow tests
 poetry run pytest -m slow

--- a/python/README.md
+++ b/python/README.md
@@ -193,10 +193,29 @@ To run only performance/stress tests:
 make test-performance
 ```
 
-To run all tests including performance tests:
+To run the backend-only test suite:
 
 ```bash
-poetry run pytest mdvtools/
+make test-backend
+```
+
+To run the auth-only test suite:
+
+```bash
+make test-auth
+```
+
+To run all core tests including performance tests:
+
+```bash
+poetry run pytest mdvtools/tests
+```
+
+Auth and backend tests depend on optional Poetry groups that are not installed by `npm run python-setup`.
+Install those groups first if you want to run the separated suites:
+
+```bash
+poetry install --with dev,backend,auth
 ```
 
 ### Performance Testing in CI

--- a/python/conftest.py
+++ b/python/conftest.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import importlib.util
+
+
+def _has_module(module_name: str) -> bool:
+    return importlib.util.find_spec(module_name) is not None
+
+
+collect_ignore: list[str] = []
+collect_ignore_glob: list[str] = []
+
+has_backend_dependencies = all(
+    _has_module(module_name)
+    for module_name in ("flask_sqlalchemy", "psycopg2")
+)
+has_auth_dependencies = all(
+    _has_module(module_name)
+    for module_name in ("authlib", "auth0", "jose", "flask_jwt_extended", "redis")
+)
+
+if not has_backend_dependencies:
+    collect_ignore.append("mdvtools/dbutils/test")
+    collect_ignore_glob.append("mdvtools/dbutils/test/**/*.py")
+
+if not (has_backend_dependencies and has_auth_dependencies):
+    collect_ignore.append("mdvtools/auth/tests")
+    collect_ignore_glob.append("mdvtools/auth/tests/**/*.py")

--- a/python/mdvtools/llm/code_execution.py
+++ b/python/mdvtools/llm/code_execution.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 import warnings
 import tempfile
 import concurrent.futures
@@ -60,7 +61,7 @@ def execute_code(final_code: str, open_code=False, log = print):
         #     log(f"Error: {str(e)}")    
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            stdout, stderr = run_subprocess(["python", temp.name])
+            stdout, stderr = run_subprocess([sys.executable, temp.name])
             if stderr:
                 log(f"Standard Error: {stderr}")
             for warning in w:

--- a/python/mdvtools/tests/test_column_groups.py
+++ b/python/mdvtools/tests/test_column_groups.py
@@ -2,12 +2,15 @@ from mdvtools.mdvproject import MDVProject
 import os
 import pandas as pd
 
-# make a project in local temp directory, which is ignored by git
-path = os.path.join(os.path.dirname(__file__), "temp", "test_column_groups")
-if not os.path.exists(path):
-    os.makedirs(path)
-p = MDVProject(path, delete_existing=True)
 
-df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9]})
+def test_add_datasource_with_multiple_columns():
+    # Make a project in a local temp directory that is ignored by git.
+    path = os.path.join(os.path.dirname(__file__), "temp", "test_column_groups")
+    os.makedirs(path, exist_ok=True)
 
-p.add_datasource("test", df)
+    project = MDVProject(path, delete_existing=True)
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9]})
+    project.add_datasource("test", df)
+
+    datasource_columns = project.datasources[0]["columns"]
+    assert [column["name"] for column in datasource_columns] == ["a", "b", "c"]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -94,7 +94,15 @@ flask-jwt-extended = "^4.7.1"
 redis = "^5.2.1"
 
 [tool.pyright]
-venvPath = "../venv/"
+venvPath = ".."
+venv = "venv"
+pythonVersion = "3.12"
+exclude = [
+    "manual_tests",
+    "mdvtools/auth",
+    "mdvtools/dbutils",
+    "mdvtools/test_projects",
+]
 typeCheckingMode = "standard"
 
 [project]


### PR DESCRIPTION
## Summary
- limit the default Python test command to `mdvtools/tests` and add separate `test-auth` and `test-backend` targets
- skip auth and backend test collection when optional dependency groups are not installed
- update Python docs to reflect the split test commands and required Poetry groups
- fix `test_column_groups` to avoid import-time side effects during collection
- run subprocess code execution with `sys.executable` so tests use the active virtualenv
- update pyright config to use the local `venv` and exclude optional/manual paths from the default check

## Testing
- `./venv/bin/python -m pytest --collect-only python/mdvtools`
- `./venv/bin/python -m pytest python/mdvtools/tests -m "not performance"`
- `./venv/bin/python -m pytest python/mdvtools/tests/test_langchain.py -q`
- `../venv/bin/pyright`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate test suites with `make test-backend` and `make test-auth` for targeted testing.

* **Bug Fixes**
  * Fixed Python interpreter selection in code execution to use the currently active interpreter.

* **Tests**
  * Tests now gracefully skip when optional dependencies are unavailable.

* **Documentation**
  * Updated testing guidance to explain the new separate test suite commands and optional dependency requirements.

* **Chores**
  * Enhanced Pyright configuration and improved contributor guidance documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->