### PR TITLE
remove z-index which broke mouse events for viv, document className: "react-chart" weirdness.

### DIFF
--- a/src/react/components/BaseReactChart.tsx
+++ b/src/react/components/BaseReactChart.tsx
@@ -65,9 +65,12 @@ export abstract class BaseReactChart<T extends BaseConfig> extends BaseChart<T> 
         // any mobx state, so we can't just hide it in the base class.
         // (although maybe we could design a hook that hides it?)
         // const Observed = observer(ReactComponentFunction);
+        // createEl maps only `classes` to `classList`; `className` becomes a non-functional attribute, so `.react-chart`
+        // in charts.css does not apply. Using `className` here is intentional until addElProps is fixed and charts are
+        // audited (issue #426); then switch to `classes: ["react-chart"]`.
         this.reactEl = createEl(
             "div",
-            { classes: ["react-chart"] },
+            { className: "react-chart" },
             this.contentDiv,
         ); //other things may still be added to contentDiv outside react (e.g. legend)
         this.ComponentFn = ReactComponentFunction;

--- a/src/react/components/VivScatterComponent.tsx
+++ b/src/react/components/VivScatterComponent.tsx
@@ -199,10 +199,6 @@ const Main = observer(
                     }
                     return getTooltip();
                 },
-                style: {
-                    zIndex: "-1",
-                },
-                //todo figure out why GPU usage is so high (and why commenting and then uncommenting this line fixes it...)
                 layers: [
                     jsonLayer, 
                     gateDisplayLayer, 


### PR DESCRIPTION
Recent change to register `"react-chart"` class properly on `BaseReactChart` had an unnoticed regression for viv where we had an unhelpful `zIndex: -1` which combined meant that mouse-events stopped working.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Adjusted CSS class application mechanism for improved chart rendering
  * Removed z-index styling configuration from scatter visualization component to streamline layer composition

<!-- end of auto-generated comment: release notes by coderabbit.ai -->