### PR TITLE
Add psycopg2-binary dependency and minor doc cleanup

### DIFF
--- a/docs/MDVTOOLS_PACKAGING_PROPOSAL.md
+++ b/docs/MDVTOOLS_PACKAGING_PROPOSAL.md
@@ -1,12 +1,8 @@
 # mdvtools Packaging & Release Proposal
 
-**Status:** Decisions locked (grilling session 2026-05-29). See `docs/adr/0001`, `docs/adr/0002`, and `CONTEXT.md`.
 **Author:** Marouf Shaikh
 **Date:** 2026-05-29
-**Goal (set by management):** Stop maintaining two diverging `pyproject.toml` files. Manage **one** well-structured `pyproject.toml` that serves both the slim `pip install mdvtools` (the majority of users) and the full Docker image. Maintainability first; smaller install is a secondary benefit.
-
-**Recommendation (decided):** Collapse to a **single `python/pyproject.toml`** on **uv**. Required deps = slim core; the entire optional cluster becomes **one `app` extra** + guarded imports. `pip install mdvtools` → slim; the Docker image runs `uv sync --all-extras` → full. **Delete `mdvtools_lite_build/`.** No second package, no second version, no `force-include`, ship all modules.
-
+**Goal:** Stop maintaining two diverging `pyproject.toml` files. Manage **one** well-structured `pyproject.toml` that serves both the slim `pip install mdvtools` (the majority of users) and the full Docker image. Maintainability first; smaller install is a secondary benefit.
 ---
 
 ## 1. The problem
@@ -29,13 +25,13 @@ Because both files hand-declare `name = "mdvtools"`, `version`, and overlapping 
 
 ---
 
-## 2. Martin's concern, answered with numbers
+## 2. Some concerns, answered with numbers
 
 Martin built the lite wheel and observed:
 
 > *"I use hatch to cherry-pick modules… even doing this, with all the dependencies, the install is still **over 1.4 GB**."*
 
-That observation is the whole argument, and Martin draws the right conclusion himself: *"the only other way is optional dependencies + a graceful way of handling them."* The build backend's file-selection power operates on the axis that doesn't matter (`.py` source), while the 1.4 GB lives in **dependencies**, which `[project.optional-dependencies]` controls — backend-agnostically.
+ The build backend's file-selection power operates on the axis that doesn't matter (`.py` source), while the 1.4 GB lives in **dependencies**, which `[project.optional-dependencies]` controls — backend-agnostically.
 
 | What | Size | Notes |
 |---|---|---|
@@ -169,19 +165,9 @@ llm     → auth    (chat_server_extension)      ┘
 
 ## 7. Open questions for standup
 
-1. ~~Why was uv #468 reverted (#471)?~~ **Moot** — uv re-landed on `main` via #472 and is passing CI.
-2. **`required-version` exact pin** — #472 set `[tool.uv] required-version = "0.11.14"` (exact `==`), which fails on any uv drift (hit during this work). Consider relaxing to a range (e.g. `>=0.11.14,<0.12`).
-3. **PyPI ownership** — add Marouf (`mrfshk`) as collaborator on PyPI + TestPyPI `mdvtools` (Martin to action).
-4. **Existing-user impact** — slim install becomes *lighter*; full-app users must add `[app]`. spatial is unchanged (stays in core). The full Docker image now also pulls `gspread`/`oauth2client` (previously absent). Note in release notes / version bump.
+1. **`required-version` exact pin** — #472 set `[tool.uv] required-version = "0.11.14"` (exact `==`), which fails on any uv drift (hit during this work). Consider relaxing to a range (e.g. `>=0.11.14,<0.12`).
 
 ---
-
-## 8. Appendix — approaches considered and not chosen
-
-- **Keep Poetry** (the earlier recommendation). Poetry 2.x supports PEP 621 extras and would be a ~2-line Dockerfile change, but it leaves us on Poetry against the team's direction and re-converts the toml later anyway. Rejected — see ADR-0002.
-- **Spatial as an extra** (Martin's preference). Today's PyPI wheel already ships spatial + requires spatialdata; demoting it breaks existing `pip install mdvtools` users for a maintainability goal that doesn't require the break. Rejected — spatial stays in core. (ADR-0001)
-- **Separate named extras (spatial/chat/server/auth).** auth+dbutils+llm form an import cycle, so three "independent" extras that each pull the other two is false granularity. Collapsed to one `app` extra. (ADR-0001 / §4)
-- **Two PyPI packages (pydantic-ai umbrella) / separate repo (Martin's "MDVApp").** Both *add* packages/versions to manage — the opposite of the goal. The 576 KB figure removes the footprint rationale. Rejected. (ADR-0001)
 
 ## 9. References
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -11,7 +11,7 @@ How to build and publish the `mdvtools` package. One package, one version, one
 ## Prerequisites
 
 - Accounts on **TestPyPI** and **PyPI**, and **collaborator** access on the `mdvtools`
-  project on each (ask Martin Sergeant to add you).
+  project on each.
 - An **API token** for each index (account → API tokens). Export it when publishing:
   ```bash
   export UV_PUBLISH_TOKEN="pypi-…"     # the token for the index you're publishing to

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
 app = [
     # server / database
     "flask-sqlalchemy>=3.1.1,<4",
-    "psycopg2>=2.9.9,<3",
+    "psycopg2-binary>=2.9.9,<3",
     "gunicorn==23.0.0",
     "psycogreen>=1.0.2,<2",
     # chat / LLM

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -2157,7 +2157,7 @@ all = [
     { name = "nbformat" },
     { name = "oauth2client" },
     { name = "psycogreen" },
-    { name = "psycopg2" },
+    { name = "psycopg2-binary" },
     { name = "python-dotenv" },
     { name = "python-jose" },
     { name = "redis" },
@@ -2182,7 +2182,7 @@ app = [
     { name = "nbformat" },
     { name = "oauth2client" },
     { name = "psycogreen" },
-    { name = "psycopg2" },
+    { name = "psycopg2-binary" },
     { name = "python-dotenv" },
     { name = "python-jose" },
     { name = "redis" },
@@ -2245,7 +2245,7 @@ requires-dist = [
     { name = "pandas", specifier = "==2.3.2" },
     { name = "polars", specifier = ">=1.31.0,<2" },
     { name = "psycogreen", marker = "extra == 'app'", specifier = ">=1.0.2,<2" },
-    { name = "psycopg2", marker = "extra == 'app'", specifier = ">=2.9.9,<3" },
+    { name = "psycopg2-binary", marker = "extra == 'app'", specifier = ">=2.9.9,<3" },
     { name = "python-dotenv", marker = "extra == 'app'", specifier = ">=1.0.1,<2" },
     { name = "python-jose", marker = "extra == 'app'", specifier = ">=3.3.0,<4" },
     { name = "redis", marker = "extra == 'app'", specifier = ">=5.2.1,<6" },
@@ -3019,15 +3019,33 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/eb/72/4a7965cf54e341006ad74cdc72cd6572c789bc4f4e3fadc78672f1fbcfbd/psycogreen-1.0.2.tar.gz", hash = "sha256:c429845a8a49cf2f76b71265008760bcd7c7c77d80b806db4dc81116dbcd130d", size = 5411, upload-time = "2020-02-22T19:55:22.02Z" }
 
 [[package]]
-name = "psycopg2"
-version = "2.9.10"
+name = "psycopg2-binary"
+version = "2.9.12"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/62/51/2007ea29e605957a17ac6357115d0c1a1b60c8c984951c19419b3474cdfd/psycopg2-2.9.10.tar.gz", hash = "sha256:12ec0b40b0273f95296233e8750441339298e6a572f7039da5b260e3c8b60e11", size = 385672, upload-time = "2024-10-16T11:24:54.832Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/60/a3624f79acea344c16fbef3a94d28b89a8042ddfb8f3e4ca83f538671409/psycopg2_binary-2.9.12.tar.gz", hash = "sha256:5ac9444edc768c02a6b6a591f070b8aae28ff3a99be57560ac996001580f294c", size = 379686, upload-time = "2026-04-21T09:40:34.304Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/a2/c51ca3e667c34e7852157b665e3d49418e68182081060231d514dd823225/psycopg2-2.9.10-cp311-cp311-win32.whl", hash = "sha256:47c4f9875125344f4c2b870e41b6aad585901318068acd01de93f3677a6522c2", size = 1024538, upload-time = "2024-10-16T11:18:33.48Z" },
-    { url = "https://files.pythonhosted.org/packages/33/39/5a9a229bb5414abeb86e33b8fc8143ab0aecce5a7f698a53e31367d30caa/psycopg2-2.9.10-cp311-cp311-win_amd64.whl", hash = "sha256:0435034157049f6846e95103bd8f5a668788dd913a7c30162ca9503fdf542cb4", size = 1163736, upload-time = "2024-10-16T11:18:36.616Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/16/4623fad6076448df21c1a870c93a9774ad8a7b4dd1660223b59082dd8fec/psycopg2-2.9.10-cp312-cp312-win32.whl", hash = "sha256:65a63d7ab0e067e2cdb3cf266de39663203d38d6a8ed97f5ca0cb315c73fe067", size = 1025113, upload-time = "2024-10-16T11:18:40.148Z" },
-    { url = "https://files.pythonhosted.org/packages/66/de/baed128ae0fc07460d9399d82e631ea31a1f171c0c4ae18f9808ac6759e3/psycopg2-2.9.10-cp312-cp312-win_amd64.whl", hash = "sha256:4a579d6243da40a7b3182e0430493dbd55950c493d8c68f4eec0b302f6bbf20e", size = 1163951, upload-time = "2024-10-16T11:18:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/19/d4ce60954f3bb9d8e3bc5e5c4d1f2487de2d3851bf2391d54954c9df12a6/psycopg2_binary-2.9.12-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5c8ce6c61bd1b1f6b9c24ee32211599f6166af2c55abb19456090a21fd16554b", size = 3712338, upload-time = "2026-04-20T23:34:03.961Z" },
+    { url = "https://files.pythonhosted.org/packages/53/71/c85409ee0d78890f0660eff262e815e7dd2bb741a17611d82e9e8cd9dc5e/psycopg2_binary-2.9.12-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b4a9eaa6e7f4ff91bec10aa3fb296878e75187bced5cc4bafe17dc40915e1326", size = 3822407, upload-time = "2026-04-20T23:34:05.977Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/ed/60486c2c7f0d4d1ede2bfb1ed27e2498477ce646bc7f6b2759906303117e/psycopg2_binary-2.9.12-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c6528cefc8e50fcc6f4a107e27a672058b36cc5736d665476aeb413ba88dbb06", size = 4578425, upload-time = "2026-04-20T23:34:08.246Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b9/656cb03fad9f4f49f2145c334b1126ee75189929ca4e6187d485a2d59951/psycopg2_binary-2.9.12-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e4e184b1fb6072bf05388aa41c697e1b2d01b3473f107e7ec44f186a32cfd0b8", size = 4273709, upload-time = "2026-04-20T23:34:10.974Z" },
+    { url = "https://files.pythonhosted.org/packages/99/66/08cf0da0e25cc6fb142c89be45fc8418792858f0c4cbff5e24530ff02cd6/psycopg2_binary-2.9.12-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4766ab678563054d3f1d064a4db19cc4b5f9e3a8d9018592a8285cf200c248f3", size = 5893779, upload-time = "2026-04-20T23:34:13.905Z" },
+    { url = "https://files.pythonhosted.org/packages/17/d7/eecd9ce8e146d3721115d82d3836efdbb712187e4590325df549989d18f4/psycopg2_binary-2.9.12-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5a0253224780c978746cb9be55a946bcdaf40fe3519c0f622924cdabdafe2c39", size = 4109308, upload-time = "2026-04-20T23:34:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/2e/b1dc289b362cc8d45697b57eefbd673186f49a4ea0906928988e3affcc98/psycopg2_binary-2.9.12-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0dc9228d47c46bda253d2ecd6bb93b56a9f2d7ad33b684a1fa3622bf74ffe30c", size = 3654405, upload-time = "2026-04-20T23:34:19.303Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e4/4c4aea6473214dbdbd0fbba11aa4691e76dc01722c55724c5951719865ff/psycopg2_binary-2.9.12-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:f921f3cd87035ef7df233383011d7a53ea1d346224752c1385f1edfd790ceb6a", size = 3299187, upload-time = "2026-04-20T23:34:21.206Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/5d/b03b99986446a4f57b170ed9a2579fb7ff9783ca0fa5226b19db99737fee/psycopg2_binary-2.9.12-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:3d999bd982a723113c1a45b55a7a6a90d64d0ed2278020ed625c490ff7bef96c", size = 3047716, upload-time = "2026-04-20T23:34:23.077Z" },
+    { url = "https://files.pythonhosted.org/packages/14/86/382ee4afbd1d97500c9d2862b20c2fdeddf4b7335e984df3fb4309f64108/psycopg2_binary-2.9.12-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:29d4d134bd0ab46ffb04e94aa3c5fa3ef582e9026609165e2f758ff76fc3a3be", size = 3349237, upload-time = "2026-04-20T23:34:25.211Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/16/9a57c75ba1eda7165c017342f526810d5f5a12647dde749c99ae9a7141d7/psycopg2_binary-2.9.12-cp311-cp311-win_amd64.whl", hash = "sha256:cb4a1dacdd48077150dc762a9e5ddbf32c256d66cb46f80839391aa458774936", size = 2757036, upload-time = "2026-04-20T23:34:27.77Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/9f/ef4ef3c8e15083df90ca35265cfd1a081a2f0cc07bb229c6314c6af817f4/psycopg2_binary-2.9.12-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5cdc05117180c5fa9c40eea8ea559ce64d73824c39d928b7da9fb5f6a9392433", size = 3712459, upload-time = "2026-04-20T23:34:30.549Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/01/3dd14e46ba48c1e1a6ec58ee599fa1b5efa00c246d5046cd903d0eeb1af1/psycopg2_binary-2.9.12-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d3227a3bc228c10d21011a99245edca923e4e8bf461857e869a507d9a41fe9f6", size = 3822936, upload-time = "2026-04-20T23:34:32.77Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/f7/0640e4901119d8a9f7a1784b927f494e2198e213ceb593753d1f2c8b1b30/psycopg2_binary-2.9.12-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:995ce929eede89db6254b50827e2b7fd61e50d11f0b116b29fffe4a2e53c4580", size = 4578676, upload-time = "2026-04-20T23:34:35.18Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/55/44df3965b5f297c50cc0b1b594a31c67d6127a9d133045b8a66611b14dfb/psycopg2_binary-2.9.12-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9fe06d93e72f1c048e731a2e3e7854a5bfaa58fc736068df90b352cefe66f03f", size = 4274917, upload-time = "2026-04-20T23:34:37.982Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/4b/74535248b1eac0c9336862e8617c765ac94dac76f9e25d7c4a79588c8907/psycopg2_binary-2.9.12-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40e7b28b63aaf737cb3a1edc3a9bbc9a9f4ad3dcb7152e8c1130e4050eddcb7d", size = 5894843, upload-time = "2026-04-20T23:34:40.856Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/ba/f1bf8d2ae71868ad800b661099086ee52bc0f8d9f05be1acd8ebb06757cc/psycopg2_binary-2.9.12-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:89d19a9f7899e8eb0656a2b3a08e0da04c720a06db6e0033eab5928aabe60fa9", size = 4110556, upload-time = "2026-04-20T23:34:44.016Z" },
+    { url = "https://files.pythonhosted.org/packages/45/46/c15706c338403b7c420bcc0c2905aad116cc064545686d8bf85f1999ea00/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:612b965daee295ae2da8f8218ce1d274645dc76ef3f1abf6a0a94fd57eff876d", size = 3655714, upload-time = "2026-04-20T23:34:46.233Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7c/a2d5dc09b64a4564db242a0fe418fde7d33f6f8259dd2c5b9d7def00fb5a/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:b9a339b79d37c1b45f3235265f07cdeb0cb5ad7acd2ac7720a5920989c17c24e", size = 3301154, upload-time = "2026-04-20T23:34:49.528Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/e8/cc8c9a4ce71461f9ec548d38cadc41dc184b34c73e6455450775a9334ccd/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:3471336e1acfd9c7fe507b8bad5af9317b6a89294f9eb37bd9a030bb7bebcdc6", size = 3048882, upload-time = "2026-04-20T23:34:51.86Z" },
+    { url = "https://files.pythonhosted.org/packages/19/6a/31e2296bc0787c5ab75d3d118e40b239db8151b5192b90b77c72bc9256e9/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7af18183109e23502c8b2ae7f6926c0882766f35b5175a4cd737ad825e4d7a1b", size = 3351298, upload-time = "2026-04-20T23:34:54.124Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/a8/75f4e3e11203b590150abed2cf7794b9c9c9f7eceddae955191138b44dde/psycopg2_binary-2.9.12-cp312-cp312-win_amd64.whl", hash = "sha256:398fcd4db988c7d7d3713e2b8e18939776fd3fb447052daae4f24fa39daede4c", size = 2757230, upload-time = "2026-04-20T23:34:56.242Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Follow-up to the `pyproject.toml` consolidation work:

* Add `psycopg2-binary` to `pyproject.toml` dependencies and updated `uv.lock` to match this. 
* Minor documentation cleanup

### Testing:
* Tested this new `pyproject.toml` against the `app` install and it works well. No `pycopg2` build error. 
* `make test` runs fine. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated packaging proposal documentation to reflect finalized single-source dependency management strategy and consolidated action items.
  * Simplified release prerequisites documentation regarding collaborator access requirements.

* **Chores**
  * Updated PostgreSQL library dependency specification in optional application extras.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->