### PR TITLE
fix new project upload permission check when datafile is missing

### DIFF
--- a/python/mdvtools/mdvproject.py
+++ b/python/mdvtools/mdvproject.py
@@ -143,12 +143,14 @@ class MDVProject:
         This is independent of any permissions set in db etc,
         but can be used to guard against inappropriate admin actions
         """
+        # check if project has a h5 file or write permissions, newly created project doesn't have a h5 file which blocks file upload
+        h5_writable_or_not_created = (not exists(self.h5file)) or os.access(self.h5file, os.W_OK)
         return (
             # belt and braces
             os.access(self.statefile, os.W_OK)
             and os.access(self.dir, os.W_OK | os.X_OK)
             and os.access(self.viewsfile, os.W_OK)
-            and os.access(self.h5file, os.W_OK)
+            and h5_writable_or_not_created
         )
 
     @property


### PR DESCRIPTION
This should fix the issue: #499 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed project writeability detection to correctly identify projects as writable even when the data file has not yet been created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->