### PR TITLE
fix missing react-chart class causing issues with layout/overflow, fix #427

### DIFF
--- a/src/react/components/BaseReactChart.tsx
+++ b/src/react/components/BaseReactChart.tsx
@@ -65,12 +65,9 @@ export abstract class BaseReactChart<T extends BaseConfig> extends BaseChart<T> 
         // any mobx state, so we can't just hide it in the base class.
         // (although maybe we could design a hook that hides it?)
         // const Observed = observer(ReactComponentFunction);
-        // createEl maps only `classes` to `classList`; `className` becomes a non-functional attribute, so `.react-chart`
-        // in charts.css does not apply. Using `className` here is intentional until addElProps is fixed and charts are
-        // audited (issue #426); then switch to `classes: ["react-chart"]`.
         this.reactEl = createEl(
             "div",
-            { className: "react-chart" },
+            { classes: ["react-chart"] },
             this.contentDiv,
         ); //other things may still be added to contentDiv outside react (e.g. legend)
         this.ComponentFn = ReactComponentFunction;


### PR DESCRIPTION
There had been a long-standing issue with `className: "react-chart"` not applying the class as expected.

I believe that everything now behaves correctly with this change, there had previously been issues which lead us to revert to previous behaviour out of abundance of caution, but that meant that the new react-based markdown text chart couldn't be scrolled (and also lead to other issues when attempting to develop other features).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated chart component styling approach to improve code consistency and reduce unnecessary documentation overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->