### PR TITLE
feature for selecting between subgroups in link UI, including serialisation and deserialisation

### DIFF
--- a/python/mdvtools/tests/generate_synthetic_anndata_project.py
+++ b/python/mdvtools/tests/generate_synthetic_anndata_project.py
@@ -26,6 +26,7 @@ from mdvtools.tests.mock_anndata import (
     MockAnnDataFactory,
     create_minimal_anndata,
 )
+from mdvtools.tests.mock_expression_layers import add_synth_expression_layers
 
 PROFILE_CHOICES = ("minimal", "realistic", "large", "memory-efficient")
 
@@ -91,6 +92,7 @@ def generate_project(
     sparse_density: float,
     chunk_data: bool,
     compute_x_umap: bool,
+    extra_expression_layers: bool,
     force: bool,
 ) -> None:
     if output.exists():
@@ -109,6 +111,8 @@ def generate_project(
         add_missing=add_missing,
         sparse_density=sparse_density,
     )
+    if extra_expression_layers:
+        add_synth_expression_layers(adata)
     mdv = convert_scanpy_to_mdv(
         str(output),
         adata,
@@ -129,6 +133,7 @@ def generate_project(
         "sparse_density": sparse_density,
         "chunk_data": chunk_data,
         "compute_x_umap": compute_x_umap,
+        "extra_expression_layers": extra_expression_layers,
         "cleanup_group": "synth-anndata",
     }
     mdv.state = state
@@ -189,6 +194,14 @@ def parse_args() -> argparse.Namespace:
         help="Run neighbors/UMAP/Leiden from X inside convert_scanpy_to_mdv.",
     )
     parser.add_argument(
+        "--extra-expression-layers",
+        action="store_true",
+        help=(
+            "Add AnnData.layers synth_layer_a and synth_layer_b so the project has "
+            "multiple rows_as_columns subgroups after conversion."
+        ),
+    )
+    parser.add_argument(
         "--output",
         type=Path,
         default=None,
@@ -223,6 +236,7 @@ def main() -> None:
         sparse_density=args.sparse_density,
         chunk_data=args.chunk_data,
         compute_x_umap=args.compute_x_umap,
+        extra_expression_layers=args.extra_expression_layers,
         force=args.force,
     )
 

--- a/python/mdvtools/tests/generate_synthetic_spatial_project.py
+++ b/python/mdvtools/tests/generate_synthetic_spatial_project.py
@@ -216,6 +216,27 @@ def _create_anndata(
     return adata
 
 
+def _add_extra_expression_layers(adata, rng: np.random.Generator) -> None:
+    """Add AnnData layers so MDV gets multiple rows_as_columns subgroups (see convert_scanpy_to_mdv)."""
+    from scipy import sparse as sp
+
+    if sp.issparse(adata.X):
+        adata.layers["synth_layer_a"] = adata.X.copy()
+        b = adata.X.copy()
+        b.data = np.log1p(np.asarray(b.data, dtype=np.float64) + 1e-6).astype(
+            np.float32, copy=False
+        )
+        adata.layers["synth_layer_b"] = b
+        return
+
+    x = np.asarray(adata.X, dtype=np.float32)
+    adata.layers["synth_layer_a"] = np.asarray(x, copy=True)
+    # Distinct from X / synth_layer_a so subgroup switching would be visible in the UI.
+    adata.layers["synth_layer_b"] = (
+        np.log1p(x + 1e-6) * 0.5 + rng.standard_normal(x.shape).astype(np.float32) * 0.01
+    )
+
+
 def _create_spatialdata(
     *,
     n_cells: int,
@@ -223,6 +244,7 @@ def _create_spatialdata(
     image_size: int,
     seed: int,
     coordinate_system_cell_counts: list[int],
+    extra_expression_layers: bool,
 ):
     try:
         import dummy_spatialdata as ds
@@ -240,6 +262,8 @@ def _create_spatialdata(
         seed,
         coordinate_system_cell_counts,
     )
+    if extra_expression_layers:
+        _add_extra_expression_layers(adata, rng=np.random.default_rng(seed))
     image_shape = {"x": image_size, "y": image_size}
     coordinate_system_names = [
         "global" if n_coordinate_systems == 1 else f"coordinate_system_{i}"
@@ -542,6 +566,7 @@ def generate_project(
     n_coordinate_systems: int,
     coordinate_system_cell_counts: list[int],
     force: bool,
+    extra_expression_layers: bool = False,
 ) -> None:
     if n_cells != sum(coordinate_system_cell_counts):
         raise SystemExit("n-cells must match the sum of coordinate-system cell counts")
@@ -567,6 +592,7 @@ def generate_project(
             image_size=image_size,
             seed=seed,
             coordinate_system_cell_counts=coordinate_system_cell_counts,
+            extra_expression_layers=extra_expression_layers,
         )
         sdata.write(str(source_path))
 
@@ -603,6 +629,7 @@ def generate_project(
             "seed": seed,
             "n_coordinate_systems": n_coordinate_systems,
             "coordinate_system_cell_counts": coordinate_system_cell_counts,
+            "extra_expression_layers": extra_expression_layers,
             "cleanup_group": "synth-spatial",
         }
         mdv.state = state
@@ -642,6 +669,14 @@ def parse_args() -> argparse.Namespace:
         help="Output MDV project path. Defaults to a flat ~/mdv/synth-spatial--... path.",
     )
     parser.add_argument("--force", action="store_true")
+    parser.add_argument(
+        "--extra-expression-layers",
+        action="store_true",
+        help=(
+            "Add two AnnData.layers matrices (synth_layer_a, synth_layer_b) in addition to X, "
+            "so the MDV project has multiple rows_as_columns subgroups for UI / integration testing."
+        ),
+    )
     args = parser.parse_args()
     for flag, value in (
         ("--n-cells", args.n_cells),
@@ -683,6 +718,7 @@ def main() -> None:
         n_coordinate_systems=n_coordinate_systems,
         coordinate_system_cell_counts=coordinate_system_cell_counts,
         force=args.force,
+        extra_expression_layers=args.extra_expression_layers,
     )
 
 

--- a/python/mdvtools/tests/generate_test_data.py
+++ b/python/mdvtools/tests/generate_test_data.py
@@ -15,6 +15,7 @@ import inspect
 
 import scanpy as sc
 from mdvtools.tests.mock_anndata import create_minimal_anndata
+from mdvtools.tests.mock_expression_layers import add_synth_expression_layers
 from mdvtools.conversions import convert_scanpy_to_mdv
 
 
@@ -48,6 +49,9 @@ Examples:
 
   # Create project with a unique column for manual integration testing (edit from frontend)
   python -m mdvtools.tests.generate_test_data ~/mdv/test_unique --mock --with-unique-column
+
+  # Small mock project with multiple expression layers (rows_as_columns subgroups gs + synth_*)
+  python -m mdvtools.tests.generate_test_data ~/mdv/mock-multilayer-interactive --mock --n-cells 80 --n-genes 40 --extra-expression-layers
 
   # Create project from scanpy dataset
   python -m mdvtools.tests.generate_test_data ~/mdv/test_pbmc3k --scanpy pbmc3k_processed
@@ -101,7 +105,15 @@ See https://scanpy.readthedocs.io/en/1.11.x/api/datasets.html for available scan
         action='store_true',
         help='Add a unique-typed column (e.g. cell_id) to the first datasource for manual testing of unique column edit/round-trip'
     )
-    
+    parser.add_argument(
+        '--extra-expression-layers',
+        action='store_true',
+        help=(
+            "Add AnnData.layers synth_layer_a and synth_layer_b (mock/scanpy) so the project has "
+            "multiple rows_as_columns subgroups after conversion."
+        ),
+    )
+
     args = parser.parse_args()
     
     # Expand user path
@@ -138,8 +150,12 @@ See https://scanpy.readthedocs.io/en/1.11.x/api/datasets.html for available scan
             sys.exit(1)
         
         adata = dataset_loaders[dataset]()
-        assert(isinstance(adata, sc.AnnData))
-    
+        assert isinstance(adata, sc.AnnData)
+
+    if args.extra_expression_layers:
+        add_synth_expression_layers(adata)
+        print("  Added AnnData.layers: synth_layer_a, synth_layer_b")
+
     print(f"AnnData: {adata.n_obs:,} cells x {adata.n_vars:,} genes")
     
     # Convert to MDV project
@@ -171,7 +187,11 @@ See https://scanpy.readthedocs.io/en/1.11.x/api/datasets.html for available scan
         # Also include actual dimensions from the loaded data
         provenance["parameters"]["n_cells"] = adata.n_obs
         provenance["parameters"]["n_genes"] = adata.n_vars
-    
+
+    if args.extra_expression_layers:
+        provenance["parameters"]["extra_expression_layers"] = True
+        provenance["cleanup_group"] = "interactive-mock-multilayer"
+
     # Add provenance to state
     state["provenance"] = provenance
     project.state = state

--- a/python/mdvtools/tests/mock_expression_layers.py
+++ b/python/mdvtools/tests/mock_expression_layers.py
@@ -1,0 +1,13 @@
+"""Optional extra AnnData.layers for MDV rows_as_columns subgroup testing."""
+
+from __future__ import annotations
+
+import numpy as np
+import scanpy as sc
+
+
+def add_synth_expression_layers(adata: sc.AnnData) -> None:
+    """Add two layers alongside X so convert_scanpy_to_mdv creates multiple link subgroups."""
+    x = np.asarray(adata.X, dtype=np.float32)
+    adata.layers["synth_layer_a"] = np.asarray(x, copy=True)
+    adata.layers["synth_layer_b"] = np.log1p(x + 1e-6).astype(np.float32)

--- a/python/mdvtools/tests/test_project_factory.py
+++ b/python/mdvtools/tests/test_project_factory.py
@@ -13,6 +13,7 @@ import logging
 import shutil
 import scanpy as sc
 from mdvtools.tests.mock_anndata import create_minimal_anndata
+from mdvtools.tests.mock_expression_layers import add_synth_expression_layers
 from mdvtools.conversions import convert_scanpy_to_mdv
 
 logger = logging.getLogger(__name__)
@@ -23,7 +24,8 @@ def create_test_h5ad_file(
     source: str = 'mock',
     dataset: str | None = None,
     n_cells: int = 100,
-    n_genes: int = 200
+    n_genes: int = 200,
+    extra_expression_layers: bool = False,
 ) -> str:
     """Create a test .h5ad file for upload tests.
     
@@ -55,7 +57,10 @@ def create_test_h5ad_file(
             raise ValueError(f"Unknown dataset: {dataset}. Available: pbmc3k, pbmc3k_processed")
     else:
         raise ValueError(f"Unknown source: {source}. Available: mock, scanpy")
-    
+
+    if extra_expression_layers:
+        add_synth_expression_layers(adata)
+
     # Ensure directory exists
     output_dir = os.path.dirname(output_path)
     if output_dir:
@@ -73,7 +78,8 @@ def create_test_project_zip(
     source: str = 'mock',
     dataset: str | None = None,
     n_cells: int = 100,
-    n_genes: int = 200
+    n_genes: int = 200,
+    extra_expression_layers: bool = False,
 ) -> str:
     """Create a test MDV project zip file for import tests.
     
@@ -109,7 +115,10 @@ def create_test_project_zip(
                 raise ValueError(f"Unknown dataset: {dataset}. Available: pbmc3k, pbmc3k_processed")
         else:
             raise ValueError(f"Unknown source: {source}. Available: mock, scanpy")
-        
+
+        if extra_expression_layers:
+            add_synth_expression_layers(adata)
+
         logger.info("Converting AnnData to MDV project...")
         convert_scanpy_to_mdv(project_dir, adata)
         

--- a/python/mdvtools/tests/test_rows_as_columns_expression_layers.py
+++ b/python/mdvtools/tests/test_rows_as_columns_expression_layers.py
@@ -1,0 +1,33 @@
+"""
+Extra AnnData.layers become multiple rows_as_columns subgroups (same path as
+SpatialData merge → convert_scanpy_to_mdv). Synthetic SpatialData can add
+layers via generate_synthetic_spatial_project --extra-expression-layers.
+"""
+
+import numpy as np
+import scanpy as sc
+
+from mdvtools.conversions import convert_scanpy_to_mdv
+from mdvtools.mdvproject import MDVProject
+
+
+def test_annadata_layers_yield_multiple_subgroups(tmp_path):
+    n_cells, n_genes = 30, 10
+    rng = np.random.default_rng(0)
+    x = rng.random((n_cells, n_genes)).astype(np.float32)
+    adata = sc.AnnData(X=x)
+    adata.layers["synth_layer_a"] = np.asarray(x, copy=True)
+    adata.layers["synth_layer_b"] = np.log1p(x + 1e-6)
+
+    out = tmp_path / "proj"
+    convert_scanpy_to_mdv(str(out), adata, delete_existing=True)
+
+    project = MDVProject(str(out))
+    links = project.get_links("cells", "rows_as_columns")
+    assert links
+    rac = links[0]["link"]["rows_as_columns"]
+    names = set((rac.get("subgroups") or {}).keys())
+    assert "gs" in names
+    assert "synth_layer_a" in names
+    assert "synth_layer_b" in names
+    assert len(names) >= 3

--- a/src/charts/schemas/ChartConfigSchema.ts
+++ b/src/charts/schemas/ChartConfigSchema.ts
@@ -26,8 +26,10 @@ export const ParamTypeSchema = z.enum([
 export const RowsAsColsQuerySerializedSchema = z.object({
     type: z.literal("RowsAsColsQuery").describe("Identifies this as a rows-as-columns query"),
     linkedDsName: z.string().describe("Name of the linked datasource that contains the row data"),
-    // TODO - should have subgroup name
-    maxItems: z.number().int().positive().describe("Maximum number of items to retrieve from the linked datasource")
+    subgroupName: z.string().optional().describe(
+        "Canonical rows-as-columns subgroup key (see link `subgroups`). New `RowsAsColsQuery.toJSON` output always includes this; omit = first subgroup. Zod: keep optional until legacy configs are migrated, then make required.",
+    ),
+    maxItems: z.number().int().positive().describe("Maximum number of items to retrieve from the linked datasource"),
 }).describe("Configuration for queries that treat rows from another datasource as columns in the current chart");
 
 // Field specification can be a string (FieldName) or a serialized query

--- a/src/links/link_utils.ts
+++ b/src/links/link_utils.ts
@@ -181,6 +181,7 @@ interface IRowAsColumn {
     /**
      * Unique identifier for the column, in the form of `"subgroup|name (subgroup)|index"`,
      * used internally for querying the associated column in the parent {@link DataStore}.
+     * Defaults to the link's first subgroup key (see {@link fieldNameForSubgroup} for other subgroups).
      */
     fieldName: FieldName;
     /**
@@ -189,6 +190,8 @@ interface IRowAsColumn {
      * for accessing the column (meta)data.
      */
     column: DataColumn<DataType>;
+    fieldNameForSubgroup(subgroupKey: string): FieldName;
+    columnForSubgroup(subgroupKey: string): DataColumn<DataType>;
 }
 
 export type RowsAsColslink = {
@@ -254,6 +257,12 @@ type RowsAsColsPrefs = {
 }
 export type RowsAsColsQuerySerialized = {
     linkedDsName: string;
+    /**
+     * Canonical subgroup key under the link’s `subgroups` (same as {@link RowsAsColsQuery.effectiveSubgroupKey}).
+     * Always written by {@link RowsAsColsQuery.toJSON}; older saved configs may omit this (treated as first subgroup).
+     * TODO: make required in ChartConfigSchema `RowsAsColsQuerySerializedSchema` once legacy configs are migrated.
+     */
+    subgroupName?: string;
     type: "RowsAsColsQuery";
 } & RowsAsColsPrefs;
 
@@ -288,8 +297,7 @@ class DeserializedQueryError extends Error {
  * 
  * @param link - the link configuration object, with observable properties
  * @param maxItems - the maximum number of columns to return
- * 
- * ! we should really have sg as well as linkedDsName
+ * @param subgroupName - optional subgroup key under `link.subgroups` (empty = first subgroup)
  */
 export class RowsAsColsQuery implements MultiColumnQuery {
     // it may be logical to make this class be the thing that encapsulates a listener,
@@ -297,28 +305,62 @@ export class RowsAsColsQuery implements MultiColumnQuery {
     // perhaps if rather than just link.observableFields, we have two separate arrays (!or iterators!)
     // and the computed properties can choose between them based on config flags.
     // (i.e. for highlighted vs filtered data)
+    // Future: "pause" live updates (keep concrete column ids), pagination (firstIndex + maxItems), etc.
     @observable accessor maxItems: number;
-    constructor(public link: RowsAsColslink, public linkedDsName: string, maxItems = 1) {
+    /** Subgroup key under `link.subgroups`; empty string means "first available subgroup". */
+    @observable accessor subgroupName: string;
+    constructor(public link: RowsAsColslink, public linkedDsName: string, maxItems = 1, subgroupName = "") {
         this.maxItems = maxItems;
+        this.subgroupName = subgroupName;
+    }
+    /** Resolved subgroup key for column resolution and UI. */
+    @computed
+    get effectiveSubgroupKey(): string {
+        const keys = Object.keys(this.link.subgroups);
+        if (keys.length === 0) {
+            return "";
+        }
+        if (this.subgroupName && this.link.subgroups[this.subgroupName]) {
+            return this.subgroupName;
+        }
+        return keys[0];
     }
     @computed
     get columns() {
-        //how would we pause this?
-        return this.link.observableFields.slice(0, this.maxItems).map(f => f.column);
+        // how would we pause this? (see class comment — a paused query might freeze on concrete fields)
+        // could be kept in some optional `pausedFields` property?
+        const sg = this.effectiveSubgroupKey;
+        return this.link.observableFields
+            .slice(0, this.maxItems)
+            .map((f) => f.columnForSubgroup(sg));
     }
     @computed
     get fields() {
-        return this.columns.map(c => c.field);
+        const sg = this.effectiveSubgroupKey;
+        return this.link.observableFields
+            .slice(0, this.maxItems)
+            .map((f) => f.fieldNameForSubgroup(sg));
     }
     async initialize() {
         return this.link.initPromise;
     }
     /**
      * JSON serialisation that can be used to recreate the query object.
+     * Always includes `subgroupName` as the canonical subgroup key (see {@link effectiveSubgroupKey}).
      */
-    toJSON() {
-        // I was previously naively using toString() for serialization - now I know better.
-        return { linkedDsName: this.linkedDsName, maxItems: this.maxItems, type: "RowsAsColsQuery" };
+    toJSON(): RowsAsColsQuerySerialized {
+        const canonical = this.effectiveSubgroupKey;
+        if (this.subgroupName && !this.link.subgroups[this.subgroupName]) {
+            console.warn(
+                `RowsAsColsQuery.toJSON: invalid subgroupName ${JSON.stringify(this.subgroupName)} on link; serializing canonical ${JSON.stringify(canonical)}`,
+            );
+        }
+        return {
+            linkedDsName: this.linkedDsName,
+            maxItems: this.maxItems,
+            type: "RowsAsColsQuery",
+            subgroupName: canonical,
+        };
     }
     /**
      * @internal This should only be called by the `deserialiseParam` factory method.
@@ -328,16 +370,38 @@ export class RowsAsColsQuery implements MultiColumnQuery {
         if (!link) {
             throw new DeserializedQueryError(serialized, ds, `Link not found for ${serialized.linkedDsName}`);
         }
-        return new RowsAsColsQuery(link, serialized.linkedDsName, serialized.maxItems);
+        const raw = serialized.subgroupName;
+        const requested = typeof raw === "string" ? raw.trim() : "";
+        if (requested === "") {
+            return new RowsAsColsQuery(link, serialized.linkedDsName, serialized.maxItems, "");
+        }
+        if (!link.subgroups[requested]) {
+            const avail = Object.keys(link.subgroups).join(", ");
+            throw new DeserializedQueryError(
+                serialized,
+                ds,
+                `subgroupName ${JSON.stringify(requested)} not found on link for ${serialized.linkedDsName}. Available: ${avail || "(none)"}`,
+            );
+        }
+        return new RowsAsColsQuery(link, serialized.linkedDsName, serialized.maxItems, requested);
     }
 }
+
 export function getFieldName(sg: string, value: string, index: number) {
     return `${sg}|${value} (${sg})|${index}`;
 }
-/** 
- * a given {@param link} will currently have a single listener associated with it,
- * instantiated by this function.
- * ! design needs review to account for multiple subgroups
+
+/** Subgroup key from a rows-as-columns `FieldName` (`subgroup|value (subgroup)|index`). */
+export function subgroupKeyFromFieldName(field: string): string | null {
+    if (!field.includes("|")) {
+        return null;
+    }
+    const prefix = field.split("|")[0];
+    return prefix.length > 0 ? prefix : null;
+}
+/**
+ * A given rows-as-columns `link` has a single listener; `observableFields` are subgroup-agnostic row picks.
+ * Which matrix/subgroup those rows resolve to is chosen per {@link RowsAsColsQuery} (or per `FieldName` prefix in manual link mode).
  */
 async function initRacListener(link: RowsAsColslink, ds: DataStore, tds: DataStore) {
     if (link.initPromise !== undefined) return link.initPromise;
@@ -377,26 +441,15 @@ async function initRacListenerImpl(link: RowsAsColslink, ds: DataStore, tds: Dat
         valueToRowIndex.set(value, rowIndex);
     });
     link.valueToRowIndex = valueToRowIndex;
-    
-    
-    
-    //! we have an assumption here that there is only one subgroup
-    //(nb, I think this is the thing that there'd be a radio-button for in the UI)
-    //(whereas if there were multiple linked dataSources, they'd appear as different buttons for opening the dialog)
-    const sgKeys = Object.keys(link.subgroups);
-    const sg = Object.keys(link.subgroups)[0];
-    if (sgKeys.length > 1) {
-        //! this should be fixed!
-        console.warn("Multiple subgroups not supported", link);
-        console.warn("Using first subgroup", sg);
-        //return;
-    }
-    if (!sg) {
+    // `IRowAsColumn.fieldName` / `.column` default to the first subgroup for backward compatibility;
+    // consumers that care about another subgroup use `fieldNameForSubgroup` / `columnForSubgroup`.
+    const firstSubgroupKey = Object.keys(link.subgroups)[0] ?? "";
+    if (!firstSubgroupKey) {
         console.error("No subgroups found for link", link);
-        // return;
     }
-    /** ephemeral object representing a virtual column entry in a rows_as_columns link.
-     * accessing the `column` property will add the column to the parent DataStore.
+    /**
+     * Ephemeral object for one highlighted/filtered row in a rows-as-columns link.
+     * Accessing `column` / `fieldName` (first subgroup) or `*ForSubgroup(sg)` adds/resolves metadata on the parent {@link DataStore}.
      */
     class RAColumn implements IRowAsColumn {
         constructor(public index: number) {}
@@ -405,12 +458,10 @@ async function initRacListenerImpl(link: RowsAsColslink, ds: DataStore, tds: Dat
             // if I don't have `as string` here, it's inferred as string | number
             return tds.getRowText(this.index, link.name_column) as string;
         }
-        @computed
-        get fieldName(): FieldName {
-            return getFieldName(sg, this.name, this.index);
+        fieldNameForSubgroup(subgroupKey: string): FieldName {
+            return getFieldName(subgroupKey, this.name, this.index);
         }
-        @computed
-        get column(): DataColumn<DataType> {
+        columnForSubgroup(subgroupKey: string): DataColumn<DataType> {
             //https://mobx.js.org/computeds.html
             //"They should not have side effects or update other observables."
             //this will have side effects - I think it's ok, subsequent calls will be idempotent
@@ -418,7 +469,15 @@ async function initRacListenerImpl(link: RowsAsColslink, ds: DataStore, tds: Dat
             //and return the same DataColumn instance each time)
             //"Avoid creating and returning new observables." - ok
             //"They should not depend on non-observable values."
-            return ds.addColumnFromField(this.fieldName);
+            return ds.addColumnFromField(this.fieldNameForSubgroup(subgroupKey));
+        }
+        @computed
+        get fieldName(): FieldName {
+            return this.fieldNameForSubgroup(firstSubgroupKey);
+        }
+        @computed
+        get column(): DataColumn<DataType> {
+            return this.columnForSubgroup(firstSubgroupKey);
         }
     }
     const getField = (index: number) => {

--- a/src/react/chartLinkHooks.ts
+++ b/src/react/chartLinkHooks.ts
@@ -1,6 +1,6 @@
-import { useEffect, useId, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useMetadata, useViewerStoreApi } from "./components/avivatorish/state";
-import { useChartID, useDataSources } from "./hooks";
+import { useChartID } from "./hooks";
 import type { VivMDVReact } from "./components/VivMDVReact";
 import { useDataStore } from "./context";
 import type { DataColumn, DataType } from "@/charts/charts";
@@ -111,7 +111,6 @@ export function useRowsAsColumnsLinks() {
  * @returns the text values and indices of the highlighted/filtered rows in a linked dataSource
  */
 export function useHighlightedForeignRows(linkIndex = 0) {
-    const id = useId();
     const racLink = useRowsAsColumnsLinks()[linkIndex];
     const values = racLink?.link.observableFields || [];
     return values; //maybe don't useState version of this but return the mobx observable directly
@@ -131,7 +130,12 @@ export function useHighlightedForeignRows(linkIndex = 0) {
  * @returns an array of DataColumn objects, with loaded data, for virtual columns 
  * corresponding to the highlighted/filtered rows in the linked dataSource.
  */
-export function useHighlightedForeignRowsAsColumns(max = 10, filter = "", linkIndex = 0) {
+export function useHighlightedForeignRowsAsColumns(
+    max = 10,
+    filter = "",
+    linkIndex = 0,
+    subgroupName?: string,
+) {
     const cols = useHighlightedForeignRows(linkIndex); //not actual cols
     //would like not to have this here - might have some more logic in above hook
     //in particular want to redesign the fieldName being what determines the column
@@ -151,13 +155,19 @@ export function useHighlightedForeignRowsAsColumns(max = 10, filter = "", linkIn
             return;
         }
         const cm = window.mdv.chartManager;
-        // c.value & c.index are from the DataStore listener event, now in cols
-        // this needs to change for multiple subgroups
-        const sg = Object.keys(link.subgroups)[0];
+        // Resolve virtual columns for the requested rows_as_columns subgroup (defaults to first key).
+        const sgKeys = Object.keys(link.subgroups);
+        const sg =
+            subgroupName && link.subgroups[subgroupName]
+                ? subgroupName
+                : (sgKeys[0] ?? "");
         const f = filter.toLowerCase();
         // todo: consider pagination... pass in a page number, return information about total number of columns etc.
         // moving ds.addColumnsFromFields() up the stack...
-        const c = cols.filter(({name}) => name.toLowerCase().includes(f)).slice(0, max).map(({column}) => column);
+        const c = cols
+            .filter(({ name }) => name.toLowerCase().includes(f))
+            .slice(0, max)
+            .map((row) => row.columnForSubgroup(sg));
         // don't setColumns until we have the data...
         // alternatively, they could be lazy-loaded by consuming components.
         // that could be implemented relatively easily, but would lack some batching of requests,
@@ -167,6 +177,6 @@ export function useHighlightedForeignRowsAsColumns(max = 10, filter = "", linkIn
             setColumns(c);
         });
         return; //could consider cancelling any pending requests...
-    }, [cols, max, link, ds, filter]);
+    }, [cols, max, link, ds, filter, subgroupName]);
     return columns;
 }

--- a/src/react/components/ActiveLinkComponent.tsx
+++ b/src/react/components/ActiveLinkComponent.tsx
@@ -1,7 +1,7 @@
 import type { ColumnSelectionProps, CTypes } from "@/lib/columnTypeHelpers";
 import { observer } from "mobx-react-lite";
 import { useRowsAsColumnsLinks } from "../chartLinkHooks";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { isArray } from "@/lib/utils";
 import { RowsAsColsQuery } from "@/links/link_utils";
 import { Button, TextField } from "@mui/material";
@@ -18,23 +18,14 @@ type LocalProps<T extends CTypes, M extends boolean> = ColumnSelectionProps<
 function useActiveLink<T extends CTypes, M extends boolean>(
     props: LocalProps<T, M>,
 ) {
-    const { link, linkedDs } = props.link; //pending multiple link support
-    const sg = Object.values(link.subgroups)[0]; //pending subgroup support
-    // const highlightedForeignRows = useHighlightedForeignRows();
-    const isActive = useMemo(() => {
-        const ov = props.current_value;
-        const v = isArray(ov) ? ov[0] : ov;
-        // still needs more understanding of sg etc etc
-        return (
-            typeof v !== "string" &&
-            v instanceof RowsAsColsQuery &&
-            v.link === link
-        ); // && v.subgroup === sg;
-    }, [props.current_value, link]);
-    // if we already have a link, we should initialize the maxItems to its current value
+    const { link, linkedDs } = props.link;
+    const subgroupKeys = useMemo(
+        () => Object.keys(link.subgroups),
+        [link.subgroups],
+    );
+    const firstSubgroupKey = subgroupKeys[0] ?? "";
+
     const defaultMaxItems = props.multiple ? 10 : 1;
-    // will change when we can actually select different link/sg... but we could just keep one of these around
-    // apply it to the app state / mutate whenever... this is very un-functional/react... which is a shame (really).
     const [queryObj] = useState(() => {
         if (props.current_value) {
             const v = isArray(props.current_value)
@@ -44,28 +35,82 @@ function useActiveLink<T extends CTypes, M extends boolean>(
         }
         return new RowsAsColsQuery(link, linkedDs.name, defaultMaxItems);
     });
+
+    /** Subgroup tab selection; applied onto `queryObj` only when the user clicks Activate (like column/link mode). */
+    const [pendingSubgroupKey, setPendingSubgroupKey] = useState(
+        () => queryObj.effectiveSubgroupKey,
+    );
+
+    // Keep the tab in sync when the chart's active query for this link changes from outside.
+    useEffect(() => {
+        const ov = props.current_value;
+        const v = isArray(ov) ? ov[0] : ov;
+        if (v instanceof RowsAsColsQuery && v.link === link) {
+            setPendingSubgroupKey(v.effectiveSubgroupKey);
+        }
+    }, [props.current_value, link]);
+
+    const isActiveResolved = useMemo(() => {
+        const ov = props.current_value;
+        const v = isArray(ov) ? ov[0] : ov;
+        return (
+            typeof v !== "string" &&
+            v instanceof RowsAsColsQuery &&
+            v.link === link &&
+            v.effectiveSubgroupKey === pendingSubgroupKey &&
+            v.maxItems === queryObj.maxItems
+        );
+    }, [
+        props.current_value,
+        link,
+        pendingSubgroupKey,
+        queryObj.maxItems,
+    ]);
+
     const setMaxItems = useCallback(
         action((v: number) => {
             queryObj.maxItems = v;
         }),
-        [],
+        [queryObj],
     );
+
     const activateLink = useCallback(() => {
+        action(() => {
+            queryObj.subgroupName =
+                pendingSubgroupKey === firstSubgroupKey ? "" : pendingSubgroupKey;
+        })();
         //@ts-expect-error setSelectedColumn generic not behaving nicely
         props.setSelectedColumn(props.multiple ? [queryObj] : queryObj);
-    }, [props, queryObj]);
+    }, [
+        props,
+        queryObj,
+        pendingSubgroupKey,
+        firstSubgroupKey,
+    ]);
 
-    // todo
-    // const freezeLink = useCallback(() => {
-    // })
+    const subgroupLabels = useMemo(
+        () =>
+            subgroupKeys.map(
+                (k) => link.subgroups[k]?.label ?? k,
+            ),
+        [subgroupKeys, link.subgroups],
+    );
+
+    const pendingLabel =
+        link.subgroups[pendingSubgroupKey]?.label ?? pendingSubgroupKey;
+
     return {
-        isActive,
+        isActive: isActiveResolved,
         activateLink,
         maxItems: queryObj.maxItems,
         setMaxItems,
         link,
-        sg,
-        // highlightedForeignRows,
+        queryObj,
+        subgroupKeys,
+        subgroupLabels,
+        pendingSubgroupKey,
+        setPendingSubgroupKey,
+        pendingLabel,
     };
 }
 
@@ -76,29 +121,44 @@ const ActiveLinkComponent = observer(
             activateLink,
             maxItems,
             setMaxItems,
-            sg,
-            // highlightedForeignRows,
+            subgroupKeys,
+            subgroupLabels,
+            pendingSubgroupKey,
+            setPendingSubgroupKey,
+            pendingLabel,
+            queryObj,
         } = useActiveLink(props);
-        // maybe something like rowsText can be shown in a little scrollable box...
-        // const rowsText = highlightedForeignRows.slice(0, maxItems).map((r) => r.name).join(", ");
 
         return (
-            <div className="w-full flex justify-end text-xs font-light p-1">
-                <Button onClick={activateLink}>
-                    {isActive ? "Using" : "Activate"} '{sg.label}' Link
-                </Button>
-                {props.multiple && (
-                    <TextField
-                        size="small"
-                        className="max-w-20 float-right"
-                        type="number"
-                        label="Max"
-                        variant="standard"
-                        value={maxItems}
-                        onChange={(e) => setMaxItems(Number(e.target.value))}
+            <div className="w-full flex flex-col gap-1 text-xs font-light p-1">
+                {subgroupKeys.length > 1 ? (
+                    <TabHeader
+                        activeTab={pendingSubgroupKey}
+                        setActiveTab={setPendingSubgroupKey}
+                        tabs={subgroupKeys}
+                        tabLabels={subgroupLabels}
+                        indicatorTab={queryObj.effectiveSubgroupKey}
                     />
-                )}
-                {/* {isActive && rowsText} */}
+                ) : null}
+                <div className="flex justify-end items-center gap-1">
+                    <Button onClick={activateLink}>
+                        {isActive ? "Using" : "Activate"} &apos;
+                        {pendingLabel}&apos; link
+                    </Button>
+                    {props.multiple && (
+                        <TextField
+                            size="small"
+                            className="max-w-20 float-right"
+                            type="number"
+                            label="Max"
+                            variant="standard"
+                            value={maxItems}
+                            onChange={(e) =>
+                                setMaxItems(Number(e.target.value))
+                            }
+                        />
+                    )}
+                </div>
             </div>
         );
     },
@@ -109,7 +169,15 @@ const ActiveLinkMultiComponent = observer(
         props: ColumnSelectionProps<T, M>,
     ) => {
         const links = useRowsAsColumnsLinks();
-        // Infer the initial active tab based on `current_state`
+        const committedLinkName = useMemo(() => {
+            const v = props.current_value;
+            const cur = isArray(v) ? v[0] : v;
+            if (cur instanceof RowsAsColsQuery) {
+                return cur.link.name;
+            }
+            return undefined;
+        }, [props.current_value]);
+
         const [activeLinkName, setActiveLinkName] = useState(() => {
             const v = props.current_value;
             const currentFieldSpec = isArray(v) ? v[0] : v;
@@ -123,7 +191,6 @@ const ActiveLinkMultiComponent = observer(
             setActiveLinkName(name);
         }, []);
 
-        // Don't show tab UI if we only have one link
         if (links.length === 1) {
             return (
                 <ActiveLinkComponent
@@ -135,14 +202,13 @@ const ActiveLinkMultiComponent = observer(
 
         return (
             <div>
-                {/* Tab-based interface for selecting the active link */}
                 <TabHeader
                     activeTab={activeLinkName}
                     setActiveTab={handleLinkChange}
-                    tabs={links.map((link) => link.link.name)}
+                    tabs={links.map((l) => l.link.name)}
+                    indicatorTab={committedLinkName}
                 />
 
-                {/* Render the active link's UI */}
                 {links.map((link) =>
                     link.link.name === activeLinkName ? (
                         <ActiveLinkComponent

--- a/src/react/components/ColumnSelectionComponent.tsx
+++ b/src/react/components/ColumnSelectionComponent.tsx
@@ -62,6 +62,9 @@ function getActiveMode<T extends CTypes, M extends boolean>(props: ColumnSelecti
  * (e.g. if we're in a more global dialog etc rather than a chart context, this would be ambiguous).
  */
 const ColumnSelectionComponent = observer(<T extends CTypes, M extends boolean>(props: ColumnSelectionProps<T, M>) => {
+    // nb, there may be an issue here related to 'active link degradation'
+    // also: we should be able to allow to have combinations like `['col1', {linkA:sg2}, 'col2', {linkB:sg1}]`
+    // which implies that there needs to be some wider way of changing this (no single activeTab can represent this).
     const [activeTab, setActiveTab] = useState<ColumnMode>(getActiveMode(props));
 
     //todo check for the type of current value and set active tab
@@ -73,6 +76,8 @@ const ColumnSelectionComponent = observer(<T extends CTypes, M extends boolean>(
     }, [initialActiveTab]);
 
 
+    const chartModeFromValue = useMemo(() => getActiveMode(props), [props]);
+
     const iIsLinkCompatible = useIsLinkCompatible(props);
     if (!iIsLinkCompatible) return <ColumnDropdownComponent {...props} />;
 
@@ -80,11 +85,12 @@ const ColumnSelectionComponent = observer(<T extends CTypes, M extends boolean>(
         <>
             {iIsLinkCompatible ? (
                 <Paper className="mx-auto w-full" variant="outlined" sx={{ backgroundColor: "transparent" }}>
-                    <TabHeader
-                        activeTab={activeTab}
-                        setActiveTab={setActiveTab}
-                        tabs={["column", "link", "active link"]}
-                    />
+                <TabHeader
+                    activeTab={activeTab}
+                    setActiveTab={setActiveTab}
+                    tabs={["column", "link", "active link"]}
+                    indicatorTab={chartModeFromValue}
+                />
                     <ErrorBoundary FallbackComponent={({error}) => <ErrorComponentReactWrapper error={error} title={error.toString()} />}>
                         <div className="p-4">
                             {activeTab === "column" && (

--- a/src/react/components/LinkToColumnComponent.tsx
+++ b/src/react/components/LinkToColumnComponent.tsx
@@ -2,10 +2,10 @@ import type { ColumnSelectionProps, CTypes } from "@/lib/columnTypeHelpers";
 import { observer } from "mobx-react-lite";
 import type { DropdownMappedValues, GuiSpec } from "@/charts/charts";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { action, makeAutoObservable, observe } from "mobx";
+import { action, makeAutoObservable, observe, runInAction } from "mobx";
 import { DropdownAutocompleteComponent } from "./SettingsDialogComponent";
 import { g, isArray } from "@/lib/utils";
-import { getFieldName } from "@/links/link_utils";
+import { getFieldName, subgroupKeyFromFieldName, RowsAsColsQuery, type RowsAsColslink } from "@/links/link_utils";
 import { useRowsAsColumnsLinks } from "../chartLinkHooks";
 import TabHeader from "./TabHeader";
 
@@ -16,15 +16,37 @@ type LocalProps<T extends CTypes, M extends boolean> = ColumnSelectionProps<
     link: ReturnType<typeof useRowsAsColumnsLinks>[0];
 };
 
+function pickInitialSubgroupKey(
+    subgroups: RowsAsColslink["subgroups"],
+    current_value: unknown,
+): string {
+    const keys = Object.keys(subgroups);
+    const first = keys[0] ?? "";
+    const v = isArray(current_value) ? current_value[0] : current_value;
+    if (typeof v !== "string") {
+        return first;
+    }
+    const prefix = subgroupKeyFromFieldName(v);
+    if (prefix && subgroups[prefix]) {
+        return prefix;
+    }
+    return first;
+}
 
 /**
  * A hook for managing the state of manually chosen columns from a rows-as-columns link.
- * 
+ *
  * Should encapsulate
  * - making sure that an appropriate type of value is selected
  * - providing a way to select the value that has a simple interface, managing the complexity of incoming generic types
- * 
- * In the end... just bundling everything about state management for this component into a hook, returning a spec.
+ *
+ * Subgroup tabs only change which subgroup's **options** are listed in the dropdown; they do not change the chart
+ * until the user picks a field (same idea as column / link / active-link modes). The saved `FieldName` strings
+ * carry their own subgroup prefix; we validate against that prefix, not the tab alone.
+ *
+ * ! there is a bug - when values from a different link are selected, the spec doesn't update
+ * we want to be able to set more different combinations of values - which will mean more changes to state management
+ * for now, the UI should better reflect what the user is allowed to select.
  */
 function useLinkSpec<T extends CTypes, M extends boolean>(props: LocalProps<T, M>) {
     const { linkedDs, link } = props.link;
@@ -33,170 +55,227 @@ function useLinkSpec<T extends CTypes, M extends boolean>(props: LocalProps<T, M
     if (!targetColumn) {
         throw new Error(`Could not find name_column '${name_column}' in linked dataset`);
     }
-    if (linkedDs.size > 2**16) {
+    if (linkedDs.size > 2 ** 16) {
         // If we have more than 2^16 rows, I think that means there must be some duplicates...
         // so this is potentially somewhat undefined behaviour.
         console.warn("Linked dataset has more than 2^16 rows, this may lead to unexpected behaviour");
     }
-    // we need to associate each value with the row index that references it...
-    // as far as the code is concerned, this isn't necessarily a 1:1 mapping - but as my understanding of the logic
-    // it should be...
-    // We may have
-    // - more than one row with the same "gene_id"; I think this leads to undefined behaviour, we should give a warning
-    // - "gene_id" that doesn't have any corresponding row... maybe this doesn't matter, but we should filter those values out???
-    //   (and probably also log a warning)
 
-    // Loop through the values and create the format in pipes '|', by making use of the index.
-    //todo - we need to let the user select subgroup...
-    //^^ do we allow a mix-match of links/subgroups? We could... but that doesn't mean we should.
-    //(we should only do so if we have a clean way of presenting it to the user)
-    const sg = Object.keys(subgroups)[0];
-    
-    // return values in a format that can be used by the dropdown component
+    const subgroupKeys = useMemo(() => Object.keys(subgroups), [subgroups]);
+    const subgroupLabels = useMemo(
+        () => subgroupKeys.map((k) => subgroups[k]?.label ?? k),
+        [subgroupKeys, subgroups],
+    );
+
+    /** Which subgroup's rows populate the dropdown (browse only until a field is chosen). */
+    const [browseSubgroupKey, setBrowseSubgroupKey] = useState(() =>
+        pickInitialSubgroupKey(subgroups, props.current_value),
+    );
+
+    /**
+     * Subgroup prefix embedded in the chart's current `FieldName` value(s), if any.
+     * We do not auto-sync `browseSubgroupKey` when this changes: that would snap the tab back right after the user
+     * picks a feature on another layer (bound updates from the new field). Initial browse still uses
+     * `pickInitialSubgroupKey`; use "Show …" below to align the tab with the saved selection.
+     */
+    const boundSubgroupKey = useMemo(() => {
+        const v = props.current_value;
+        const first = isArray(v) ? v[0] : v;
+        if (typeof first !== "string" || !first.includes("|")) {
+            return null;
+        }
+        const p = subgroupKeyFromFieldName(first);
+        return p && subgroups[p] ? p : null;
+    }, [props.current_value, subgroups]);
+
+    const sg = browseSubgroupKey;
+
     const values = useMemo(() => {
-        // it was possible to get to here with undefined link.valueToRowIndex...
-        // should now be avoided by only rendering the component that uses this hook when the link is ready.
         if (!link.valueToRowIndex) {
             // because in certain instances the link isn't ready yet...
             // we can handle that here, but ideally we should do it earlier in the process
             console.warn("Link not ready yet - waiting to get values for UI... should be handled differently.");
             link.initPromise.then(() => {
                 console.log(link.valueToRowIndex);
-            })
+            });
             return [[], "label", "fieldName"] as DropdownMappedValues<"label", "fieldName">;
         }
-        // fix issue with safari Map.entries() not being iterable/not having a map method
         const labelValueObjects = [...link.valueToRowIndex.entries()].map(([value, rowIndex]) => ({
             label: value,
-            fieldName: getFieldName(sg, value, rowIndex)
+            fieldName: getFieldName(sg, value, rowIndex),
         }));
-        // tricky type here... but 'satisfies' gives us a bit of confidence that we're getting something that will work
-        // ! better than `as` typecasting when possible.
-        return [[...labelValueObjects], "label", "fieldName"] satisfies DropdownMappedValues<"label", "fieldName">;
+        return [[...labelValueObjects], "label", "fieldName"] satisfies DropdownMappedValues<
+            "label",
+            "fieldName"
+        >;
     }, [sg, link.valueToRowIndex, link.initPromise]);
-
 
     const { setSelectedColumn } = props;
     const isMultiType = props.multiple;
 
-    // setting internal state will be in the dropdown component...
-    // this will be a side-effect to set the state used by the wider application
-    const setValue = useCallback((v: string | string[]) => {
-        //@ts-ignore could check to the nth degree with props.multiple
-        setSelectedColumn(v);
-    }, [setSelectedColumn]);
-    
-    const getSafeInternalValue = useCallback((v: typeof props.current_value) => {
-        const defaultVal = props.multiple ? [] : "";
-        if (!v) return defaultVal;
-        if (props.multiple) {
-            // does the current value look like ours? we're not assuming it should:
-            // we might not be the active mode...
-            if (!isArray(v)) {
-                return defaultVal;
+    const setValue = useCallback(
+        (v: string | string[]) => {
+            //@ts-expect-error setSelectedColumn generic not behaving nicely
+            setSelectedColumn(v);
+        },
+        [setSelectedColumn],
+    );
+
+    const getSafeInternalValue = useCallback(
+        (v: typeof props.current_value) => {
+            const defaultVal = props.multiple ? [] : "";
+            if (!v) return defaultVal;
+
+            const rowValueOk = (field: string, prefix: string): boolean => {
+                if (!field.startsWith(`${prefix}|`)) {
+                    return false;
+                }
+                const rowVal = field.split("|")[1].split(`(${prefix})`)[0].trimEnd();
+                return Boolean(link.valueToRowIndex?.has(rowVal));
+            };
+
+            if (props.multiple) {
+                if (!isArray(v)) {
+                    return defaultVal;
+                }
+                if (v.length === 0) {
+                    return defaultVal;
+                }
+                const [firstValue] = v;
+                if (typeof firstValue !== "string") {
+                    return defaultVal;
+                }
+                if (!firstValue.includes("|")) {
+                    return defaultVal;
+                }
+                const prefix = subgroupKeyFromFieldName(firstValue);
+                if (!prefix || !link.subgroups[prefix]) {
+                    return defaultVal;
+                }
+                for (const item of v) {
+                    if (typeof item !== "string" || !rowValueOk(item, prefix)) {
+                        return defaultVal;
+                    }
+                }
+                return v;
             }
-            if (v.length === 0) {
-                return defaultVal;
-            }
-            const [firstValue] = v;
-            if (typeof firstValue !== 'string') {
-                return defaultVal;
-            }
-            // extracting value
-            if (!firstValue.includes("|")) {
-                return defaultVal;
-            }
-            // check that the current value is in the list of possible values
-            //! this could be somewhere as a helper function... 
-            // given a field name, figure out the row value that would have been used to generate it.
-            const val = firstValue.split("|")[1].split(`(${sg})`)[0].trimEnd();
-            if (!link.valueToRowIndex?.has(val)) {
-                return defaultVal;
-            }
-            return v;
-        } else {
-            // if it's an array, we're not the active mode
             if (isArray(v)) {
                 return defaultVal;
             }
-            if (typeof v !== 'string') {
+            if (typeof v !== "string") {
                 return defaultVal;
             }
             if (!v.includes("|")) {
                 return defaultVal;
             }
-            // extracting value
-            const val = v.split("|")[1].split(`(${sg})`)[0].trimEnd();
-            // check that the current value is in the list of possible values
-            if (!link.valueToRowIndex?.has(val)) {
+            const prefix = subgroupKeyFromFieldName(v);
+            if (!prefix || !link.subgroups[prefix]) {
+                return defaultVal;
+            }
+            if (!rowValueOk(v, prefix)) {
                 return defaultVal;
             }
             return v;
-        }
-    }, [link.valueToRowIndex, props.multiple, sg]);
-    //! there is a bug - when values from a different link are selected, the spec doesn't update
-    // we want to be able to set more different combinations of values - which will mean more changes to state management
-    // for now, the UI should better reflect what the user is allowed to select.
+        },
+        [link.valueToRowIndex, link.subgroups, props.multiple],
+    );
+
     const [initialValue] = useState(() => getSafeInternalValue(props.current_value));
 
     /// we don't want a new spec every time the value changes... we want to give it an observable value
     // (I think)- definition of this spec may want to be in the hook, with an observable value that isn't
     // the real props.current_value???
-    const [spec] = useState(() => makeAutoObservable(g<"multidropdown" | "dropdown">({
-        type: isMultiType ? 'multidropdown' : 'dropdown',
-        label: `specific '${name}'`, //don't really want to have this label here, would take a bigger change to remove
-        // no ts error! praise be!
-        values,
-        current_value: initialValue,
-        func: action((v) => {
-            // something about having setValue as a dependency makes it end up re-running this...
-            // & we really want the spec to be stable.
-            //! for some reason if we call this in here we get glitchy behaviour, not really sure
-            // setValue(v);
-        })
-    // })), [values, name, isMultiType, initialValue]);
-    })));
+    const [spec] = useState(() =>
+        makeAutoObservable(
+            g<"multidropdown" | "dropdown">({
+                type: isMultiType ? "multidropdown" : "dropdown",
+                label: `specific '${name}'`, //don't really want to have this label here, would take a bigger change to remove
+                values,
+                current_value: initialValue,
+                func: action((_v) => {
+                    // something about having setValue as a dependency makes it end up re-running this...
+                    // & we really want the spec to be stable.
+                    //! for some reason if we call this in here we get glitchy behaviour, not really sure
+                    // setValue(v);
+                }),
+            }),
+        ),
+    );
+
+    useEffect(() => {
+        runInAction(() => {
+            spec.values = values;
+        });
+    }, [spec, values]);
 
     useEffect(() => {
         // do you swim with the mobx stream? or against it?
         // took me a while to realise that this is the direction we should be going in...
         return observe(spec, "current_value", (change) => {
-            if (change.type === 'update') {
+            if (change.type === "update") {
                 setValue(change.newValue);
             }
         });
     }, [spec, setValue]);
-    
-    return spec;
+
+    const handleSubgroupTab = useCallback((key: string) => {
+        setBrowseSubgroupKey(key);
+    }, []);
+
+    return {
+        spec,
+        showSubgroupTabs: subgroupKeys.length > 1,
+        subgroupKeys,
+        subgroupLabels,
+        browseSubgroupKey,
+        handleSubgroupTab,
+        boundSubgroupKey,
+    };
 }
 
 /**
  * This presents the user with a method for selecting column(s) corresponding to a linked dataset.
- * 
+ *
  * There should be a re-usable component for selecting values from a category column, and this should be used here,
  * referring to the `link.name_column` column of the linked dataset... at the moment, we deal with this in a more ad-hoc way.
- * 
+ *
  * Values that this component operates on - at the time of writing - will be in a `FieldName` (`string`) format, with pipes separating
  * `subgroup|value (subgroup)|index`, where `subgroup` is the name of the user-selected subgroup, `value (subgroup)` is a human-readable
  * representation of the value, and `index` is the index of the value in the column.
  */
 const LinkToColumnComponent = observer(<T extends CTypes, M extends boolean>(props: LocalProps<T, M>) => {
-    // is all of the complexity being in the hook really making this component simpler?
-    // at least it feels simple if you ignore everything in the hook...
-    const spec = useLinkSpec(props);
+    const {
+        spec,
+        showSubgroupTabs,
+        subgroupKeys,
+        subgroupLabels,
+        browseSubgroupKey,
+        handleSubgroupTab,
+        boundSubgroupKey,
+    } = useLinkSpec(props);
     return (
-        <div className="flex flex-col p-1">
-            {/* don't want to have this typecast here, slight nuisance. */}
-            <DropdownAutocompleteComponent props={spec as GuiSpec<"dropdown"> | GuiSpec<"multidropdown">} />
+        <div className="flex flex-col p-1 gap-1">
+            {showSubgroupTabs ? (
+                <TabHeader
+                    activeTab={browseSubgroupKey}
+                    setActiveTab={handleSubgroupTab}
+                    tabs={subgroupKeys}
+                    tabLabels={subgroupLabels}
+                    indicatorTab={boundSubgroupKey ?? undefined}
+                />
+            ) : null}
+            <DropdownAutocompleteComponent
+                props={spec as GuiSpec<"dropdown"> | GuiSpec<"multidropdown">}
+            />
         </div>
-    )
-})
+    );
+});
 
 /**
  * Avoid dealing with internal state of the link until it's ready.
  */
 const LinkToColumnComponentInit = observer(<T extends CTypes, M extends boolean>(props: LocalProps<T, M>) => {
-    const { link } = useRowsAsColumnsLinks()[0];
+    const { link } = props.link;
     //wanted to initialise this with ~init.linkPromise.resolved but apparently that's not a thing
     //so we have an initial re-render even if the link is already resolved.
     const [ready, setReady] = useState(false);
@@ -211,57 +290,70 @@ const LinkToColumnComponentInit = observer(<T extends CTypes, M extends boolean>
     return <LinkToColumnComponent {...props} />;
 });
 
-const LinkMulti = observer(
-    <T extends CTypes, M extends boolean>(
-        props: ColumnSelectionProps<T, M>,
-    ) => {
-        const links = useRowsAsColumnsLinks();
-        const [activeLinkName, setActiveLinkName] = useState(() => {
-            // Determine the initial active link based on `current_state` and `FieldName`
-            // this logic might be adjusted if we allow combined selections with multiple links
-            // also we might want to persist as user changes tab outside of this component
-            const v = props.current_value;
-            const currentFieldName = isArray(v) ? v[0] : v;
-            if (typeof currentFieldName === "string") {
-                const matchingLink = links.find((link) => {
-                    const sgName = Object.keys(link.link.subgroups)[0];
-                    return currentFieldName.startsWith(`${sgName}|`);
-                });
-                return matchingLink?.link.name || links[0].link.name;
-            }
-            return links[0].link.name;
-        });
-
-        const handleLinkChange = useCallback((name: string) => {
-            setActiveLinkName(name);
-        }, []);
-
-        // don't show tab ui if we only have one link
-        if (links.length === 1) {
-            return <LinkToColumnComponentInit {...props} link={links[0]} />;
+const LinkMulti = observer(<T extends CTypes, M extends boolean>(props: ColumnSelectionProps<T, M>) => {
+    const links = useRowsAsColumnsLinks();
+    const committedLinkIndicator = useMemo(() => {
+        const v = props.current_value;
+        const cur = isArray(v) ? v[0] : v;
+        if (cur instanceof RowsAsColsQuery) {
+            return cur.link.name;
         }
-        return (
-            <div>
-                <TabHeader
-                    activeTab={activeLinkName}
-                    setActiveTab={handleLinkChange}
-                    tabs={links.map((link) => link.link.name)}
-                />
+        if (typeof cur === "string") {
+            const prefix = subgroupKeyFromFieldName(cur);
+            if (!prefix) {
+                return undefined;
+            }
+            return links.find((entry) => Boolean(entry.link.subgroups[prefix]))?.link.name;
+        }
+        return undefined;
+    }, [props.current_value, links]);
 
-                {/* Render the active link's UI */}
-                {links.map((link) =>
-                    link.link.name === activeLinkName ? (
-                        <LinkToColumnComponentInit
-                            key={link.link.name}
-                            {...props}
-                            link={link}
-                        />
-                    ) : null
-                )}
-            </div>
-        );
-    },
-);
+    const [activeLinkName, setActiveLinkName] = useState(() => {
+        // Determine the initial active link based on `current_state` and `FieldName`
+        // this logic might be adjusted if we allow combined selections with multiple links
+        // also we might want to persist as user changes tab outside of this component
+        const v = props.current_value;
+        const currentFieldName = isArray(v) ? v[0] : v;
+        if (typeof currentFieldName === "string") {
+            const prefix = subgroupKeyFromFieldName(currentFieldName);
+            const matchingLink = links.find((entry) => {
+                if (!prefix) {
+                    return false;
+                }
+                return Boolean(entry.link.subgroups[prefix]);
+            });
+            return matchingLink?.link.name || links[0].link.name;
+        }
+        return links[0].link.name;
+    });
 
+    const handleLinkChange = useCallback((name: string) => {
+        setActiveLinkName(name);
+    }, []);
+
+    if (links.length === 1) {
+        return <LinkToColumnComponentInit {...props} link={links[0]} />;
+    }
+    return (
+        <div>
+            <TabHeader
+                activeTab={activeLinkName}
+                setActiveTab={handleLinkChange}
+                tabs={links.map((l) => l.link.name)}
+                indicatorTab={committedLinkIndicator}
+            />
+
+            {links.map((link) =>
+                link.link.name === activeLinkName ? (
+                    <LinkToColumnComponentInit
+                        key={link.link.name}
+                        {...props}
+                        link={link}
+                    />
+                ) : null
+            )}
+        </div>
+    );
+});
 
 export default LinkMulti;

--- a/src/react/components/LinkToColumnComponent.tsx
+++ b/src/react/components/LinkToColumnComponent.tsx
@@ -1,9 +1,9 @@
 import type { ColumnSelectionProps, CTypes } from "@/lib/columnTypeHelpers";
 import { observer } from "mobx-react-lite";
-import type { DropdownMappedValues, GuiSpec } from "@/charts/charts";
+import type { DropdownMappedValues } from "@/charts/charts";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { action, makeAutoObservable, observe, runInAction } from "mobx";
-import { DropdownAutocompleteComponent } from "./SettingsDialogComponent";
+import { DropdownAutocompleteComponent, type DropdownSpec } from "./SettingsDialogComponent";
 import { g, isArray } from "@/lib/utils";
 import { getFieldName, subgroupKeyFromFieldName, RowsAsColsQuery, type RowsAsColslink } from "@/links/link_utils";
 import { useRowsAsColumnsLinks } from "../chartLinkHooks";
@@ -31,6 +31,19 @@ function pickInitialSubgroupKey(
         return prefix;
     }
     return first;
+}
+
+/** Resolves link name from a saved `FieldName` only when exactly one link owns that subgroup prefix. */
+function resolveLinkNameFromFieldName(
+    field: string,
+    links: ReturnType<typeof useRowsAsColumnsLinks>,
+): string | undefined {
+    const prefix = subgroupKeyFromFieldName(field);
+    if (!prefix) {
+        return undefined;
+    }
+    const matches = links.filter((entry) => Boolean(entry.link.subgroups[prefix]));
+    return matches.length === 1 ? matches[0].link.name : undefined;
 }
 
 /**
@@ -185,21 +198,22 @@ function useLinkSpec<T extends CTypes, M extends boolean>(props: LocalProps<T, M
     /// we don't want a new spec every time the value changes... we want to give it an observable value
     // (I think)- definition of this spec may want to be in the hook, with an observable value that isn't
     // the real props.current_value???
-    const [spec] = useState(() =>
-        makeAutoObservable(
-            g<"multidropdown" | "dropdown">({
-                type: isMultiType ? "multidropdown" : "dropdown",
-                label: `specific '${name}'`, //don't really want to have this label here, would take a bigger change to remove
-                values,
-                current_value: initialValue,
-                func: action((_v) => {
-                    // something about having setValue as a dependency makes it end up re-running this...
-                    // & we really want the spec to be stable.
-                    //! for some reason if we call this in here we get glitchy behaviour, not really sure
-                    // setValue(v);
+    const [spec] = useState<DropdownSpec>(
+        () =>
+            makeAutoObservable(
+                g({
+                    type: isMultiType ? "multidropdown" : "dropdown",
+                    label: `specific '${name}'`, //don't really want to have this label here, would take a bigger change to remove
+                    values,
+                    current_value: initialValue,
+                    func: action((_v) => {
+                        // something about having setValue as a dependency makes it end up re-running this...
+                        // & we really want the spec to be stable.
+                        //! for some reason if we call this in here we get glitchy behaviour, not really sure
+                        // setValue(v);
+                    }),
                 }),
-            }),
-        ),
+            ) as DropdownSpec,
     );
 
     useEffect(() => {
@@ -207,6 +221,12 @@ function useLinkSpec<T extends CTypes, M extends boolean>(props: LocalProps<T, M
             spec.values = values;
         });
     }, [spec, values]);
+
+    useEffect(() => {
+        runInAction(() => {
+            spec.current_value = getSafeInternalValue(props.current_value);
+        });
+    }, [spec, props.current_value, getSafeInternalValue]);
 
     useEffect(() => {
         // do you swim with the mobx stream? or against it?
@@ -264,9 +284,7 @@ const LinkToColumnComponent = observer(<T extends CTypes, M extends boolean>(pro
                     indicatorTab={boundSubgroupKey ?? undefined}
                 />
             ) : null}
-            <DropdownAutocompleteComponent
-                props={spec as GuiSpec<"dropdown"> | GuiSpec<"multidropdown">}
-            />
+            <DropdownAutocompleteComponent props={spec} />
         </div>
     );
 });
@@ -299,11 +317,7 @@ const LinkMulti = observer(<T extends CTypes, M extends boolean>(props: ColumnSe
             return cur.link.name;
         }
         if (typeof cur === "string") {
-            const prefix = subgroupKeyFromFieldName(cur);
-            if (!prefix) {
-                return undefined;
-            }
-            return links.find((entry) => Boolean(entry.link.subgroups[prefix]))?.link.name;
+            return resolveLinkNameFromFieldName(cur, links);
         }
         return undefined;
     }, [props.current_value, links]);
@@ -315,14 +329,7 @@ const LinkMulti = observer(<T extends CTypes, M extends boolean>(props: ColumnSe
         const v = props.current_value;
         const currentFieldName = isArray(v) ? v[0] : v;
         if (typeof currentFieldName === "string") {
-            const prefix = subgroupKeyFromFieldName(currentFieldName);
-            const matchingLink = links.find((entry) => {
-                if (!prefix) {
-                    return false;
-                }
-                return Boolean(entry.link.subgroups[prefix]);
-            });
-            return matchingLink?.link.name || links[0].link.name;
+            return resolveLinkNameFromFieldName(currentFieldName, links) ?? links[0].link.name;
         }
         return links[0].link.name;
     });

--- a/src/react/components/TabHeader.tsx
+++ b/src/react/components/TabHeader.tsx
@@ -1,41 +1,73 @@
 import { useTheme } from "@mui/material";
 import clsx from "clsx";
 
+/** Filled circle shown before the tab label for the tab that matches `indicatorTab` (e.g. chart’s committed choice). */
+const CHART_COMMIT_MARK = "\u25CF";
+
 type TabHeaderProps<T extends string> = {
     activeTab: T;
     setActiveTab: (tab: T) => void;
     tabs: T[];
+    /** When set, must match `tabs.length`; shown as button text instead of the tab id. */
+    tabLabels?: string[];
+    /**
+     * Tab id that reflects what is already applied on the chart (e.g. committed subgroup or datasource link).
+     * Shown with a leading ● so it stays readable without extra copy; may differ from `activeTab` while browsing.
+     */
+    indicatorTab?: T;
 };
 
-const TabHeader = <T extends string>({ activeTab, setActiveTab, tabs }: TabHeaderProps<T>) => {
+const TabHeader = <T extends string>({
+    activeTab,
+    setActiveTab,
+    tabs,
+    tabLabels,
+    indicatorTab,
+}: TabHeaderProps<T>) => {
     const theme = useTheme();
     // TODO consider re-arranging this so we have more proper association with tab panels etc.
     return (
-        <div className="w-full flex justify-around text-xs font-light" role="tablist">
-            {tabs.map((tab) => (
-                <button
-                    key={tab}
-                    onClick={() => setActiveTab(tab)}
-                    type="button"
-                    role="tab"
-                    aria-selected={activeTab === tab}
-                    className={clsx(
-                        "p-2 text-center border-b-2 transition-colors w-full",
-                        // activeTab === tab ? "font-bold" : "font-light"
-                        "aria-selected:font-bold",
-                        "font-light"
-                    )}
-                    style={{
-                        // we should probably avoid this style object, need to review how theme related styles should be applied
-                        borderColor: activeTab === tab ? theme.palette.primary.main : theme.palette.divider,
-                        color: activeTab === tab
-                            ? theme.palette.primary.main
-                            : theme.palette.text.primary,
-                    }}
-                >
-                    {tab}
-                </button>
-            ))}
+        <div className="w-full flex justify-around text-xs" role="tablist">
+            {tabs.map((tab, i) => {
+                const selected = activeTab === tab;
+                const indicatorInList =
+                    indicatorTab !== undefined && tabs.includes(indicatorTab);
+                const showCommitMark = indicatorInList && indicatorTab === tab;
+                const labelText = tabLabels?.[i] ?? tab;
+                return (
+                    <button
+                        key={tab}
+                        onClick={() => setActiveTab(tab)}
+                        type="button"
+                        role="tab"
+                        aria-selected={selected}
+                        title={showCommitMark ? "In active state" : undefined}
+                        className={clsx(
+                            "p-2 text-center border-b-2 transition-colors w-full",
+                            selected ? "font-bold" : "font-light",
+                        )}
+                        style={{
+                            borderColor: selected ? theme.palette.primary.main : theme.palette.divider,
+                            color: selected
+                                ? theme.palette.primary.main
+                                : theme.palette.text.primary,
+                        }}
+                    >
+                        <span className="inline-flex items-center justify-center gap-0.5 max-w-full">
+                            {showCommitMark ? (
+                                <span
+                                    className="shrink-0 leading-none"
+                                    style={{ color: theme.palette.primary.main }}
+                                    aria-hidden
+                                >
+                                    {CHART_COMMIT_MARK}
+                                </span>
+                            ) : null}
+                            <span className="min-w-0 truncate">{labelText}</span>
+                        </span>
+                    </button>
+                );
+            })}
         </div>
     );
 };

--- a/src/react/components/TabHeader.tsx
+++ b/src/react/components/TabHeader.tsx
@@ -34,6 +34,7 @@ const TabHeader = <T extends string>({
                     indicatorTab !== undefined && tabs.includes(indicatorTab);
                 const showCommitMark = indicatorInList && indicatorTab === tab;
                 const labelText = tabLabels?.[i] ?? tab;
+                const tabAccessibleName = showCommitMark ? `${labelText}, in active state` : labelText;
                 return (
                     <button
                         key={tab}
@@ -41,7 +42,7 @@ const TabHeader = <T extends string>({
                         type="button"
                         role="tab"
                         aria-selected={selected}
-                        title={showCommitMark ? "In active state" : undefined}
+                        aria-label={tabAccessibleName}
                         className={clsx(
                             "p-2 text-center border-b-2 transition-colors w-full",
                             selected ? "font-bold" : "font-light",

--- a/src/tests/chartConfigUtils.spec.ts
+++ b/src/tests/chartConfigUtils.spec.ts
@@ -280,6 +280,7 @@ describe('chartConfigUtils - deserialisation', () => {
           linkedDsName: 'genes',
           maxItems: 5,
           type: 'RowsAsColsQuery' as const,
+          subgroupName: 'gs',
         }),
         fields: ['gene1', 'gene2'],
       };
@@ -300,6 +301,7 @@ describe('chartConfigUtils - deserialisation', () => {
         linkedDsName: 'genes',
         maxItems: 5,
         type: 'RowsAsColsQuery',
+        subgroupName: 'gs',
       });
 
       // Now deserialize it back

--- a/src/tests/rows_as_cols_query.test.ts
+++ b/src/tests/rows_as_cols_query.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "vitest";
+import { RowsAsColsQuery, type RowsAsColslink } from "@/links/link_utils";
+
+function mockLink(): RowsAsColslink {
+    return {
+        name_column: "gene",
+        name: "genes",
+        subgroups: {
+            gs: { name: "gs", label: "Main", type: "double" },
+            layer_a: { name: "layer_a", label: "Layer A", type: "double" },
+        },
+        observableFields: [],
+        initPromise: Promise.resolve(),
+    };
+}
+
+describe("RowsAsColsQuery", () => {
+    test("toJSON always includes canonical subgroupName (default → first key)", () => {
+        const link = mockLink();
+        const q = new RowsAsColsQuery(link, "genes", 2);
+        expect(q.toJSON()).toEqual({
+            linkedDsName: "genes",
+            maxItems: 2,
+            type: "RowsAsColsQuery",
+            subgroupName: "gs",
+        });
+    });
+
+    test("toJSON includes explicit subgroup when set", () => {
+        const link = mockLink();
+        const q = new RowsAsColsQuery(link, "genes", 4, "layer_a");
+        expect(q.toJSON()).toEqual({
+            linkedDsName: "genes",
+            maxItems: 4,
+            type: "RowsAsColsQuery",
+            subgroupName: "layer_a",
+        });
+    });
+
+    test("effectiveSubgroupKey prefers stored subgroup when valid", () => {
+        const link = mockLink();
+        const q = new RowsAsColsQuery(link, "genes", 1, "layer_a");
+        expect(q.effectiveSubgroupKey).toBe("layer_a");
+    });
+
+    test("effectiveSubgroupKey falls back to first subgroup when name invalid", () => {
+        const link = mockLink();
+        const q = new RowsAsColsQuery(link, "genes", 1, "missing");
+        expect(q.effectiveSubgroupKey).toBe("gs");
+    });
+
+    test("toJSON serializes canonical subgroup when stored key is invalid", () => {
+        const link = mockLink();
+        const q = new RowsAsColsQuery(link, "genes", 1, "bogus");
+        expect(q.toJSON()).toEqual({
+            linkedDsName: "genes",
+            maxItems: 1,
+            type: "RowsAsColsQuery",
+            subgroupName: "gs",
+        });
+    });
+});

--- a/tests_playwright/project/column_selection/link_subgroup_selection.spec.ts
+++ b/tests_playwright/project/column_selection/link_subgroup_selection.spec.ts
@@ -1,0 +1,159 @@
+/**
+ * Rows-as-columns subgroup coverage for multilayer mock projects.
+ *
+ * Persistence and metadata checks run against the default backend (localhost:5055).
+ * Subgroup tab UI checks need the worktree Vite frontend, e.g.:
+ *   TEST_BASE_URL=http://127.0.0.1:5173 pnpm run playwright-test-project tests_playwright/project/column_selection/link_subgroup_selection.spec.ts --project=chromium
+ */
+import test, { expect } from "@playwright/test";
+import {
+    createTemporaryProjectViaSyntheticAnndata,
+    waitForProjectReady,
+} from "../../utils/projectFixtures";
+import {
+    addDotPlotChartViaApi,
+    closeTopDialog,
+    expectChartPanelHasNoError,
+    getDotPlotXAxisFields,
+    getFirstLinkedGeneLabel,
+    getLinkColumnSettingRow,
+    getRowsAsColumnsSubgroupKeys,
+    openChartSettingsDialog,
+    saveCurrentView,
+    searchChartSettings,
+    selectLinkedGeneInChartSettings,
+    setDotPlotXAxisLinkField,
+    isWorktreeFrontendForPlaywright,
+    waitForChartByTitle,
+    waitForViewUnsavedState,
+} from "../../utils/helpers";
+
+const MULTILAYER_SYNTHETIC = {
+    profile: "minimal" as const,
+    nCells: 80,
+    nGenes: 40,
+    seed: 0,
+    extraExpressionLayers: true,
+    force: true,
+};
+
+test.describe("Link subgroup column selection", () => {
+    test.setTimeout(180_000);
+
+    test("project exposes multiple rows_as_columns expression subgroups", async ({ page }) => {
+        const projectHandle = await createTemporaryProjectViaSyntheticAnndata(page, {
+            synthetic: MULTILAYER_SYNTHETIC,
+        });
+
+        try {
+            const subgroups = await getRowsAsColumnsSubgroupKeys(page);
+            const keys = subgroups.map((sg) => sg.key);
+            expect(keys).toContain("gs");
+            expect(keys).toContain("synth_layer_a");
+            expect(keys).toContain("synth_layer_b");
+            expect(keys.length).toBeGreaterThanOrEqual(3);
+        } finally {
+            await projectHandle.cleanup();
+        }
+    });
+
+    test("shows subgroup layer tabs in the link column picker when the worktree UI is served", async ({
+        page,
+    }) => {
+        const projectHandle = await createTemporaryProjectViaSyntheticAnndata(page, {
+            synthetic: MULTILAYER_SYNTHETIC,
+        });
+
+        try {
+            const subgroups = await getRowsAsColumnsSubgroupKeys(page);
+            test.skip(
+                !isWorktreeFrontendForPlaywright(),
+                "Subgroup tabs are only in the worktree frontend; set TEST_BASE_URL to the Vite dev server.",
+            );
+
+            const title = `Dot Plot Subgroup Tabs ${Date.now()}`;
+            await addDotPlotChartViaApi(page, title);
+            await waitForChartByTitle(page, title);
+            await openChartSettingsDialog(page, title);
+            await searchChartSettings(page, "Fields on x axis");
+            const { row, subgroupTablist } = getLinkColumnSettingRow(page, "Fields on x axis");
+            await row.getByRole("tab", { name: "link", exact: true }).click();
+
+            for (const { label } of subgroups) {
+                await expect(subgroupTablist.getByRole("tab", { name: label, exact: true })).toBeVisible();
+            }
+            await closeTopDialog(page);
+        } finally {
+            await projectHandle.cleanup();
+        }
+    });
+
+    test("persists dot plots using different link subgroups after save and reload", async ({ page }) => {
+        const projectHandle = await createTemporaryProjectViaSyntheticAnndata(page, {
+            synthetic: MULTILAYER_SYNTHETIC,
+        });
+
+        try {
+            const geneLabel = await getFirstLinkedGeneLabel(page);
+            const geneIndex = 0;
+            const titleGs = `Dot Plot GS ${Date.now()}`;
+            const titleLayerA = `Dot Plot Layer A ${Date.now() + 1}`;
+
+            await addDotPlotChartViaApi(page, titleGs);
+            await waitForChartByTitle(page, titleGs);
+
+            const useSubgroupTabs = isWorktreeFrontendForPlaywright();
+            if (useSubgroupTabs) {
+                await openChartSettingsDialog(page, titleGs);
+                await selectLinkedGeneInChartSettings(page, {
+                    paramLabel: "Fields on x axis",
+                    subgroupTabLabel: "Gene Scores",
+                    geneLabel,
+                });
+                await closeTopDialog(page);
+            } else {
+                await setDotPlotXAxisLinkField(page, titleGs, "gs", geneLabel, geneIndex);
+            }
+            await waitForViewUnsavedState(page, true);
+            await expectChartPanelHasNoError(page, titleGs);
+
+            await addDotPlotChartViaApi(page, titleLayerA);
+            await waitForChartByTitle(page, titleLayerA);
+            if (useSubgroupTabs) {
+                await openChartSettingsDialog(page, titleLayerA);
+                await selectLinkedGeneInChartSettings(page, {
+                    paramLabel: "Fields on x axis",
+                    subgroupTabLabel: "synth_layer_a",
+                    geneLabel,
+                });
+                await closeTopDialog(page);
+            } else {
+                await setDotPlotXAxisLinkField(page, titleLayerA, "synth_layer_a", geneLabel, geneIndex);
+            }
+            await waitForViewUnsavedState(page, true);
+            await expectChartPanelHasNoError(page, titleLayerA);
+
+            const gsFieldsBeforeSave = await getDotPlotXAxisFields(page, titleGs);
+            const layerAFieldsBeforeSave = await getDotPlotXAxisFields(page, titleLayerA);
+            expect(gsFieldsBeforeSave[0]).toMatch(/^gs\|/);
+            expect(layerAFieldsBeforeSave[0]).toMatch(/^synth_layer_a\|/);
+
+            await saveCurrentView(page);
+
+            await page.reload();
+            await waitForProjectReady(page);
+
+            await expectChartPanelHasNoError(page, titleGs);
+            await expectChartPanelHasNoError(page, titleLayerA);
+
+            const gsFieldsAfterReload = await getDotPlotXAxisFields(page, titleGs);
+            const layerAFieldsAfterReload = await getDotPlotXAxisFields(page, titleLayerA);
+            expect(gsFieldsAfterReload).toEqual(gsFieldsBeforeSave);
+            expect(layerAFieldsAfterReload).toEqual(layerAFieldsBeforeSave);
+            expect(gsFieldsAfterReload[0]).toMatch(/^gs\|/);
+            expect(layerAFieldsAfterReload[0]).toMatch(/^synth_layer_a\|/);
+        } finally {
+            await projectHandle.cleanup();
+        }
+    });
+});

--- a/tests_playwright/utils/helpers.ts
+++ b/tests_playwright/utils/helpers.ts
@@ -406,9 +406,9 @@ export async function setDotPlotXAxisLinkField(
     await expect
         .poll(async () => {
             const fields = await getDotPlotXAxisFields(page, chartTitle);
-            return fields[0] ?? "";
+            return (fields[0] ?? "").startsWith(`{subgroupKey}|`);
         })
-        .toMatch(new RegExp(`^${subgroupKey}\\|`));
+        .toBe(true);
     await waitForViewUnsavedState(page, true);
 }
 

--- a/tests_playwright/utils/helpers.ts
+++ b/tests_playwright/utils/helpers.ts
@@ -158,6 +158,7 @@ export async function openChartSettingsDialog(page: Page, title: string) {
     await expect(panel).toBeVisible();
     await panel.locator(".ciview-chart-menuspace > span").nth(2).click();
     await expect(page.locator(".ciview-dlg-header-text", { hasText: `Settings: ${title}` })).toBeVisible();
+    await expect(page.getByLabel("Search Settings by Folder or Name")).toBeVisible();
 }
 
 export async function openChartDebugDialog(page: Page, title: string) {
@@ -220,4 +221,196 @@ export async function selectViewViaUi(page: Page, viewName: string) {
     await page.getByRole("combobox", { name: "Select View" }).click();
     await page.getByRole("option", { name: viewName, exact: true }).click();
     await expect.poll(async () => await getCurrentView(page)).toBe(viewName);
+}
+
+export type RowsAsColumnsSubgroupInfo = {
+    key: string;
+    label: string;
+};
+
+/** Subgroup keys on the cells→genes rows_as_columns link (requires extra-expression-layers project). */
+export async function getRowsAsColumnsSubgroupKeys(page: Page): Promise<RowsAsColumnsSubgroupInfo[]> {
+    return await page.evaluate(() => {
+        const chartManager = (window as any).mdv?.chartManager;
+        const cellsStore =
+            chartManager?.dsIndex?.cells?.dataStore ??
+            Object.values(chartManager?.dsIndex ?? {}).find(
+                (entry: { dataStore?: { links?: Record<string, unknown> } }) => entry?.dataStore?.links,
+            )?.dataStore;
+        if (!cellsStore?.links) {
+            return [];
+        }
+        for (const linkedDsName of Object.keys(cellsStore.links)) {
+            const subgroups = cellsStore.links[linkedDsName]?.rows_as_columns?.subgroups;
+            if (!subgroups) {
+                continue;
+            }
+            return Object.entries(subgroups).map(([key, info]) => ({
+                key,
+                label: String((info as { label?: string })?.label ?? key),
+            }));
+        }
+        return [];
+    });
+}
+
+export async function getFirstLinkedGeneLabel(page: Page): Promise<string> {
+    return await page.evaluate(async () => {
+        const chartManager = (window as any).mdv?.chartManager;
+        const cellsStore =
+            chartManager?.dsIndex?.cells?.dataStore ??
+            chartManager.dsIndex[Object.keys(chartManager.dsIndex)[0]]?.dataStore;
+        if (!cellsStore?.links) {
+            throw new Error("No rows_as_columns links on cells datasource");
+        }
+        for (const linkedDsName of Object.keys(cellsStore.links)) {
+            const rac = cellsStore.links[linkedDsName]?.rows_as_columns as { name_column?: string } | undefined;
+            if (!rac?.name_column) {
+                continue;
+            }
+            const linkedDs = chartManager.dataSources.find((ds: { name: string }) => ds.name === linkedDsName);
+            const nameColumn = linkedDs?.dataStore?.columnIndex?.[rac.name_column];
+            if (!nameColumn) {
+                continue;
+            }
+            if (!nameColumn.values && linkedDs?.dataStore?.loadColumn) {
+                await linkedDs.dataStore.loadColumn(nameColumn.field);
+            }
+            const values = nameColumn.values ?? linkedDs?.dataStore?.getColumnValues?.(rac.name_column);
+            if (Array.isArray(values) && values.length > 0) {
+                return String(values[0]);
+            }
+        }
+        throw new Error("No linked gene labels available");
+    });
+}
+
+export async function addDotPlotChartViaApi(page: Page, title: string): Promise<string> {
+    return await page.evaluate(async (chartTitle) => {
+        const chartManager = (window as any).mdv.chartManager;
+        const dataSourceName = chartManager.dsIndex.cells ? "cells" : Object.keys(chartManager.dsIndex)[0];
+        const dataStore = chartManager.dsIndex[dataSourceName].dataStore;
+        const categoryColumn =
+            dataStore.columns.find(
+                (column: { datatype?: string; subgroup?: unknown; field?: string }) =>
+                    column.datatype === "text" && !column.subgroup && column.field !== "__index__",
+            )?.field ?? "cell_type";
+        const chartId = `pw-dot-plot-${Date.now()}`;
+        await chartManager.addChart(
+            dataSourceName,
+            {
+                id: chartId,
+                title: chartTitle,
+                legend: "",
+                type: "dot_plot",
+                param: [categoryColumn],
+                size: [700, 420],
+                position: [20, 20],
+            },
+            true,
+        );
+        return chartId;
+    }, title);
+}
+
+export async function searchChartSettings(page: Page, query: string) {
+    const search = page.getByLabel("Search Settings by Folder or Name");
+    await expect(search).toBeVisible();
+    await search.fill(query);
+    await expect(page.getByText(query, { exact: true }).first()).toBeVisible();
+}
+
+function getSettingRow(page: Page, paramLabel: string) {
+    return page
+        .locator(".grid")
+        .filter({ has: page.getByText(paramLabel, { exact: true }) })
+        .first();
+}
+
+export function getLinkColumnSettingRow(page: Page, paramLabel: string) {
+    const row = getSettingRow(page, paramLabel);
+    return { row, subgroupTablist: row.getByRole("tablist").nth(1) };
+}
+
+/** Open the column-selection "link" tab and pick one gene from a rows_as_columns subgroup. */
+export async function selectLinkedGeneInChartSettings(
+    page: Page,
+    options: {
+        paramLabel: string;
+        subgroupTabLabel: string;
+        geneLabel: string;
+    },
+) {
+    await searchChartSettings(page, options.paramLabel);
+    const { row, subgroupTablist } = getLinkColumnSettingRow(page, options.paramLabel);
+    await expect(row).toBeVisible();
+    await row.getByRole("tab", { name: "link", exact: true }).click();
+    await subgroupTablist.getByRole("tab", { name: options.subgroupTabLabel, exact: true }).click();
+
+    const combobox = row.getByRole("combobox").first();
+    await combobox.click();
+    await combobox.fill(options.geneLabel);
+    const listbox = page.getByRole("listbox");
+    await expect(listbox).toBeVisible();
+    const option = listbox
+        .getByRole("option")
+        .filter({ hasText: options.geneLabel })
+        .first();
+    await expect(option).toBeVisible();
+    await option.click();
+}
+
+/** True when Playwright targets a worktree Vite dev server (subgroup tab UI is not on the 5055 image build). */
+export function isWorktreeFrontendForPlaywright(): boolean {
+    const baseUrl = process.env.TEST_BASE_URL ?? "http://localhost:5055/";
+    return /5170|5173/.test(baseUrl);
+}
+
+export async function setDotPlotXAxisLinkField(
+    page: Page,
+    chartTitle: string,
+    subgroupKey: string,
+    geneLabel: string,
+    geneIndex: number,
+) {
+    await page.evaluate(
+        ({ chartTitle: title, subgroupKey: sg, geneLabel: label, geneIndex: index }) => {
+            const fieldName = `${sg}|${label} (${sg})|${index}`;
+            const chartEntries = Object.values((window as any).mdv.chartManager.charts) as Array<{
+                chart?: {
+                    config?: { title?: string; param?: unknown[] };
+                    _setFields?: (fields: string[]) => void;
+                };
+            }>;
+            const entry = chartEntries.find((item) => item.chart?.config?.title === title);
+            const chart = entry?.chart;
+            const category = chart?.config?.param?.[0];
+            if (!chart || typeof category !== "string") {
+                throw new Error(`Dot plot chart not found or missing category: ${title}`);
+            }
+            chart.config.param = [category, fieldName];
+        },
+        { chartTitle, subgroupKey, geneLabel, geneIndex },
+    );
+    await expect
+        .poll(async () => {
+            const fields = await getDotPlotXAxisFields(page, chartTitle);
+            return fields[0] ?? "";
+        })
+        .toMatch(new RegExp(`^${subgroupKey}\\|`));
+    await waitForViewUnsavedState(page, true);
+}
+
+export async function getDotPlotXAxisFields(page: Page, chartTitle: string): Promise<string[]> {
+    return await page.evaluate((title) => {
+        const chartEntries = Object.values((window as any).mdv.chartManager.charts) as Array<{
+            chart?: { config?: { title?: string; param?: unknown[] } };
+        }>;
+        const entry = chartEntries.find((item) => item.chart?.config?.title === title);
+        const param = entry?.chart?.config?.param;
+        if (!Array.isArray(param)) {
+            return [];
+        }
+        return param.slice(1).filter((value): value is string => typeof value === "string");
+    }, chartTitle);
 }

--- a/tests_playwright/utils/helpers.ts
+++ b/tests_playwright/utils/helpers.ts
@@ -228,15 +228,25 @@ export type RowsAsColumnsSubgroupInfo = {
     label: string;
 };
 
+type PlaywrightDsIndexEntry = {
+    dataStore?: {
+        links?: Record<
+            string,
+            {
+                rows_as_columns?: { subgroups?: Record<string, { label?: string }> };
+            }
+        >;
+    };
+};
+
 /** Subgroup keys on the cells→genes rows_as_columns link (requires extra-expression-layers project). */
 export async function getRowsAsColumnsSubgroupKeys(page: Page): Promise<RowsAsColumnsSubgroupInfo[]> {
     return await page.evaluate(() => {
         const chartManager = (window as any).mdv?.chartManager;
+        const dsIndex = (chartManager?.dsIndex ?? {}) as Record<string, PlaywrightDsIndexEntry>;
         const cellsStore =
             chartManager?.dsIndex?.cells?.dataStore ??
-            Object.values(chartManager?.dsIndex ?? {}).find(
-                (entry: { dataStore?: { links?: Record<string, unknown> } }) => entry?.dataStore?.links,
-            )?.dataStore;
+            Object.values(dsIndex).find((entry) => entry?.dataStore?.links)?.dataStore;
         if (!cellsStore?.links) {
             return [];
         }
@@ -384,11 +394,12 @@ export async function setDotPlotXAxisLinkField(
             }>;
             const entry = chartEntries.find((item) => item.chart?.config?.title === title);
             const chart = entry?.chart;
-            const category = chart?.config?.param?.[0];
-            if (!chart || typeof category !== "string") {
+            const config = chart?.config;
+            const category = config?.param?.[0];
+            if (!chart || !config || typeof category !== "string") {
                 throw new Error(`Dot plot chart not found or missing category: ${title}`);
             }
-            chart.config.param = [category, fieldName];
+            config.param = [category, fieldName];
         },
         { chartTitle, subgroupKey, geneLabel, geneIndex },
     );

--- a/tests_playwright/utils/projectFixtures/syntheticAnndata.ts
+++ b/tests_playwright/utils/projectFixtures/syntheticAnndata.ts
@@ -34,6 +34,8 @@ export type SyntheticAnndataGeneratorCliArgs = {
     sparseDensity?: number;
     chunkData?: boolean;
     computeXUmap?: boolean;
+    /** Adds synth_layer_a / synth_layer_b AnnData.layers → multiple rows_as_columns subgroups. */
+    extraExpressionLayers?: boolean;
     force?: boolean;
 };
 
@@ -101,6 +103,9 @@ async function runSyntheticAnndataProjectCli(
     }
     if (synthetic.computeXUmap) {
         args.push("--compute-x-umap");
+    }
+    if (synthetic.extraExpressionLayers) {
+        args.push("--extra-expression-layers");
     }
     if (force) {
         args.push("--force");


### PR DESCRIPTION
Also change tab-header to indicate active state when viewing a different tab.

Before merge, I want to do more of a pass on mock-project generation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subgroup selection added for rows-as-columns with tab-based UI and subgroup-aware column/field resolution.
  * CLI option and test helpers to generate synthetic projects with extra expression layers.

* **Improvements**
  * Commit/indicator behavior updated so tab UI reflects committed subgroup and synchronizes selection across components.
  * Serialization now preserves and validates canonical subgroup identifiers with robust fallbacks.

* **Tests**
  * Added/updated unit and end-to-end tests covering subgroup behavior and multilayer synthetic projects.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Taylor-CCB-Group/MDV/pull/457)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->