### PR TITLE
Scope pyright analysis to source paths

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -97,7 +97,15 @@ redis = "^5.2.1"
 venvPath = ".."
 venv = "venv"
 pythonVersion = "3.12"
+include = [
+    "mdvtools",
+    "conftest.py",
+]
 exclude = [
+    ".venv",
+    "__pycache__",
+    ".pytest_cache",
+    ".ruff_cache",
     "manual_tests",
     "mdvtools/auth",
     "mdvtools/dbutils",


### PR DESCRIPTION
## Summary
- configure Pyright to analyze the Python source paths explicitly
- exclude generated/cache/manual-test paths from analysis

Previously running `make type` / `poetry run pyright` from the Python folder was taking a very long time because it seems to read lots of files from the environment.

## Testing
- Not run at user request; change is a scoped Pyright config update (it was run in a different branch but this commit has been cherry-picked).