### PR TITLE
Nicer debug-dialog validation UI

### DIFF
--- a/src/react/components/DebugButton.tsx
+++ b/src/react/components/DebugButton.tsx
@@ -39,8 +39,7 @@ const DebugButton = observer(() => {
                 views,
                 state,
                 buildInfo,
-                ...(validationFindings?.hasAny && { validationFindings: validationFindings.snapshot }),
-            });
+            }, undefined, { showValidationSection: true });
         } catch (err) {
             setError(err instanceof Error ? {
                 message: err.message,
@@ -91,4 +90,3 @@ const DebugButton = observer(() => {
 });
 
 export default DebugButton;
-

--- a/src/react/components/DebugJsonDialogComponent.test.tsx
+++ b/src/react/components/DebugJsonDialogComponent.test.tsx
@@ -1,0 +1,138 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import ValidationFindingsStore from "@/lib/ValidationFindingsStore";
+import DebugJsonDialogComponent from "./DebugJsonDialogComponent";
+
+type MockChartManager = {
+    validationFindings?: ValidationFindingsStore;
+};
+
+const mocks = vi.hoisted<{
+    chartManager: MockChartManager;
+    jsonViewSources: unknown[];
+}>(() => ({
+    chartManager: {},
+    jsonViewSources: [],
+}));
+
+vi.mock("../hooks", () => ({
+    useChartManager: () => mocks.chartManager,
+}));
+
+vi.mock("../viv_loader_cache", () => ({
+    vivLoaderCacheTelemetryObservable: {
+        snapshot: { cacheEntries: 3 },
+    },
+}));
+
+vi.mock("./CustomTooltip", () => ({
+    default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("react18-json-view", () => ({
+    default: ({ src }: { src: unknown }) => {
+        mocks.jsonViewSources.push(src);
+        return <pre data-testid="json-view">{JSON.stringify(src)}</pre>;
+    },
+}));
+
+function buildStoreWithFindings() {
+    const store = new ValidationFindingsStore();
+    store.addChartFinding("scatter_plot v2", {
+        issues: [
+            {
+                path: "param.0",
+                message: "Expected numeric column",
+                code: "invalid_type",
+            },
+        ],
+        rawConfig: {
+            type: "scatter_plot",
+            param: ["cell_type"],
+        },
+        details: {
+            chartId: "chart-1",
+        },
+    });
+    store.addDatasourceFinding("cells", {
+        issues: [
+            {
+                path: "columns.2.datatype",
+                message: "Required",
+            },
+        ],
+        rawConfig: {
+            name: "cells",
+        },
+    });
+    return store;
+}
+
+describe("DebugJsonDialogComponent", () => {
+    beforeEach(() => {
+        mocks.jsonViewSources.length = 0;
+        mocks.chartManager.validationFindings = new ValidationFindingsStore();
+    });
+
+    test("renders grouped validation issue details outside the generic JSON view", () => {
+        mocks.chartManager.validationFindings = buildStoreWithFindings();
+
+        render(
+            <DebugJsonDialogComponent
+                json={{
+                    chartTypes: [],
+                    validationFindings: { old: "payload should not be supplied here" },
+                }}
+                showValidationSection
+            />,
+        );
+
+        expect(screen.getByText("Validation issues")).toBeTruthy();
+        expect(screen.getByText("Total:")).toBeTruthy();
+        expect(screen.getByText("Charts (1)")).toBeTruthy();
+        expect(screen.getByText("Datasources (1)")).toBeTruthy();
+        expect(screen.getByText("scatter_plot v2")).toBeTruthy();
+        expect(screen.getByText("cells")).toBeTruthy();
+        expect(screen.getByText("param.0 (invalid_type)")).toBeTruthy();
+        expect(screen.getByText("Expected numeric column")).toBeTruthy();
+        expect(screen.getByText("columns.2.datatype")).toBeTruthy();
+        expect(screen.getByText("Required")).toBeTruthy();
+        expect(screen.getAllByText("Raw config")).toHaveLength(2);
+        expect(screen.getByText("Details")).toBeTruthy();
+
+        const topLevelJsonSource = mocks.jsonViewSources.at(-1);
+        expect(topLevelJsonSource).toMatchObject({
+            chartTypes: [],
+            vivLoaderCacheTelemetry: { cacheEntries: 3 },
+        });
+        expect(topLevelJsonSource).not.toHaveProperty("validationFindings");
+    });
+
+    test("renders the empty validation state", () => {
+        render(
+            <DebugJsonDialogComponent
+                json={{ chartTypes: [] }}
+                showValidationSection
+            />,
+        );
+
+        expect(screen.getByText("No validation issues recorded.")).toBeTruthy();
+    });
+
+    test("clear button clears all validation findings", () => {
+        const store = buildStoreWithFindings();
+        mocks.chartManager.validationFindings = store;
+
+        render(
+            <DebugJsonDialogComponent
+                json={{ chartTypes: [] }}
+                showValidationSection
+            />,
+        );
+
+        fireEvent.click(screen.getByRole("button", { name: "Clear" }));
+
+        expect(store.hasAny).toBe(false);
+    });
+});

--- a/src/react/components/DebugJsonDialogComponent.tsx
+++ b/src/react/components/DebugJsonDialogComponent.tsx
@@ -13,6 +13,8 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { DEBUG_JSON_REPORT_MESSAGE, MDV_EMAIL } from "@/utilities/constants";
 import { useChartManager } from "../hooks";
 import CustomTooltip from "./CustomTooltip";
+import type ValidationFindingsStore from "@/lib/ValidationFindingsStore";
+import type { ValidationFinding } from "@/lib/ValidationFindingsStore";
 
 type JSONObject = { [key: string]: any };
 type DataLoaderFaultMode = "empty" | "corrupt" | "timeout";
@@ -90,6 +92,175 @@ function filterJSON(obj: JSONObject, filter: string): JSONObject {
     return recursiveFilter(obj, []) || {};
 }
 
+function omitValidationFindings(json: any) {
+    if (typeof json !== "object" || json === null || !("validationFindings" in json)) {
+        return json;
+    }
+    const { validationFindings: _validationFindings, ...jsonWithoutValidationFindings } = json;
+    return jsonWithoutValidationFindings;
+}
+
+function formatSeenAt(timestamp: number) {
+    return new Date(timestamp).toISOString();
+}
+
+function issuePathLabel(path: string) {
+    return path || "(root)";
+}
+
+function FindingDetailsJson({ label, value }: { label: string; value: unknown }) {
+    return (
+        <Box
+            component="details"
+            sx={{
+                mt: 1,
+                "& summary": {
+                    cursor: "pointer",
+                    fontWeight: 600,
+                },
+            }}
+        >
+            <summary>{label}</summary>
+            <JsonView
+                src={value}
+                style={{
+                    fontSize: "0.8125rem",
+                    fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+                    padding: "8px",
+                }}
+                collapsed={1}
+            />
+        </Box>
+    );
+}
+
+function ValidationFindingCard({ finding }: { finding: ValidationFinding }) {
+    const latest = finding.latest;
+
+    return (
+        <Box
+            sx={{
+                border: "1px solid var(--border_menu_bar_color)",
+                borderRadius: "8px",
+                p: 1.5,
+                mb: 1,
+            }}
+        >
+            <Box sx={{ display: "flex", flexWrap: "wrap", alignItems: "baseline", gap: 1 }}>
+                <Typography sx={{ fontWeight: 700 }}>
+                    {finding.subject}
+                </Typography>
+                <Typography variant="body2" sx={{ opacity: 0.75 }}>
+                    Repeated {finding.count} {finding.count === 1 ? "time" : "times"}
+                </Typography>
+                <Typography variant="body2" sx={{ opacity: 0.75 }}>
+                    Latest: {formatSeenAt(finding.lastSeenAt)}
+                </Typography>
+            </Box>
+            <Box sx={{ mt: 1 }}>
+                {latest?.issues?.length ? (
+                    latest.issues.map((issue, index) => (
+                        <Box
+                            key={`${issue.path}-${issue.message}-${index}`}
+                            sx={{
+                                borderLeft: "3px solid #f2c94c",
+                                pl: 1,
+                                mb: 1,
+                            }}
+                        >
+                            <Typography
+                                variant="body2"
+                                sx={{
+                                    fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+                                    fontWeight: 600,
+                                }}
+                            >
+                                {issuePathLabel(issue.path)}
+                                {issue.code ? ` (${issue.code})` : ""}
+                            </Typography>
+                            <Typography variant="body2">{issue.message}</Typography>
+                        </Box>
+                    ))
+                ) : (
+                    <Typography variant="body2">No issue details recorded.</Typography>
+                )}
+            </Box>
+            {latest?.rawConfig !== undefined && (
+                <FindingDetailsJson label="Raw config" value={latest.rawConfig} />
+            )}
+            {latest?.details !== undefined && (
+                <FindingDetailsJson label="Details" value={latest.details} />
+            )}
+        </Box>
+    );
+}
+
+function ValidationFindingGroup({
+    title,
+    findingsBySubject,
+}: {
+    title: string;
+    findingsBySubject: Record<string, ValidationFinding[]>;
+}) {
+    const entries = Object.entries(findingsBySubject).sort(([a], [b]) => a.localeCompare(b));
+    if (entries.length === 0) return null;
+
+    const totalFindings = entries.reduce((sum, [, findings]) => sum + findings.length, 0);
+
+    return (
+        <Box sx={{ mb: 2 }}>
+            <Typography variant="subtitle1" sx={{ fontWeight: 700, mb: 1 }}>
+                {title} ({totalFindings})
+            </Typography>
+            {entries.map(([subject, findings]) => {
+                const repeatCount = findings.reduce((sum, finding) => sum + finding.count, 0);
+                return (
+                    <Box key={subject} sx={{ mb: 1.5 }}>
+                        <Typography variant="body2" sx={{ mb: 0.75, opacity: 0.8 }}>
+                            {subject}: {findings.length} grouped {findings.length === 1 ? "finding" : "findings"}, {repeatCount} total {repeatCount === 1 ? "report" : "reports"}
+                        </Typography>
+                        {findings.map((finding) => (
+                            <ValidationFindingCard key={finding.signature} finding={finding} />
+                        ))}
+                    </Box>
+                );
+            })}
+        </Box>
+    );
+}
+
+export function ValidationIssuesSection({
+    validationFindings,
+}: {
+    validationFindings?: ValidationFindingsStore;
+}) {
+    const snapshot = validationFindings?.snapshot;
+    const hasAnyFindings = Boolean(validationFindings?.hasAny);
+
+    if (!hasAnyFindings || !snapshot || !validationFindings) {
+        return <Typography>No validation issues recorded.</Typography>;
+    }
+
+    return (
+        <>
+            <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 2, mb: 1 }}>
+                <Typography>
+                    Total: <strong>{snapshot.totalCount}</strong>
+                </Typography>
+                <Button
+                    variant="outlined"
+                    size="small"
+                    onClick={() => validationFindings.clearAll()}
+                >
+                    Clear
+                </Button>
+            </Box>
+            <ValidationFindingGroup title="Charts" findingsBySubject={snapshot.charts} />
+            <ValidationFindingGroup title="Datasources" findingsBySubject={snapshot.datasources} />
+        </>
+    );
+}
+
 const DebugJsonDialogComponent = observer(function DebugJsonDialogComponent({
     json,
     header,
@@ -102,18 +273,21 @@ const DebugJsonDialogComponent = observer(function DebugJsonDialogComponent({
     const [filter, setFilter] = useState("");
     const [debouncedFilter] = useDebounce(filter, 300); //why is this returning a tuple?
     const { validationFindings } = useChartManager();
+    const jsonWithoutValidationFindings = useMemo(
+        () => omitValidationFindings(json),
+        [json],
+    );
     const jsonWithVivTelemetry = useMemo(
         () => ({
-            ...json,
+            ...jsonWithoutValidationFindings,
             vivLoaderCacheTelemetry: vivLoaderCacheTelemetryObservable.snapshot,
         }),
-        [json, vivLoaderCacheTelemetryObservable.snapshot],
+        [jsonWithoutValidationFindings, vivLoaderCacheTelemetryObservable.snapshot],
     );
     const filteredJson = useMemo(
         () => filterJSON(jsonWithVivTelemetry, debouncedFilter),
         [jsonWithVivTelemetry, debouncedFilter],
     );
-    const chartTypeCounts: Record<string, number> = validationFindings?.chartTypeCounts ?? {};
     const hasAnyFindings = Boolean(validationFindings?.hasAny);
     const injectFaultAndReload = (mode: DataLoaderFaultMode) => {
         if (setDataLoaderFaultMode(mode)) {
@@ -206,40 +380,7 @@ const DebugJsonDialogComponent = observer(function DebugJsonDialogComponent({
                     </AccordionSummary>
                     <Divider />
                     <AccordionDetails sx={{ mt: 1 }}>
-                        {hasAnyFindings ? (
-                            <>
-                                <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 2, mb: 1 }}>
-                                    <Typography>
-                                        Total: <strong>{validationFindings.totalCount}</strong>
-                                    </Typography>
-                                    <Button
-                                        variant="outlined"
-                                        size="small"
-                                        onClick={() => validationFindings.clearAll()}
-                                    >
-                                        Clear
-                                    </Button>
-                                </Box>
-                                <Box sx={{ mb: 1 }}>
-                                    {Object.entries(chartTypeCounts).length > 0 ? (
-                                        Object.entries(chartTypeCounts)
-                                            .sort((a, b) => b[1] - a[1])
-                                            .map(([chartType, count]) => (
-                                                <Typography key={chartType} sx={{ fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" }}>
-                                                    {chartType}: {count}
-                                                </Typography>
-                                            ))
-                                    ) : (
-                                        <Typography>No chart validation issues recorded yet.</Typography>
-                                    )}
-                                </Box>
-                                <Typography variant="body2" sx={{ opacity: 0.8, mb: 1 }}>
-                                    Aggregated details are also available in the JSON below under <code>validationFindings</code>.
-                                </Typography>
-                            </>
-                        ) : (
-                            <Typography>No validation issues recorded.</Typography>
-                        )}
+                        <ValidationIssuesSection validationFindings={validationFindings} />
                     </AccordionDetails>
                 </Accordion>
             )}

--- a/src/react/components/DebugJsonDialogReactWrapper.tsx
+++ b/src/react/components/DebugJsonDialogReactWrapper.tsx
@@ -6,6 +6,15 @@ import Gui from "./DebugJsonDialogComponent";
 import type BaseChart from "../../charts/BaseChart";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 
+type DebugChartReactWrapperOptions = {
+    showValidationSection?: boolean;
+};
+
+type DebugDialogContent = {
+    json: any;
+    showValidationSection?: boolean;
+};
+
 const DebugChart = observer(
     ({
         chart,
@@ -35,7 +44,7 @@ class DebugChartReactWrapper extends BaseDialog {
     set root(v) {
         this._root = v;
     }
-    constructor(json: any, chart?: BaseChart<any>) {
+    constructor(json: any, chart?: BaseChart<any>, options: DebugChartReactWrapperOptions = {}) {
         const name = chart
             ? chart.config.title || `${chart.config.type} ${chart.config.id}`
             : "";
@@ -49,17 +58,15 @@ class DebugChartReactWrapper extends BaseDialog {
                 chart?.dialogs.splice(chart.dialogs.indexOf(this), 1);
             },
         };
-        super(config, json);
+        super(config, {
+            json,
+            showValidationSection: options.showValidationSection,
+        });
     }
-    init(parent: any) {
+    init(content: DebugDialogContent) {
         const div = createEl("div", {}, this.dialog);
-        const showValidationSection = Boolean(
-            parent &&
-            typeof parent === "object" &&
-            "validationFindings" in parent,
-        );
         this.root = createMdvPortal(
-            <DebugChart chart={parent} showValidationSection={showValidationSection} />,
+            <DebugChart chart={content.json} showValidationSection={content.showValidationSection} />,
             div,
             this,
         );


### PR DESCRIPTION
## Summary
Rather than living in the `validationFindings` tree in the generic JSON, the "Validation Issues" section of debug dialog has a nicer representation of issues.

Considered also having a chart-level version of this but would take a bit more work to do cleanly, this is an incremental improvement that should help to be able to digest the output.

## Testing
- `pnpm exec vitest run src/react/components/DebugJsonDialogComponent.test.tsx`
- `pnpm exec tsgo`