### PR TITLE
Fix slickgrid row selection and stray React component roots

### DIFF
--- a/src/charts/ChartManager.js
+++ b/src/charts/ChartManager.js
@@ -57,6 +57,7 @@ import connectIPC from "../utilities/InterProcessCommunication";
 import { addChartLink } from "../links/link_utils";
 import popoutChart from "@/utilities/Popout";
 import { makeObservable, observable, action, makeAutoObservable } from "mobx";
+import { createElement } from "react";
 import { createMdvPortal } from "@/react/react_utils";
 import ViewManager from "./ViewManager";
 import ErrorComponentReactWrapper from "@/react/components/ErrorComponentReactWrapper";
@@ -235,7 +236,7 @@ export class ChartManager {
         // classes: ["ciview-main-menu-bar"],
         this.menuBar = createEl("div", {}, this.containerDiv);
 
-        createMdvPortal(MenuBarWrapper(), this.menuBar);
+        createMdvPortal(createElement(MenuBarWrapper), this.menuBar);
 
         this._setupThemeContextMenu();
 
@@ -1901,7 +1902,7 @@ export class ChartManager {
                     { message: error }
                     :
                     { message: "An error occurred while creating the chart" };
-            createMdvPortal(ErrorComponentReactWrapper({ error: errorObj, height, width, extraMetaData: { config } }), debugNode);
+            createMdvPortal(createElement(ErrorComponentReactWrapper, { error: errorObj, height, width, extraMetaData: { config } }), debugNode);
             const closeButtonContainer = createEl(
                 "div",
                 {

--- a/src/charts/dialogs/ReusableAlertDialog.tsx
+++ b/src/charts/dialogs/ReusableAlertDialog.tsx
@@ -5,11 +5,12 @@ import {
     Dialog,
     DialogActions,
 } from "@mui/material";
+import type { ReactElement } from "react";
 
 export interface ReusableAlertDialogProps {
     open: boolean;
     handleClose: () => void;
-    component: JSX.Element;
+    component: ReactElement;
     isAlertErrorComponent?: boolean;
     isConfirmButton?: boolean;
     confirmText?: string;

--- a/src/charts/dialogs/ReusableDialog.tsx
+++ b/src/charts/dialogs/ReusableDialog.tsx
@@ -6,11 +6,12 @@ import {
     DialogActions,
     DialogContent,
 } from "@mui/material";
+import type { ReactElement } from "react";
 
 export interface ReusableDialogProps {
     open: boolean;
     handleClose: () => void;
-    component: JSX.Element;
+    component: ReactElement;
     isAlertErrorComponent?: boolean;
     isConfirmButton?: boolean;
     confirmText?: string;

--- a/src/dataloaders/DataLoaderUtil.ts
+++ b/src/dataloaders/DataLoaderUtil.ts
@@ -4,6 +4,7 @@ import {
 } from "./DataLoaders";
 import type { DataSource, DataColumn, DataType, LoadedDataColumn } from "@/charts/charts";
 import { isColumnLoaded } from "@/lib/columnTypeHelpers";
+import { createElement } from "react";
 import { createMdvPortal } from "@/react/react_utils";
 import ErrorComponentReactWrapper from "@/react/components/ErrorComponentReactWrapper";
 import { decompressData } from "./DataLoaders";
@@ -27,7 +28,7 @@ export async function fetchJsonConfig(url: string, root: string, createErrorComp
             document.body.style.display = "flex";
             document.body.style.justifyContent = "center";
             document.body.style.alignItems = "center";
-            createMdvPortal(ErrorComponentReactWrapper({ error: {message: `Error fetching JSON '${url}'`}, extraMetaData: {message: `${error}`} }), document.body);
+            createMdvPortal(createElement(ErrorComponentReactWrapper, { error: {message: `Error fetching JSON '${url}'`}, extraMetaData: {message: `${error}`} }), document.body);
         }
         console.error(`Error fetching ${url}: ${error}`);
         throw error;

--- a/src/modules/static_index.ts
+++ b/src/modules/static_index.ts
@@ -14,6 +14,7 @@ import BaseChart from "../charts/BaseChart";
 import type { DataSource } from "@/charts/charts";
 import { getProjectName } from "./ProjectContext";
 import { getApiRootFromDir, getProjectDirFromLocation } from "@/utils/mdvRouting";
+import { createElement } from "react";
 import { createMdvPortal } from "@/react/react_utils";
 import ProjectStateHandlerWrapper from "@/react/ProjectStateHandler";
 import type { Root } from "react-dom/client";
@@ -129,7 +130,7 @@ async function loadData() {
                 stateHandlerContainer.id = "mdv_state_handler";
                 document.body.appendChild(stateHandlerContainer);
             }
-            stateHandlerRoot = createMdvPortal(ProjectStateHandlerWrapper({root, data, staticFolder, permission}), stateHandlerContainer);
+            stateHandlerRoot = createMdvPortal(createElement(ProjectStateHandlerWrapper, {root, data, staticFolder, permission}), stateHandlerContainer);
         }
         if (type === "view_loaded") {
             changeURLParam("view", cm.viewManager.current_view);

--- a/src/react/components/DeckScatterComponent.tsx
+++ b/src/react/components/DeckScatterComponent.tsx
@@ -235,7 +235,7 @@ const DeckScatter = observer(function DeckScatterComponent({
     
     const outerContainer = useOuterContainer();
     const deckContainerRef = useRef<HTMLDivElement | null>(null);
-    const deckRef = useRef<any>();
+    const deckRef = useRef<any>(null);
     const getTooltipContent = useCallback(
         (info: PickingInfo) => {
             const richInfo = getPickingInfoWithAlternates(info, deckRef.current?.deck);

--- a/src/react/components/HistogramWidget.tsx
+++ b/src/react/components/HistogramWidget.tsx
@@ -64,7 +64,7 @@ const createScale = (
         : d3.scaleLinear().domain(domain).range(range);
 
 const useBrushX = (
-    ref: React.RefObject<SVGSVGElement>,
+    ref: React.RefObject<SVGSVGElement | null>,
     brushConfig: HistogramBrushConfig | undefined,
     histoWidth: number,
     histoHeight: number,

--- a/src/react/components/PopoutWindow.tsx
+++ b/src/react/components/PopoutWindow.tsx
@@ -17,8 +17,8 @@ export function PopoutWindow({ children, features = "width=600,height=400", titl
     // Popout window
     const externalWindow = useRef<Window | null>(null);
     // Theme and style observers
-    const themeObserver = useRef<MutationObserver>();
-    const observer = useRef<MutationObserver>();
+    const themeObserver = useRef<MutationObserver | null>(null);
+    const observer = useRef<MutationObserver | null>(null);
     const onCloseRef = useRef(onClose);
     const emotionCacheRef = useRef<EmotionCache | null>(null);
 

--- a/src/react/components/TextFieldExtended.tsx
+++ b/src/react/components/TextFieldExtended.tsx
@@ -1,5 +1,6 @@
 import { styled } from '@mui/material/styles';
 import { TextField, type TextFieldProps } from "@mui/material";
+import type { ReactElement } from "react";
 
 const StyledAdornment = styled('div')(({ theme }) => ({
     display: 'flex',
@@ -14,7 +15,7 @@ const StyledAdornment = styled('div')(({ theme }) => ({
 /** Modified version of TextField that allows a `customEndAdornment`
  * along with the standard endAdornment passed in `InputProps`.
  */
-export const TextFieldExtended = (props: TextFieldProps & { customEndAdornment?: JSX.Element; customStartAdornment?: JSX.Element}) => {
+export const TextFieldExtended = (props: TextFieldProps & { customEndAdornment?: ReactElement; customStartAdornment?: ReactElement}) => {
     const { InputProps, customEndAdornment, ...rest } = props;
     const inputProps: typeof InputProps = {
         ...InputProps,

--- a/src/react/components/VivScatterComponent.tsx
+++ b/src/react/components/VivScatterComponent.tsx
@@ -130,7 +130,7 @@ const Main = observer(
 
         const viewState = useViewerStore((store) => store.viewState);
         useViewStateLink();
-        const vsRef = useRef<ViewState>();
+        const vsRef = useRef<ViewState | null>(null);
         const vsDebugDivRef = useRef<HTMLPreElement>(null);
 
         useEffect(() => {

--- a/src/react/hooks.ts
+++ b/src/react/hooks.ts
@@ -687,7 +687,7 @@ export function useRangeDimension2D() {
 }
 
 
-export const useCloseOnIntersection = (ref: React.RefObject<HTMLElement>, onClose: () => void) => {
+export const useCloseOnIntersection = (ref: React.RefObject<HTMLElement | null>, onClose: () => void) => {
     useEffect(() => {
         if (!ref.current) return;
         // Observer to observe the an element and close it when it intersects the parent element (most likely while scrolling)
@@ -781,7 +781,7 @@ export const usePasteHandler = <T, V = T>({
  * Hook that provides the resize logic for a drawer
  */
 export const useResizeDrawer = (
-    dialogRef: React.RefObject<HTMLDivElement>, 
+    dialogRef: React.RefObject<HTMLDivElement | null>, 
     defaultDrawerWidth: number, 
     minDrawerWidth: number, 
     maxDrawerWidth: number

--- a/src/react/hooks/useSlickGridReact.ts
+++ b/src/react/hooks/useSlickGridReact.ts
@@ -668,6 +668,7 @@ const useSlickGridReact = () => {
                 multiSelect: true,
                 enableSelection: true,
                 selectionOptions: {
+                    selectionType: "row",
                     selectActiveRow: true,
                 },
                 headerMenu: {

--- a/src/react/hooks/useSlickGridReact.ts
+++ b/src/react/hooks/useSlickGridReact.ts
@@ -666,8 +666,8 @@ const useSlickGridReact = () => {
                 enableCellNavigation: true,
                 enableExcelCopyBuffer: true,
                 multiSelect: true,
-                enableRowSelection: true,
-                rowSelectionOptions: {
+                enableSelection: true,
+                selectionOptions: {
                     selectActiveRow: true,
                 },
                 headerMenu: {

--- a/src/react/react_utils.tsx
+++ b/src/react/react_utils.tsx
@@ -1,7 +1,7 @@
 import { createRoot } from "react-dom/client";
 import { createTheme, ThemeProvider } from "@mui/material/styles";
 import CssBaseline from "@mui/material/CssBaseline";
-import { type PropsWithChildren, StrictMode, useMemo } from "react";
+import { type PropsWithChildren, type ReactElement, StrictMode, useMemo } from "react";
 import { ProjectProvider } from "@/modules/ProjectContext";
 import { observer } from "mobx-react-lite";
 import type BaseChart from "@/charts/BaseChart";
@@ -92,7 +92,7 @@ const queryClient = new QueryClient({
  * If not provided, the default is document.body.
  * @returns the root element that was created
  */
-const createMdvPortal = (component: JSX.Element, container: HTMLElement, parent?: BaseChart<any> | BaseDialog) => {
+const createMdvPortal = (component: ReactElement, container: HTMLElement, parent?: BaseChart<any> | BaseDialog) => {
     const root = createRoot(container);
     root.render(
         <StrictMode>

--- a/src/react/screen_state.tsx
+++ b/src/react/screen_state.tsx
@@ -1,7 +1,7 @@
 import type BaseChart from "@/charts/BaseChart";
 import type { BaseDialog } from "@/utilities/Dialog";
 import { observer } from "mobx-react-lite";
-import { createContext, useContext } from "react";
+import { createContext, type ReactElement, useContext } from "react";
 import type { createMdvPortal } from "./react_utils";
 import createCache, { type EmotionCache } from "@emotion/cache";
 import { CacheProvider } from "@emotion/react";
@@ -50,7 +50,7 @@ export function useEmotionCache(container: HTMLElement) {
  * hopefully the implementation will be easy to change if/when necessary.
  */
 export const OuterContainerProvider = observer(
-    ({ children, parent }: { children: JSX.Element; parent?: BaseChart<any> | BaseDialog }) => {
+    ({ children, parent }: { children: ReactElement; parent?: BaseChart<any> | BaseDialog }) => {
         const container = parent?.observable?.container || document.body;
         const cache = useEmotionCache(container);
         return (

--- a/src/tests/table_react/hooks/testUtils/createSlickGridMock.ts
+++ b/src/tests/table_react/hooks/testUtils/createSlickGridMock.ts
@@ -37,6 +37,7 @@ export function createSlickGridMock(): SlickgridReactInstance {
             unsubscribe: vi.fn(),
         })),
         publish: vi.fn(),
+        unsubscribeAll: vi.fn(),
     };
 
     const mockSlickGrid = {


### PR DESCRIPTION
## Summary

Cherry-picks three small, independent fixes from the `react-compiler` branch onto `main` so they can land without waiting for the larger experiment:

- **`fix places where react components aren't created properly`** (`5e0a4b8c`) — fixes a few call sites in `ChartManager.js`, `DataLoaderUtil.ts`, and `static_index.ts` where React roots/components were not being created/mounted correctly.
- **`fix types`** (`9535061e`) — type fixes after the React 19 + slickgrid 10.6 upgrade in `64de7292`. Includes the rename of the SlickGrid options `enableRowSelection` / `rowSelectionOptions` to `enableSelection` / `selectionOptions` (the legacy names were dropped from `@slickgrid-universal/common` 10.x).
- **`fix slickgrid selection-type "row"`** (`df9d4c5c`) — restores full-row highlighting in the SlickGrid table. The new `HybridSelectionModelOption` defaults `selectionType` to `'mixed'`, which only selects whole rows on handler columns; setting `selectionType: 'row'` brings back the previous click-to-select-whole-row behaviour.

The last commit fixes a regression introduced by the second; both should land together.

## Test plan

- [x] `pnpm install` and `pnpm exec tsgo` from the repo root (TS files changed, per `AGENTS.md`).
- [x] Open a project that uses the SlickGrid React table and confirm clicking a row highlights the whole row, not just the cell.
- [x] Smoke-test the components touched by `5e0a4b8c` (chart manager loading, data loader util, static index entry) to confirm React roots mount as expected.


Made with [Cursor](https://cursor.com)