### PR TITLE
Add MDVProject.writable check, applied as a guard on set_editable. Never tell frontend project is 'editable' when not writable.

### DIFF
--- a/python/mdvtools/dbutils/mdv_server_app.py
+++ b/python/mdvtools/dbutils/mdv_server_app.py
@@ -403,9 +403,11 @@ def serve_projects_from_db(app):
                             # Default to editable when access level is missing/unknown or non-string (e.g., MagicMock)
                             access_level_val = getattr(project, 'access_level', None)
                             is_editable = (access_level_val == 'editable') if isinstance(access_level_val, str) else True
+                        # nb this will warn in log if the project isn't writable by current user
+                        # avoiding touching other aspects of surrounding logic for now.
                         p.set_editable(is_editable)
                     except Exception:
-                        # Favor editable by default on unexpected errors
+                        # Favor editable by default on unexpected errors (see comment above on writable check)
                         p.set_editable(True)
                     # todo: look up how **kwargs works and maybe have a shared app config we can pass around
                     p.serve(options=options)

--- a/python/mdvtools/mdvproject.py
+++ b/python/mdvtools/mdvproject.py
@@ -200,10 +200,9 @@ class MDVProject:
         field_set = set(fields)
 
         if columns is None:
-            out: dict[str, Any] = {}
-            for field in fields:
-                out[field] = self.get_column(datasource, field)
-            return pandas.DataFrame(out)
+            return pandas.DataFrame(
+                {field: self.get_column(datasource, field) for field in fields}
+            )
 
         requested_keys: list[str] = []
         for col in columns:

--- a/python/mdvtools/mdvproject.py
+++ b/python/mdvtools/mdvproject.py
@@ -35,30 +35,6 @@ from mdvtools.project_protocols import RowsAsColumnsLinkSource
 logger = get_logger(__name__)
 
 
-def _agent_debug_log(
-    run_id: str,
-    hypothesis_id: str,
-    location: str,
-    message: str,
-    data: dict,
-    *,
-    log: logging.Logger | None = None,
-) -> None:
-    """Structured debug logging for agent workflows (logger-only, no file I/O)."""
-    target = log if log is not None else logger
-    payload = {
-        "runId": run_id,
-        "hypothesisId": hypothesis_id,
-        "location": location,
-        "message": message,
-        "data": data,
-    }
-    try:
-        target.debug(json.dumps(payload))
-    except Exception:
-        target.warning("agent debug log failed", exc_info=True)
-
-
 DataSourceName = str  # NewType("DataSourceName", str)
 ColumnName = str  # NewType("ColumnName", str)
 # List[ColumnName] gets tricky, `ColumnName | str` syntax needs python>=3.10
@@ -135,6 +111,16 @@ class MDVProject:
         self.backend_db = backend_db
 
     @property
+    def writable(self):
+        """
+        Determine whether the user running this process has write-permission on relevant files
+        (state.json as a heuristic for now).
+        This is independent of any permissions set in db etc,
+        but can be used to guard against inappropriate admin actions
+        """
+        return os.access(self.statefile, os.W_OK)
+
+    @property
     def datasources(self):
         return get_json(self.datasourcesfile)
 
@@ -168,6 +154,9 @@ class MDVProject:
         save_json(self.statefile, value ,self.safe_file_save)
 
     def set_editable(self, edit=True):
+        if not self.writable:
+            logger.log(1, f"can't set_editable on '{self.dir}' because it's not writable")
+            return
         c = self.state
         c["permission"] = "edit" if edit else "view"
         self.state = c

--- a/python/mdvtools/mdvproject.py
+++ b/python/mdvtools/mdvproject.py
@@ -140,11 +140,16 @@ class MDVProject:
     def writable(self):
         """
         Determine whether the user running this process has write-permission on relevant files
-        (state.json as a heuristic for now).
         This is independent of any permissions set in db etc,
         but can be used to guard against inappropriate admin actions
         """
-        return os.access(self.statefile, os.W_OK)
+        return (
+            # belt and braces
+            os.access(self.statefile, os.W_OK)
+            and os.access(self.dir, os.W_OK | os.X_OK)
+            and os.access(self.viewsfile, os.W_OK)
+            and os.access(self.h5file, os.W_OK)
+        )
 
     @property
     def datasources(self):

--- a/python/mdvtools/mdvproject.py
+++ b/python/mdvtools/mdvproject.py
@@ -35,6 +35,32 @@ from mdvtools.project_protocols import RowsAsColumnsLinkSource
 logger = get_logger(__name__)
 
 
+def _agent_debug_log(
+    run_id: str,
+    hypothesis_id: str,
+    location: str,
+    message: str,
+    data: dict,
+    *,
+    log: logging.Logger | None = None,
+) -> None:
+    """Structured debug logging for agent workflows (logger-only, no file I/O).
+    note: this should probably be removed, but I've realised it's used elsewhere so leaving for now.
+    """
+    target = log if log is not None else logger
+    payload = {
+        "runId": run_id,
+        "hypothesisId": hypothesis_id,
+        "location": location,
+        "message": message,
+        "data": data,
+    }
+    try:
+        target.debug(json.dumps(payload))
+    except Exception:
+        target.warning("agent debug log failed", exc_info=True)
+
+
 DataSourceName = str  # NewType("DataSourceName", str)
 ColumnName = str  # NewType("ColumnName", str)
 # List[ColumnName] gets tricky, `ColumnName | str` syntax needs python>=3.10

--- a/python/mdvtools/server.py
+++ b/python/mdvtools/server.py
@@ -191,7 +191,7 @@ def create_app(
                     # if we don't have write-permission, then we definitely shouldn't allow `permission: "edit"` to get to the frontend
                     if not project.writable:
                         log("overriding editable permission because state is not writable")
-                        state["permission"] = "read-only"
+                        state["permission"] = "view"
                     # do we want this to always be true/not a flag we pass?
                     state["websocket"] = project.writable and options.websocket
                     # in future, we could iterate over a list of extensions.

--- a/python/mdvtools/server.py
+++ b/python/mdvtools/server.py
@@ -188,8 +188,12 @@ def create_app(
             with open(path) as f:
                 try:
                     state = json.load(f)
+                    # if we don't have write-permission, then we definitely shouldn't allow `permission: "edit"` to get to the frontend
+                    if not project.writable:
+                        log("overriding editable permission because state is not writable")
+                        state["permission"] = "read-only"
                     # do we want this to always be true/not a flag we pass?
-                    state["websocket"] = options.websocket
+                    state["websocket"] = project.writable and options.websocket
                     # in future, we could iterate over a list of extensions.
                     # we should alter permissions based on the permission of the user...
                     for extension in options.extensions:


### PR DESCRIPTION
Fixes https://github.com/Taylor-CCB-Group/MDV/issues/485

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved permission enforcement for read-only project directories. The system now properly detects when a project directory is not writable and enforces read-only mode, preventing editing operations and ensuring accurate permission status is displayed.
* WebSocket functionality is now correctly disabled for read-only projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->