### PR TITLE
codex/discard unsaved added columns on view switch

### DIFF
--- a/src/charts/ViewManager.ts
+++ b/src/charts/ViewManager.ts
@@ -130,6 +130,12 @@ class ViewManager {
                 }
             }
             this.cm.removeAllCharts();
+            // Unsaved added columns are view-local draft data. Drop them before
+            // loading the next view so param pickers/options reflect only
+            // persisted datasource columns.
+            for (const ds of this.cm.dataSources) {
+                ds.dataStore.discardPendingAddedColumns?.();
+            }
             contentDiv.innerHTML = "";
             this.setView(view);
             this.cm.viewLoader(view).then(async (data: object) => {

--- a/src/datastore/DataStore.js
+++ b/src/datastore/DataStore.js
@@ -417,6 +417,23 @@ class DataStore {
     }
 
     /**
+     * Drop any columns that were added locally but never persisted. Unlike
+     * removals, unsaved additions are not referenced by existing saved views,
+     * so switching away should simply forget them.
+     */
+    discardPendingAddedColumns() {
+        const addedFields = Object.keys(this.dirtyColumns.added);
+        if (addedFields.length === 0) {
+            return;
+        }
+        for (const field of addedFields) {
+            delete this.dirtyColumns.added[field];
+            this.removeColumn(field, false, false);
+        }
+        this.dirtyColumns.added = {};
+    }
+
+    /**
      * Returns the current filter, which is just an array corresponding
      * to the index of the row, which contains 0 if it is present or
      * greater than 0 if it has been filtrered out. Do not modify the array.

--- a/src/tests/DataStore.removeColumn.spec.ts
+++ b/src/tests/DataStore.removeColumn.spec.ts
@@ -29,4 +29,36 @@ describe("DataStore.removeColumn", () => {
         expect(store.dirtyColumns.removed).toEqual({ temp: true });
         expect(store._callListeners).toHaveBeenCalledWith("column_removed", "temp");
     });
+
+    test("discardPendingAddedColumns removes unsaved added columns without marking them removed", () => {
+        const fresh = {
+            field: "fresh",
+            data: new Uint8Array([1, 2, 3]),
+            buffer: new SharedArrayBuffer(3),
+        };
+        const store = {
+            columnIndex: { fresh },
+            columns: [fresh],
+            columnsWithData: ["fresh"],
+            dirtyColumns: {
+                added: { fresh: true },
+                removed: {},
+                data_changed: { fresh: true },
+                colors_changed: { fresh: true },
+            },
+            _callListeners: vi.fn(),
+            removeColumn: DataStore.prototype.removeColumn,
+        };
+
+        DataStore.prototype.discardPendingAddedColumns.call(store);
+
+        expect(store.columnIndex.fresh).toBeUndefined();
+        expect(store.columns).toEqual([]);
+        expect(store.columnsWithData).toEqual([]);
+        expect(store.dirtyColumns.added).toEqual({});
+        expect(store.dirtyColumns.removed).toEqual({});
+        expect(store.dirtyColumns.data_changed).toEqual({});
+        expect(store.dirtyColumns.colors_changed).toEqual({});
+        expect(store._callListeners).not.toHaveBeenCalled();
+    });
 });

--- a/src/tests/ViewManager.spec.ts
+++ b/src/tests/ViewManager.spec.ts
@@ -1,0 +1,117 @@
+import ViewManager from "@/charts/ViewManager";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@/utilities/Screenshot", () => ({
+    default: vi.fn(() => Promise.resolve("data:image/png;base64,test")),
+}));
+
+vi.mock("@/dataloaders/DataLoaderUtil", () => ({
+    getPostData: vi.fn(),
+    getProjectRoot: vi.fn(() => ""),
+}));
+
+describe("ViewManager.saveView", () => {
+    let chartManager: any;
+
+    beforeEach(() => {
+        chartManager = {
+            getState: vi.fn(() => ({
+                view: {
+                    dataSources: {},
+                    initialCharts: {},
+                },
+                currentView: "view-a",
+                all_views: ["view-a", "view-b"],
+                updatedColumns: {},
+                metadata: {},
+                chartErrors: [],
+            })),
+            _callListeners: vi.fn(),
+            contentDiv: document.createElement("div"),
+        };
+        Reflect.defineProperty(window, "mdv", {
+            configurable: true,
+            value: { chartManager },
+        });
+    });
+
+    test("includes updatedViews in the state_saved payload when provided", async () => {
+        const viewManager = new ViewManager("view-a", ["view-a", "view-b"]);
+        const updatedViews = {
+            "view-b": {
+                dataSources: {},
+                initialCharts: {},
+            },
+        };
+
+        await viewManager.saveView(undefined, updatedViews as any);
+
+        expect(chartManager._callListeners).toHaveBeenCalledWith(
+            "state_saved",
+            expect.objectContaining({
+                updatedViews,
+            }),
+        );
+    });
+});
+
+describe("ViewManager.changeView", () => {
+    test("discards unsaved added columns before loading the next view", async () => {
+        const discardPendingAddedColumns = vi.fn();
+        const chartManager = {
+            viewData: {
+                dataSources: {
+                    ds1: {},
+                },
+            },
+            dsIndex: {
+                ds1: { name: "ds1" },
+            },
+            dataSources: [
+                {
+                    name: "ds1",
+                    dataStore: {
+                        discardPendingAddedColumns,
+                    },
+                },
+            ],
+            gridStack: {
+                destroy: vi.fn(),
+            },
+            removeAllCharts: vi.fn(),
+            contentDiv: document.createElement("div"),
+            viewLoader: vi.fn(() =>
+                Promise.resolve({
+                    dataSources: { ds1: {} },
+                    initialCharts: { ds1: [] },
+                }),
+            ),
+            filterRemovedColumnsFromViewData: vi.fn((data) => data),
+            _init: vi.fn(() => Promise.resolve()),
+            getState: vi.fn(() => ({
+                view: {
+                    dataSources: {},
+                    initialCharts: {},
+                },
+                currentView: "view-b",
+                all_views: ["view-a", "view-b"],
+                updatedColumns: {},
+                metadata: {},
+                chartErrors: [],
+            })),
+        };
+        Reflect.defineProperty(window, "mdv", {
+            configurable: true,
+            value: { chartManager },
+        });
+
+        const viewManager = new ViewManager("view-a", ["view-a", "view-b"]);
+
+        viewManager.changeView("view-b");
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(discardPendingAddedColumns).toHaveBeenCalledTimes(1);
+        expect(chartManager._init).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/tests/columnRemovalUtils.spec.ts
+++ b/src/tests/columnRemovalUtils.spec.ts
@@ -352,7 +352,6 @@ describe("analyzeChartColumnImpact", () => {
             "removed_tooltip",
         ]);
     });
-
     test("finds missing sort columns referenced by tables", () => {
         const missingColumns = getMissingColumnsForChartConfig(
             {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * View transitions now properly discard unsaved draft column additions before loading a new view, preventing potential data state conflicts and ensuring consistent application state.

* **Tests**
  * Added test coverage for view state management transitions and column cleanup operations to validate proper handling during view changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->