### PR TITLE
Codex/add xenium annotation merge

### DIFF
--- a/python/mdvtools/cli.py
+++ b/python/mdvtools/cli.py
@@ -140,6 +140,35 @@ def merge_project(base_project, extra_project, prefix, view_prefix):
     merge_projects(base_project, extra_project, prefix=prefix, view_prefix=view_prefix)
     click.echo(f"Merged '{extra_project}' into '{base_project}'.")
 
+@cli.command("patch-spatial-annotations")
+@click.argument("project_dir")
+@click.argument("annotation_csv")
+@click.option("--datasource", default="cells", show_default=True, help="MDV datasource to patch.")
+@click.option("--spatialdata-path", default=None, help="SpatialData store to read. Defaults to auto-detecting under PROJECT_DIR/spatial.")
+@click.option("--table-name", default=None, help="SpatialData table name. Required if more than one table exists.")
+@click.option("--annotation-key", default=None, help="Column in ANNOTATION_CSV to use as the table instance key. Defaults to the SpatialData instance key.")
+@click.option("--separator", default=",", show_default=True, help="Annotation CSV delimiter.")
+@click.option("--missing-value", default="ND", show_default=True, help="Value used for cells missing from the annotation CSV.")
+@click.option("--apply", "apply_changes", is_flag=True, help="Write changes. Without this flag, only a dry-run report is produced.")
+@click.option("--overwrite-preserved", is_flag=True, help="Replace an existing preservation column such as cell_index.")
+def patch_spatial_annotations(project_dir, annotation_csv, datasource, spatialdata_path, table_name, annotation_key, separator, missing_value, apply_changes, overwrite_preserved):
+    """Patch an existing spatial MDV project with instance-key annotations."""
+    from .spatial.annotations import patch_spatial_annotations as patch_annotations
+
+    report = patch_annotations(
+        project_dir,
+        annotation_csv,
+        datasource=datasource,
+        spatialdata_path=spatialdata_path,
+        table_name=table_name,
+        annotation_key=annotation_key,
+        separator=separator,
+        missing_value=missing_value,
+        apply_changes=apply_changes,
+        overwrite_preserved=overwrite_preserved,
+    )
+    click.echo(report.to_text())
+
 @cli.command("convert-spatial")
 @click.argument('output_folder')
 @click.argument('spatialdata_path')

--- a/python/mdvtools/conversions.py
+++ b/python/mdvtools/conversions.py
@@ -232,7 +232,14 @@ def convert_scanpy_to_mdv(
         current_views = {}
     # create datasource 'cells'
     cell_table = scanpy_object.obs
-    cell_table["cell_id"] = cell_table.index
+    # we must not blindly overwrite cell_id in normal anndata, while we're here we try to be extra careful
+    cell_identifier_column = "mdv_cell_id"
+    i = 0
+    while cell_identifier_column in cell_table.columns:
+        # unlikely to happen and we don't like it much, but at least we should be safe
+        i = i + 1
+        cell_identifier_column = f"mdv_cell_id_{i}"
+    cell_table[cell_identifier_column] = cell_table.index
 
     # add any dimension reduction to the dataframe
     cell_table = _add_dims(cell_table, scanpy_object.obsm, max_dims)
@@ -241,7 +248,8 @@ def convert_scanpy_to_mdv(
     # (will be text16 by default if number of values are below 65536)
     # hopefully other columns will be of the correct format
     columns=[{
-        "name":"cell_id",
+        "name": cell_identifier_column,
+        "field": cell_identifier_column,
         "datatype":"unique"
     }]
     leiden_like_columns = sorted(

--- a/python/mdvtools/spatial/annotations.py
+++ b/python/mdvtools/spatial/annotations.py
@@ -1,0 +1,482 @@
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import warnings
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+import h5py
+import numpy
+import pandas
+
+from mdvtools.mdvproject import MDVProject
+
+if TYPE_CHECKING:
+    from anndata import AnnData
+
+
+@dataclass
+class SpatialAnnotationPatchReport:
+    project_dir: str
+    datasource: str
+    spatialdata_path: str | None
+    table_name: str
+    region: str | list[str]
+    region_key: str
+    instance_key: str
+    instance_count: int
+    key_action: str
+    preservation_column: str | None
+    annotation_key: str
+    annotation_columns: list[str]
+    missing_annotation_count: int
+    applied: bool
+    backup_dir: str | None = None
+
+    def to_text(self) -> str:
+        lines = [
+            "Spatial annotation patch report",
+            f"- Project: {self.project_dir}",
+            f"- Datasource: {self.datasource}",
+            f"- SpatialData: {self.spatialdata_path or '<provided table>'}",
+            f"- Table: {self.table_name}",
+            f"- Region key: {self.region_key}",
+            f"- Instance key: {self.instance_key}",
+            f"- Rows: {self.instance_count}",
+            f"- Key action: {self.key_action}",
+            f"- Annotation key: {self.annotation_key}",
+            f"- Annotation columns: {', '.join(self.annotation_columns) if self.annotation_columns else '<none>'}",
+            f"- Missing annotations filled: {self.missing_annotation_count}",
+            f"- Applied: {self.applied}",
+        ]
+        if self.preservation_column is not None:
+            lines.append(f"- Preserved previous key values in: {self.preservation_column}")
+        if self.backup_dir is not None:
+            lines.append(f"- Backup: {self.backup_dir}")
+        return "\n".join(lines)
+
+
+def patch_spatial_annotations(
+    project_dir: str,
+    annotation_csv: str,
+    *,
+    datasource: str = "cells",
+    spatialdata_path: str | None = None,
+    table_name: str | None = None,
+    annotation_key: str | None = None,
+    separator: str = ",",
+    missing_value: str = "ND",
+    apply_changes: bool = False,
+    overwrite_preserved: bool = False,
+) -> SpatialAnnotationPatchReport:
+    """Patch an existing MDV project using the SpatialData table instance key."""
+    adata, resolved_spatialdata_path, resolved_table_name = _load_spatial_table(
+        project_dir,
+        spatialdata_path=spatialdata_path,
+        table_name=table_name,
+    )
+    return patch_spatial_annotations_from_table(
+        project_dir,
+        annotation_csv,
+        adata,
+        table_name=resolved_table_name,
+        spatialdata_path=resolved_spatialdata_path,
+        datasource=datasource,
+        annotation_key=annotation_key,
+        separator=separator,
+        missing_value=missing_value,
+        apply_changes=apply_changes,
+        overwrite_preserved=overwrite_preserved,
+    )
+
+
+def patch_spatial_annotations_from_table(
+    project_dir: str,
+    annotation_data: str | pandas.DataFrame,
+    adata: "AnnData",
+    *,
+    table_name: str,
+    spatialdata_path: str | None = None,
+    datasource: str = "cells",
+    annotation_key: str | None = None,
+    separator: str = ",",
+    missing_value: str = "ND",
+    apply_changes: bool = False,
+    overwrite_preserved: bool = False,
+) -> SpatialAnnotationPatchReport:
+    """Patch an existing MDV project from an already-loaded SpatialData table."""
+    from spatialdata.models import get_table_keys
+
+    _validate_project_dir(project_dir)
+
+    try:
+        region, region_key, instance_key = get_table_keys(adata)
+    except ValueError as error:
+        raise ValueError(
+            "SpatialData table does not define table keys in uns['spatialdata_attrs']."
+        ) from error
+
+    if instance_key not in adata.obs.columns:
+        raise ValueError(
+            f"SpatialData instance key '{instance_key}' is not present in table obs columns."
+        )
+
+    source_ids = _coerce_key_values(adata.obs[instance_key], instance_key)
+    _validate_no_duplicates(source_ids, f"SpatialData instance key '{instance_key}'")
+
+    project = MDVProject(project_dir)
+    ds_metadata = project.get_datasource_metadata(datasource)
+    project_size = ds_metadata.get("size")
+    if project_size != len(source_ids):
+        raise ValueError(
+            f"Datasource '{datasource}' has {project_size} rows but SpatialData table "
+            f"'{table_name}' has {len(source_ids)} rows. V1 requires matching row order."
+        )
+
+    annotation_df = _load_annotation_dataframe(annotation_data, separator)
+    annotation_key = annotation_key or instance_key
+    annotation_df, annotation_columns = _normalize_annotation_dataframe(
+        annotation_df,
+        annotation_key=annotation_key,
+        instance_key=instance_key,
+    )
+    missing_annotation_count = _validate_annotation_keys(
+        annotation_df,
+        annotation_key=instance_key,
+        source_ids=source_ids,
+    )
+
+    current_fields = {column["field"] for column in ds_metadata["columns"]}
+    current_key_values: list[Any] | None = None
+    current_key_metadata = None
+    key_action = "add"
+    preservation_column: str | None = None
+
+    if instance_key in current_fields:
+        current_key_metadata = next(
+            column for column in ds_metadata["columns"] if column["field"] == instance_key
+        )
+        current_key_values = _read_mdv_column(project_dir, ds_metadata, datasource, instance_key)
+        current_key_strings = [str(value) for value in current_key_values]
+        values_match = current_key_strings == source_ids
+        if values_match and current_key_metadata.get("datatype") == "unique":
+            key_action = "unchanged"
+        elif values_match:
+            key_action = "rewrite datatype"
+        else:
+            key_action = "repair"
+            preservation_column = _preservation_column(instance_key)
+            if preservation_column in current_fields and not overwrite_preserved:
+                raise ValueError(
+                    f"Cannot preserve previous '{instance_key}' values because "
+                    f"'{preservation_column}' already exists in datasource '{datasource}'. "
+                    "Pass overwrite_preserved=True to replace it."
+                )
+
+    if apply_changes:
+        backup_dir = _backup_project_files(project_dir)
+        if preservation_column is not None:
+            assert current_key_values is not None
+            project.set_column(
+                datasource,
+                {
+                    "name": preservation_column,
+                    "field": preservation_column,
+                    "datatype": "unique",
+                },
+                [str(value) for value in current_key_values],
+            )
+        if key_action != "unchanged":
+            project.set_column(
+                datasource,
+                {
+                    "name": instance_key,
+                    "field": instance_key,
+                    "datatype": "unique",
+                },
+                source_ids,
+            )
+        _write_annotation_columns(
+            project,
+            datasource=datasource,
+            annotation_df=annotation_df,
+            annotation_columns=annotation_columns,
+            annotation_key=instance_key,
+            source_ids=source_ids,
+            missing_value=missing_value,
+        )
+    else:
+        backup_dir = None
+
+    return SpatialAnnotationPatchReport(
+        project_dir=project_dir,
+        datasource=datasource,
+        spatialdata_path=spatialdata_path,
+        table_name=table_name,
+        region=region,
+        region_key=region_key,
+        instance_key=instance_key,
+        instance_count=len(source_ids),
+        key_action=key_action,
+        preservation_column=preservation_column,
+        annotation_key=annotation_key,
+        annotation_columns=annotation_columns,
+        missing_annotation_count=missing_annotation_count,
+        applied=apply_changes,
+        backup_dir=backup_dir,
+    )
+
+
+def _validate_project_dir(project_dir: str) -> None:
+    required_files = ("datafile.h5", "datasources.json")
+    missing = [
+        filename for filename in required_files
+        if not os.path.exists(os.path.join(project_dir, filename))
+    ]
+    if missing:
+        raise FileNotFoundError(
+            f"'{project_dir}' does not appear to be an MDV project "
+            f"(missing {', '.join(missing)})."
+        )
+
+
+def _load_spatial_table(
+    project_dir: str,
+    *,
+    spatialdata_path: str | None,
+    table_name: str | None,
+) -> tuple["AnnData", str, str]:
+    from anndata import AnnData
+
+    resolved_path = spatialdata_path or _detect_single_spatialdata_path(project_dir)
+    sdata = _read_spatialdata_zarr(resolved_path)
+
+    table_items = list(sdata.tables.items())
+    if table_name is None:
+        if len(table_items) != 1:
+            table_names = ", ".join(name for name, _adata in table_items) or "<none>"
+            raise ValueError(
+                "V1 requires exactly one SpatialData table when --table-name is not supplied. "
+                f"Found {len(table_items)} table(s): {table_names}."
+            )
+        resolved_table_name, adata = table_items[0]
+    else:
+        if table_name not in sdata.tables:
+            table_names = ", ".join(name for name, _adata in table_items) or "<none>"
+            raise ValueError(
+                f"SpatialData table '{table_name}' was not found. Available tables: {table_names}."
+            )
+        resolved_table_name = table_name
+        adata = sdata.tables[table_name]
+
+    if not isinstance(adata, AnnData):
+        raise ValueError(f"SpatialData table '{resolved_table_name}' is not an AnnData table.")
+    return adata, resolved_path, resolved_table_name
+
+
+def _detect_single_spatialdata_path(project_dir: str) -> str:
+    spatial_dir = os.path.join(project_dir, "spatial")
+    if not os.path.isdir(spatial_dir):
+        raise FileNotFoundError(
+            f"Cannot auto-detect SpatialData because '{spatial_dir}' does not exist."
+        )
+
+    candidates: list[str] = []
+    for path in [spatial_dir] + [
+        os.path.join(spatial_dir, child)
+        for child in sorted(os.listdir(spatial_dir))
+        if not child.startswith(".")
+    ]:
+        if not os.path.isdir(path):
+            continue
+        try:
+            _read_spatialdata_zarr(path)
+        except Exception:
+            continue
+        candidates.append(path)
+
+    if len(candidates) != 1:
+        candidate_text = ", ".join(candidates) if candidates else "<none>"
+        raise ValueError(
+            "V1 requires exactly one SpatialData store under the project spatial folder. "
+            f"Found {len(candidates)} candidate(s): {candidate_text}."
+        )
+    return candidates[0]
+
+
+def _read_spatialdata_zarr(path: str):
+    import spatialdata as sd
+
+    ome_logger = logging.getLogger("ome_zarr.reader")
+    original_level = ome_logger.level
+    ome_logger.setLevel(logging.ERROR)
+    try:
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=UserWarning)
+            return sd.read_zarr(path)
+    finally:
+        ome_logger.setLevel(original_level)
+
+
+def _coerce_key_values(values: Any, key_name: str) -> list[str]:
+    if not isinstance(values, pandas.Series):
+        values = pandas.Series(values)
+    if values.isna().any():
+        raise ValueError(f"Key column '{key_name}' contains missing values.")
+    return [str(value) for value in values.tolist()]
+
+
+def _validate_no_duplicates(values: list[str], label: str) -> None:
+    seen: set[str] = set()
+    duplicates: list[str] = []
+    for value in values:
+        if value in seen and value not in duplicates:
+            duplicates.append(value)
+        seen.add(value)
+    if duplicates:
+        examples = ", ".join(duplicates[:5])
+        raise ValueError(
+            f"{label} contains {len(duplicates)} duplicate value(s), "
+            f"for example: {examples}."
+        )
+
+
+def _load_annotation_dataframe(
+    annotation_data: str | pandas.DataFrame,
+    separator: str,
+) -> pandas.DataFrame:
+    if isinstance(annotation_data, str):
+        return pandas.read_csv(annotation_data, sep=separator)
+    return annotation_data.copy()
+
+
+def _normalize_annotation_dataframe(
+    annotation_df: pandas.DataFrame,
+    *,
+    annotation_key: str,
+    instance_key: str,
+) -> tuple[pandas.DataFrame, list[str]]:
+    if annotation_key not in annotation_df.columns:
+        raise ValueError(
+            f"Annotation key '{annotation_key}' was not found in the annotation data."
+        )
+    if annotation_key != instance_key and instance_key in annotation_df.columns:
+        raise ValueError(
+            f"Cannot rename annotation key '{annotation_key}' to '{instance_key}' "
+            f"because the annotation data already contains a '{instance_key}' column."
+        )
+    if annotation_key != instance_key:
+        annotation_df = annotation_df.rename(columns={annotation_key: instance_key})
+    annotation_columns = [
+        column for column in annotation_df.columns
+        if column != instance_key
+    ]
+    return annotation_df, annotation_columns
+
+
+def _validate_annotation_keys(
+    annotation_df: pandas.DataFrame,
+    *,
+    annotation_key: str,
+    source_ids: list[str],
+) -> int:
+    annotation_ids = _coerce_key_values(annotation_df[annotation_key], annotation_key)
+    _validate_no_duplicates(annotation_ids, f"Annotation key '{annotation_key}'")
+    annotation_df[annotation_key] = annotation_ids
+
+    source_id_set = set(source_ids)
+    annotation_id_set = set(annotation_ids)
+    extra_ids = annotation_id_set - source_id_set
+    if extra_ids:
+        examples = ", ".join(sorted(extra_ids)[:5])
+        raise ValueError(
+            f"Annotation data contains {len(extra_ids)} id(s) not present in the "
+            f"SpatialData instance key '{annotation_key}', for example: {examples}."
+        )
+    return len(source_id_set - annotation_id_set)
+
+
+def _preservation_column(instance_key: str) -> str:
+    if instance_key == "cell_id":
+        return "cell_index"
+    return f"{instance_key}_index"
+
+
+def _backup_project_files(project_dir: str) -> str:
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
+    backup_dir = os.path.join(project_dir, "annotation_patch_backups", timestamp)
+    os.makedirs(backup_dir, exist_ok=False)
+    for filename in ("datafile.h5", "datasources.json"):
+        shutil.copy2(os.path.join(project_dir, filename), os.path.join(backup_dir, filename))
+    return backup_dir
+
+
+def _read_mdv_column(
+    project_dir: str,
+    datasource_metadata: dict[str, Any],
+    datasource: str,
+    column: str,
+) -> list[Any]:
+    column_metadata = next(
+        metadata for metadata in datasource_metadata["columns"]
+        if metadata["field"] == column
+    )
+    with h5py.File(os.path.join(project_dir, "datafile.h5"), "r") as h5:
+        group = h5[datasource]
+        if not isinstance(group, h5py.Group):
+            raise AttributeError(f"'{datasource}' is not a group in datafile.h5")
+        raw_data = numpy.array(group[column])
+
+    datatype = column_metadata["datatype"]
+    if datatype in {"text", "text16"}:
+        values = column_metadata["values"]
+        return [values[index] for index in raw_data]
+    if datatype == "multitext":
+        string_length = column_metadata["stringLength"]
+        chunks = numpy.split(raw_data, int(raw_data.shape[0] / string_length))
+        values = column_metadata["values"]
+        return [
+            ",".join(values[index] for index in chunk if index != 65535)
+            for chunk in chunks
+        ]
+    if datatype == "unique":
+        return [
+            value.decode("utf-8") if isinstance(value, bytes) else str(value)
+            for value in raw_data
+        ]
+    return list(raw_data)
+
+
+def _write_annotation_columns(
+    project: MDVProject,
+    *,
+    datasource: str,
+    annotation_df: pandas.DataFrame,
+    annotation_columns: list[str],
+    annotation_key: str,
+    source_ids: list[str],
+    missing_value: str,
+) -> None:
+    annotation_by_id = annotation_df.set_index(annotation_key)
+    for column in annotation_columns:
+        values_by_id = annotation_by_id[column].to_dict()
+        values = [
+            values_by_id.get(source_id, missing_value)
+            for source_id in source_ids
+        ]
+        values = [
+            missing_value if pandas.isna(value) else value
+            for value in values
+        ]
+        project.set_column(
+            datasource,
+            {
+                "name": column,
+                "field": column,
+                "datatype": "text",
+            },
+            values,
+        )

--- a/python/mdvtools/tests/test_conversion_edge_cases.py
+++ b/python/mdvtools/tests/test_conversion_edge_cases.py
@@ -363,6 +363,32 @@ class TestConversionWithEdgeCases:
             assert "X_umap_2" in columns
             assert columns["leiden"]["datatype"] in ["text", "text16"]
 
+    def test_cell_id_key_survives_concat_and_export(self):
+        """SpatialData instance_key values should be exported instead of synthetic concat indices.
+        
+        This is now a dumbed-down version of the test that just checks the cell_id case that we know was broken before.
+        We may in future have more things based on analysis of instance_key from get_table_keys in spatialdata.
+        """
+        factory = MockAnnDataFactory(random_seed=42)
+        adata = factory.create_minimal(5, 3)
+        xenium_ids = [f"aaaaaaa{i}-1" for i in range(5)]
+        adata.obs["cell_id"] = xenium_ids
+        adata.obs["region"] = "cell_circles"
+        adata.uns["spatialdata_attrs"] = {
+            "region": "cell_circles",
+            "region_key": "region",
+            "instance_key": "cell_id",
+        }
+
+        merged = _concat_spatial_tables([adata])
+
+        with temp_mdv_project() as test_dir:
+            with suppress_anndata_warnings():
+                mdv = convert_scanpy_to_mdv(test_dir, merged, delete_existing=True)
+
+            assert mdv.get_column("cells", "cell_id") == xenium_ids
+            assert mdv.get_column("cells", "mdv_cell_id") == list(merged.obs_names.astype(str))
+
 
 class TestConversionErrorHandling:
     """Test class for error handling during conversion."""

--- a/python/mdvtools/tests/test_spatial_annotation_patch.py
+++ b/python/mdvtools/tests/test_spatial_annotation_patch.py
@@ -1,0 +1,244 @@
+import os
+
+os.environ.setdefault("NUMBA_DISABLE_JIT", "1")
+
+import numpy as np
+import pandas as pd
+import pytest
+from anndata import AnnData
+
+from mdvtools.mdvproject import MDVProject
+from mdvtools.spatial.annotations import patch_spatial_annotations_from_table
+
+
+def _make_table(instance_key="cell_id", ids=None):
+    if ids is None:
+        ids = [f"real_{index}" for index in range(5)]
+    obs = pd.DataFrame(
+        {
+            instance_key: ids,
+            "region": ["cell_circles"] * len(ids),
+        },
+        index=pd.Index([str(index) for index in range(len(ids))]),
+    )
+    adata = AnnData(
+        X=np.ones((len(ids), 1), dtype=np.float32),
+        obs=obs,
+        var=pd.DataFrame(index=pd.Index(["gene"])),
+    )
+    adata.uns["spatialdata_attrs"] = {
+        "region": "cell_circles",
+        "region_key": "region",
+        "instance_key": instance_key,
+    }
+    return adata
+
+
+def _make_project(tmp_path, key_field="cell_id", key_values=None, extra_columns=None):
+    if key_values is None:
+        key_values = [f"{index}_0" for index in range(5)]
+    data = {
+        key_field: key_values,
+        "value": list(range(len(key_values))),
+    }
+    if extra_columns:
+        data.update(extra_columns)
+    project_dir = tmp_path / "project"
+    project = MDVProject(str(project_dir), delete_existing=True)
+    project.add_datasource(
+        "cells",
+        pd.DataFrame(data),
+        columns=[{"name": key_field, "field": key_field, "datatype": "unique"}],
+    )
+    return project_dir
+
+
+def _annotation(ids=None):
+    if ids is None:
+        ids = ["real_0", "real_1", "real_2", "real_3", "real_4"]
+    return pd.DataFrame(
+        {
+            "cell_id": ids,
+            "celltype": ["A", "B", "C", "D", "E"][: len(ids)],
+        }
+    )
+
+
+def test_patch_spatial_annotations_dry_run_does_not_write(tmp_path):
+    project_dir = _make_project(tmp_path)
+    adata = _make_table()
+
+    report = patch_spatial_annotations_from_table(
+        str(project_dir),
+        _annotation(),
+        adata,
+        table_name="table",
+    )
+
+    project = MDVProject(str(project_dir))
+    assert report.applied is False
+    assert report.key_action == "repair"
+    assert report.preservation_column == "cell_index"
+    assert project.get_column("cells", "cell_id") == [f"{index}_0" for index in range(5)]
+    fields = [column["field"] for column in project.get_datasource_metadata("cells")["columns"]]
+    assert "cell_index" not in fields
+    assert "celltype" not in fields
+
+
+def test_patch_spatial_annotations_apply_preserves_old_key_and_adds_annotations(tmp_path):
+    project_dir = _make_project(tmp_path)
+    adata = _make_table()
+
+    report = patch_spatial_annotations_from_table(
+        str(project_dir),
+        _annotation(ids=["real_0", "real_2", "real_4"]),
+        adata,
+        table_name="table",
+        apply_changes=True,
+    )
+
+    project = MDVProject(str(project_dir))
+    assert report.applied is True
+    assert report.missing_annotation_count == 2
+    assert report.backup_dir is not None
+    assert os.path.exists(os.path.join(report.backup_dir, "datafile.h5"))
+    assert os.path.exists(os.path.join(report.backup_dir, "datasources.json"))
+    assert project.get_column("cells", "cell_id") == [f"real_{index}" for index in range(5)]
+    assert project.get_column("cells", "cell_index") == [f"{index}_0" for index in range(5)]
+    assert project.get_column("cells", "celltype") == ["A", "ND", "B", "ND", "C"]
+
+
+def test_patch_spatial_annotations_is_idempotent(tmp_path):
+    project_dir = _make_project(tmp_path)
+    adata = _make_table()
+
+    patch_spatial_annotations_from_table(
+        str(project_dir),
+        _annotation(),
+        adata,
+        table_name="table",
+        apply_changes=True,
+    )
+    report = patch_spatial_annotations_from_table(
+        str(project_dir),
+        _annotation(),
+        adata,
+        table_name="table",
+        apply_changes=True,
+    )
+
+    project = MDVProject(str(project_dir))
+    fields = [column["field"] for column in project.get_datasource_metadata("cells")["columns"]]
+    assert report.key_action == "unchanged"
+    assert fields.count("cell_id") == 1
+    assert fields.count("cell_index") == 1
+    assert fields.count("celltype") == 1
+
+
+def test_patch_spatial_annotations_rejects_duplicate_annotation_ids(tmp_path):
+    project_dir = _make_project(tmp_path)
+    adata = _make_table()
+    annotations = pd.DataFrame(
+        {
+            "cell_id": ["real_0", "real_0"],
+            "celltype": ["A", "B"],
+        }
+    )
+
+    with pytest.raises(ValueError, match="duplicate"):
+        patch_spatial_annotations_from_table(
+            str(project_dir),
+            annotations,
+            adata,
+            table_name="table",
+        )
+
+
+def test_patch_spatial_annotations_rejects_extra_annotation_ids(tmp_path):
+    project_dir = _make_project(tmp_path)
+    adata = _make_table()
+    annotations = pd.DataFrame(
+        {
+            "cell_id": ["real_0", "not_in_project"],
+            "celltype": ["A", "B"],
+        }
+    )
+
+    with pytest.raises(ValueError, match="not present"):
+        patch_spatial_annotations_from_table(
+            str(project_dir),
+            annotations,
+            adata,
+            table_name="table",
+        )
+
+
+def test_patch_spatial_annotations_rejects_preservation_conflict(tmp_path):
+    project_dir = _make_project(
+        tmp_path,
+        extra_columns={"cell_index": [f"existing_{index}" for index in range(5)]},
+    )
+    adata = _make_table()
+
+    with pytest.raises(ValueError, match="cell_index"):
+        patch_spatial_annotations_from_table(
+            str(project_dir),
+            _annotation(),
+            adata,
+            table_name="table",
+            apply_changes=True,
+        )
+
+
+def test_patch_spatial_annotations_supports_non_cell_id_instance_key(tmp_path):
+    source_ids = [f"instance_{index}" for index in range(5)]
+    project_dir = _make_project(
+        tmp_path,
+        key_field="instance_id",
+        key_values=[f"old_{index}" for index in range(5)],
+    )
+    adata = _make_table(instance_key="instance_id", ids=source_ids)
+    annotations = pd.DataFrame(
+        {
+            "instance_id": ["instance_0", "instance_1", "instance_2"],
+            "celltype": ["A", "B", "C"],
+        }
+    )
+
+    report = patch_spatial_annotations_from_table(
+        str(project_dir),
+        annotations,
+        adata,
+        table_name="table",
+        apply_changes=True,
+    )
+
+    project = MDVProject(str(project_dir))
+    assert report.instance_key == "instance_id"
+    assert report.preservation_column == "instance_id_index"
+    assert project.get_column("cells", "instance_id") == source_ids
+    assert project.get_column("cells", "instance_id_index") == [f"old_{index}" for index in range(5)]
+    assert project.get_column("cells", "celltype") == ["A", "B", "C", "ND", "ND"]
+
+
+def test_patch_spatial_annotations_can_rename_incoming_annotation_key(tmp_path):
+    project_dir = _make_project(tmp_path)
+    adata = _make_table()
+    annotations = pd.DataFrame(
+        {
+            "barcode": ["real_0", "real_1"],
+            "celltype": ["A", "B"],
+        }
+    )
+
+    patch_spatial_annotations_from_table(
+        str(project_dir),
+        annotations,
+        adata,
+        table_name="table",
+        annotation_key="barcode",
+        apply_changes=True,
+    )
+
+    project = MDVProject(str(project_dir))
+    assert project.get_column("cells", "celltype") == ["A", "B", "ND", "ND", "ND"]


### PR DESCRIPTION
When we convert anndata, we avoid overwriting existing `"cell_id"`. https://github.com/Taylor-CCB-Group/MDV/issues/438.

We have also added a new cli command for simultaneously 
- patching this column in spatial projects when necessary, based on re-reading it from the original table data.
- adding additional columns of annotation joined on the `cell_id` in an annotation CSV file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New CLI command to patch spatial annotations from CSV with selectable datasource/table/instance-key mapping, delimiter and missing-value options, dry-run vs apply, and optional overwrite of preserved keys; creates backups when applying.
* **Bug Fixes**
  * Improved cell identifier generation during conversion to avoid identifier name collisions.
* **Tests**
  * Added comprehensive tests covering patching behavior, idempotency, validation, and conversion edge cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Taylor-CCB-Group/MDV/pull/444)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->