### PR TITLE
fix deck mouse event rebinding for new versions (fix #446)

### DIFF
--- a/src/lib/deckMonkeypatch.ts
+++ b/src/lib/deckMonkeypatch.ts
@@ -12,6 +12,9 @@ class MonkeyPatchDeck extends Deck<any> {
     declare public viewManager;
     declare public animationLoop;
     declare public canvas;
+    declare _onPointerDown: (event: unknown) => void;
+    declare _onPointerMove: (event: unknown) => void;
+    declare _onPointerUp?: (event: unknown) => void;
 }
 
 /**
@@ -44,25 +47,7 @@ class EditableLayer {
 ```
 */
 
-export class MonkeyPatchEditableGeoJsonLayer extends EditableGeoJsonLayer {
-    declare _onanyclick: (event: any) => void;
-
-    override _addEventHandlers() {
-        super._addEventHandlers();
-        // @ts-expect-error accessing protected props
-        const { eventManager } = this.context.deck;
-        const { eventHandler } = this.state._editableLayerState;
-        console.warn('---monkey patch adding click -> anyclick handler to editable layer pending deck update---');
-        eventManager.on('click', eventHandler, { priority: 100 });
-        eventManager.on('dblclick', eventHandler, { priority: 100 });
-    }
-    _onclick(event: any) {
-        this._onanyclick(event);
-    }
-    _ondblclick(event: any) {
-        this._onanyclick(event);
-    }
-}
+export class MonkeyPatchEditableGeoJsonLayer extends EditableGeoJsonLayer {}
 
 const EVENT_HANDLERS: { [eventName: string]: string } = {
     click: 'onClick', //is onClick a thing?
@@ -80,6 +65,14 @@ const RECOGNIZERS = {
     // pointerdown is being handled by deck.js _onPointerDown which does picking...
     // and then we miss out.
     click: [Tap, { event: 'click' }, null, ['dblclick']],
+} as const;
+
+const DECK_EVENT_MANAGER_EVENTS = {
+    pointerdown: (deck: MonkeyPatchDeck) => deck._onPointerDown,
+    pointermove: (deck: MonkeyPatchDeck) => deck._onPointerMove,
+    pointerleave: (deck: MonkeyPatchDeck) => deck._onPointerMove,
+    // Without pointerup, tap/click recognizers and panend do not reliably fire.
+    pointerup: (deck: MonkeyPatchDeck) => deck._onPointerUp,
 } as const;
 
 
@@ -131,11 +124,11 @@ export function rebindMouseEvents(deckO: Deck<any>, selectionLayer?: EditableGeo
                 requestFailure
             };
         }),
-        events: {
-            pointerdown: deck._onPointerDown,
-            pointermove: deck._onPointerMove,
-            pointerleave: deck._onPointerMove
-        }
+        events: Object.fromEntries(
+            Object.entries(DECK_EVENT_MANAGER_EVENTS)
+                .map(([eventName, getHandler]) => [eventName, getHandler(deck)])
+                .filter(([, handler]) => typeof handler === "function")
+        ),
     });
     deck.eventManager = eventManager;
     for (const eventType in EVENT_HANDLERS) {

--- a/src/tests/lib/deckMonkeypatch.test.ts
+++ b/src/tests/lib/deckMonkeypatch.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+
+const {
+    eventManagerCtor,
+    eventManagerDestroy,
+    eventManagerOn,
+    recognizerCtor,
+} = vi.hoisted(() => {
+    return {
+        eventManagerCtor: vi.fn(),
+        eventManagerDestroy: vi.fn(),
+        eventManagerOn: vi.fn(),
+        recognizerCtor: vi.fn(function recognizer(this: object) {
+            return this;
+        }),
+    };
+});
+
+vi.mock("mjolnir.js", () => {
+    class MockEventManager {
+        constructor(...args: unknown[]) {
+            eventManagerCtor(...args);
+        }
+        destroy() {
+            eventManagerDestroy();
+        }
+        on(...args: unknown[]) {
+            eventManagerOn(...args);
+        }
+    }
+    return {
+        EventManager: MockEventManager,
+        InputDirection: { Vertical: "vertical" },
+        Pan: recognizerCtor,
+        Pinch: recognizerCtor,
+        Tap: recognizerCtor,
+    };
+});
+
+import { rebindMouseEvents } from "@/lib/deckMonkeypatch";
+
+describe("deckMonkeypatch", () => {
+    it("registers pointerup when rebinding deck events", () => {
+        const deck = {
+            props: { parent: null, touchAction: "none", eventRecognizerOptions: {} },
+            canvas: {} as HTMLElement,
+            eventManager: {
+                destroy: vi.fn(),
+            },
+            viewManager: {
+                _eventManager: null,
+                controllers: {},
+                _rebuildViewports: vi.fn(),
+                setNeedsUpdate: vi.fn(),
+            },
+            _onPointerDown: vi.fn(),
+            _onPointerMove: vi.fn(),
+            _onPointerUp: vi.fn(),
+            _onEvent: vi.fn(),
+        } as any;
+
+        rebindMouseEvents(deck);
+
+        const ctorArgs = eventManagerCtor.mock.calls.at(-1);
+        expect(ctorArgs).toBeTruthy();
+        const options = ctorArgs?.[1] as { events: Record<string, unknown> };
+        expect(options.events.pointerdown).toBe(deck._onPointerDown);
+        expect(options.events.pointermove).toBe(deck._onPointerMove);
+        expect(options.events.pointerleave).toBe(deck._onPointerMove);
+        expect(options.events.pointerup).toBe(deck._onPointerUp);
+    });
+});


### PR DESCRIPTION
Internals of `deckMonkeyPatch` were no longer aligned with what was needed after upgrading these packages.

This addresses that issue so there is no longer a regression (see https://github.com/Taylor-CCB-Group/MDV/issues/446).

Pop-out windows do still have issues, fullscreen appears to be fine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced event handling system for improved responsiveness and reliability of mouse and pointer interactions.

* **Tests**
  * Added unit test coverage for event management and mouse event binding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->