### PR TITLE
Feature/chatmdv local llm

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,7 +18,8 @@
         "GIT_COMMIT_HASH": "${containerEnv:GIT_COMMIT_HASH}",
         "GIT_LAST_COMMIT_MESSAGE": "${containerEnv:GIT_LAST_COMMIT_MESSAGE}",
         "BUILD_DATE": "${containerEnv:BUILD_DATE}",
-        "GIT_DIRTY": "${containerEnv:GIT_DIRTY}"
+        "GIT_DIRTY": "${containerEnv:GIT_DIRTY}",
+        "OLLAMA_BASE_URL": "http://host.docker.internal:11434"
     },
     "customizations": {
         "vscode": {

--- a/python/mdvtools/llm/CHATMDV_BOUNDARY.md
+++ b/python/mdvtools/llm/CHATMDV_BOUNDARY.md
@@ -11,7 +11,7 @@ Chat-generated behavior (prompting, code policy, execution wrappers, verificatio
 | Datasource hints for LLM | [`datasource_roles.py`](datasource_roles.py) |
 | Subprocess execution wrapper | [`code_execution.py`](code_execution.py) |
 | Chat verification summaries | [`verification.py`](verification.py) |
-| Supporting LLM helpers | Other modules in this directory (e.g. `code_manipulation.py`, `column_field_resolve.py`) |
+| Supporting LLM helpers | Other modules in this directory (e.g. `code_manipulation.py`, `column_field_resolve.py`, `dataset_scale.py`) |
 
 ## Tests (regression / policy)
 
@@ -37,6 +37,8 @@ If the UI errors on a bad chart `param` (e.g. wrong field id), **fix prompts / f
 **Visualization vs analysis consistency:** Use `format_visualization_consistency_policy()` in [`datasource_roles.py`](datasource_roles.py). Saved MDV charts must reflect the same pipeline as printed tables—do not mix Scanpy/AnnData outputs with unrelated wrapper-based expression heatmaps for the same quantitative claim.
 
 **`rank_genes_groups` vs DotPlot/Heatmap on `cells`:** Use `format_marker_ranking_viz_policy()` and `CHAT_RANK_GENES_DATASOURCE_NAME` in [`datasource_roles.py`](datasource_roles.py). Do not use wrapper-based DotPlot or Heatmap on the **observation** datasource as a substitute for the full Scanpy marker **statistics table**. Prefer **bounded `print`**, or persist the long-format `DataFrame` with `add_datasource('chat_rank_genes_result', ..., replace_data=True, add_to_view=...)`; avoid `set_view` that overwrites `initialCharts` and drops the scratch table.
+
+**MDV-first / Scanpy last resort (large projects):** Use [`dataset_scale.py`](dataset_scale.py) (`assess_project_scale`, `load_agent_dataframes`) and `format_mdv_first_data_access_policy()` in [`datasource_roles.py`](datasource_roles.py). Prompts and the pandas agent should compare project row count and available RAM, prefer MDV chart APIs and column-subset `get_datasource_as_dataframe`, and treat Scanpy (with `backed='r'` on large `.h5ad`) as last resort for marker/DE workflows only—not for chart-only views. Enforcement is prompt/agent guidance only (no preflight blocks).
 
 ## Pre-merge drift check
 

--- a/python/mdvtools/llm/CHATMDV_PRD.md
+++ b/python/mdvtools/llm/CHATMDV_PRD.md
@@ -361,7 +361,13 @@ mkdir -p "$CHATMDV_CSV_EVAL_OUTPUT_DIR"
 | Ollama — **current** (functions + compact + question fallback + guards) | **90%** | **80%** | Run `20260613T102009Z`; 1 preflight failure (row 9, PCA) |
 | OpenAI `gpt-4.1` | 90% | 90% | Run `20260613T084756Z`; 1 runtime failure (row 10, GNLY) |
 
-**TAURUS baseline** (`prompts_TAURUS.csv`, Ollama `qwen3-coder:latest`, run `20260615T170752Z`): 40% exec / 40% charts. Failures included unnecessary `read_h5ad` / full `get_datasource_as_dataframe` on ~988k cells. MDV-first prompt rules target those OOM-class failures.
+**TAURUS baseline** (`prompts_TAURUS.csv`, Ollama `qwen3-coder:latest`):
+
+| Run | `exec_success_rate` | `view_has_charts_rate` | Notes |
+|-----|---------------------|------------------------|-------|
+| `20260615T170752Z` (pre MDV-first) | 40% | 40% | OOM / full h5ad loads |
+| `20260616T050314Z` (MDV-first policies) | 70% | 70% | Rows 5/8/9 still failing |
+| `20260616T054014Z` (MDV-first + chart recipes + import autofix) | **90%** | **90%** | Rows 5/8/9 fixed; row 6 metadata `datatype` regression |
 
 **Design notes from benchmarking:**
 

--- a/python/mdvtools/llm/CHATMDV_PRD.md
+++ b/python/mdvtools/llm/CHATMDV_PRD.md
@@ -35,12 +35,48 @@ When a chat-generated chart fails because of bad chart `param` values, first fix
 
 **Primary file:** `python/mdvtools/llm/langchain_mdv.py`
 
+**Provider selection:** `python/mdvtools/llm/llm_providers.py` — discovers OpenAI and Ollama models, pairs chat models with embedding backends for RAG, and constructs LangChain LLM/embedding instances.
+
 Responsibilities:
 
 - Coordinate prompt construction and LLM execution
+- Run the multi-step pipeline: **pandas agent → RAG codegen → preflight → execute**
+- Validate agent and RAG output before execution (no silent stub success)
 - Route generated code into execution wrapper
 - Attach execution diagnostics back to chat flow
 - Keep orchestration logic separate from policy text and verification copy
+
+#### Chat request pipeline (orchestration blocks)
+
+| Block | Role |
+|-------|------|
+| `b8` / `b10b` | Pandas agent inspects `df1`/`df2`; emits `fields` / `charts` plan |
+| `b11` / `b12` | RAG retrieval + codegen LLM |
+| `b13` / `b13b` | `prepare_code`, preflight validate (single retry) |
+| `b14` | Execute generated script |
+
+Each request logs `model_id`, `provider`, chat model name, and embedding model to `chat_debug.log` and the per-project chat log.
+
+**Agent plan guards** (all providers):
+
+- Resolve `fields` / `charts` from agent output or ReAct intermediate steps (`_resolve_agent_plan`).
+- If still missing and the user question is non-empty: **warn and continue** with a question-derived fallback plan (`_fallback_agent_plan`) so RAG retrieval can proceed.
+- If the question is empty: fail with a clear error.
+
+**Codegen guards** (all providers):
+
+- Empty RAG `result`: one retry with an explicit fenced-Python instruction, then fail.
+- No extracted Python / warning stub from `prepare_code`: fail before `execute_code`.
+
+**Ollama-specific:**
+
+- Functions agent first; ReAct fallback on tool errors or missing field/chart plan.
+- Compact RAG prompt (`get_createproject_prompt_RAG(..., compact=True)`) — shorter than full prompt but retains project context, datasource roles, do-not-recreate-datasource policy, and output-format rules.
+
+**OpenAI-specific:**
+
+- Functions agent only (no ReAct fallback).
+- Full RAG prompt (`compact=False`).
 
 ### 2. Prompt and RAG Policy
 
@@ -130,13 +166,16 @@ Responsibilities:
 
 ## End-to-End Request Flow
 
-1. User asks a question in chat.
-2. Orchestration builds context and applies template/policy guidance.
-3. LLM generates analysis code and output directives (print/chart intent).
-4. Execution wrapper runs code and captures diagnostics.
-5. Chat response includes text/tables and optional persisted chart instructions.
-6. Verification layer summarizes what to check for correctness and consistency.
-7. Optional field/token resolution logic validates persisted chart parameters.
+1. User asks a question in chat (optionally selects model from discovered OpenAI/Ollama list).
+2. Orchestration resolves chat + embedding models; logs provider/model ids.
+3. Pandas agent inspects datasources and produces a field/chart plan (with Ollama ReAct fallback and question-derived fallback when needed).
+4. RAG prompt is built (compact for Ollama, full for OpenAI); retrieval augments with `ANNDATA_examples` corpus.
+5. Codegen LLM returns fenced Python; guards reject empty output or stubs.
+6. `prepare_code` wraps script; preflight validates chart API usage (single retry on failure).
+7. Execution wrapper runs code and captures diagnostics.
+8. Chat response includes text/tables and optional persisted chart instructions.
+9. Verification layer summarizes what to check for correctness and consistency.
+10. Optional field/token resolution logic validates persisted chart parameters.
 
 ### Runnable Module Flow (`python -m`)
 
@@ -181,9 +220,13 @@ Avoid `set_view` patterns that overwrite `initialCharts` and drop scratch analys
 Policy and regression tests should be concentrated in:
 
 - `python/mdvtools/tests/test_chat_first_text_table_policy.py`
+- `python/mdvtools/tests/test_chat_ollama_pipeline.py` — agent plan resolution, ReAct fallback, RAG empty guard, stub rejection, compact prompt
+- `python/mdvtools/tests/test_llm_providers.py` — provider discovery, Ollama URL defaults, embedding pairing
+- `python/mdvtools/tests/test_langchain_mdv_helpers.py` — text/table intent helpers, init failure when no providers
 - `python/mdvtools/tests/test_datasource_roles.py`
 - `python/mdvtools/tests/test_column_field_resolve.py`
 - `python/mdvtools/tests/test_code_execution.py`
+- `python/mdvtools/test_projects/chatmdv_csv_eval/run_prompt_csv.py` — pbmc3k CSV benchmark harness (10 prompts, subprocess row isolation)
 - `python/mdvtools/test_projects/llm_automated_testing.py` — end-to-end LLM harness using the same default RAG corpus as orchestration (`RAG_examples/ANNDATA_examples/`).
 
 Add new ChatMDV policy tests in these suites rather than unrelated runtime test areas.
@@ -219,6 +262,111 @@ A non-zero exit indicates files changed outside approved ChatMDV boundaries.
 - Relevant policy/regression tests are added or updated.
 - Generated behavior follows datasource-field constraints and marker workflow policy.
 - Verification text accurately reflects what was executed and persisted.
+
+## Local Ollama and multi-provider LLM
+
+ChatMDV supports **OpenAI** (when `OPENAI_API_KEY` is set) and **Ollama** (OpenAI-compatible `/v1` API). The Chat UI exposes a model dropdown; CLI and CSV eval accept `--model <id>` or `CHATMDV_DEFAULT_MODEL`.
+
+### Recommended models
+
+| Role | OpenAI | Ollama |
+|------|--------|--------|
+| Chat / codegen | `gpt-4.1`, `gpt-4o` | `qwen2.5-coder:7b`, `qwen2.5-coder:14b`, `qwen3-coder:latest` |
+| Embeddings (RAG) | `text-embedding-3-large` | `nomic-embed-text` (`ollama pull nomic-embed-text`) |
+
+Avoid general chat models (e.g. `gemma4:26b`) for the codegen pipeline; they often return empty agent/RAG output or hit ReAct iteration limits.
+
+### Environment
+
+| Variable | Purpose |
+|----------|---------|
+| `OPENAI_API_KEY` | Enables OpenAI chat + embeddings |
+| `OLLAMA_BASE_URL` | Ollama host (Docker devcontainer default: `http://host.docker.internal:11434`) |
+| `CHATMDV_DEFAULT_MODEL` | Optional default chat model id (e.g. `ollama:chat:qwen3-coder:latest`) |
+| `CHATMDV_CSV_EVAL_OUTPUT_DIR` | Default directory for CSV benchmark artifacts |
+
+Verify Ollama from the container:
+
+```bash
+curl -s http://host.docker.internal:11434/api/tags
+```
+
+### Ollama pipeline behavior
+
+When the selected model provider is Ollama:
+
+1. **Functions agent first** — inspects `df1`/`df2` via tool calling (~3–5s typical).
+2. **ReAct fallback** — only on functions-agent exception or missing `fields`/`charts` plan.
+3. **Agent plan resolution** — extract plan from ReAct intermediate steps when final output hits iteration limits.
+4. **Question fallback** — if both agents fail but the user question is non-empty, log a warning and continue with `_fallback_agent_plan(question)` (chart hints inferred from question keywords).
+5. **Compact RAG prompt** — shorter prompt for local models; includes do-not-`add_datasource` policy for existing project datasources.
+6. **Fail fast** — empty RAG result (after one retry) or missing extracted Python blocks execution (no silent `# WARNING:::: No code captured` success).
+
+OpenAI uses the same agent/codegen guards but **no ReAct fallback** and the **full** RAG prompt.
+
+### Alignment expectations
+
+| In scope (current pipeline) | Out of scope (later work) |
+|-----------------------------|---------------------------|
+| Reliable codegen or clear errors | Curated RAG corpus expansion |
+| Field/chart plan from agent REPL + fallbacks | MDV-native tools / MCP |
+| Compact prompts + guards for local models | Fine-tuning on project Q→code traces |
+| Fail-fast on empty LLM output / stubs | vLLM or non-Ollama local serving |
+
+### CSV eval benchmarks
+
+Track pipeline quality with the pbmc3k prompt CSV harness. Project: `/app/mdv/pbmc3k_chat` (create via `setup_pbmc3k_chat.py`).
+
+```bash
+cd python
+export CHATMDV_CSV_EVAL_OUTPUT_DIR=/app/logs/chatmdv
+mkdir -p "$CHATMDV_CSV_EVAL_OUTPUT_DIR"
+
+# Smoke (one row)
+.venv/bin/python mdvtools/test_projects/chatmdv_csv_eval/run_prompt_csv.py \
+  --csv mdvtools/test_projects/chatmdv_csv_eval/prompts_pbmc3k.csv \
+  --model qwen3-coder:latest \
+  --output-dir "$CHATMDV_CSV_EVAL_OUTPUT_DIR" \
+  --limit 1
+
+# Full run (Ollama)
+.venv/bin/python mdvtools/test_projects/chatmdv_csv_eval/run_prompt_csv.py \
+  --csv mdvtools/test_projects/chatmdv_csv_eval/prompts_pbmc3k.csv \
+  --model qwen3-coder:latest \
+  --output-dir "$CHATMDV_CSV_EVAL_OUTPUT_DIR"
+
+# Full run (OpenAI baseline)
+.venv/bin/python mdvtools/test_projects/chatmdv_csv_eval/run_prompt_csv.py \
+  --csv mdvtools/test_projects/chatmdv_csv_eval/prompts_pbmc3k.csv \
+  --model openai:chat:gpt-4.1 \
+  --output-dir "$CHATMDV_CSV_EVAL_OUTPUT_DIR"
+```
+
+**Artifacts** (timestamped under `CHATMDV_CSV_EVAL_OUTPUT_DIR`):
+
+| File | Use |
+|------|-----|
+| `benchmark_summary_*.json` | `exec_success_rate`, `view_has_charts_rate`, `by_complexity` |
+| `timing_*.jsonl` | Per-row block timings (`block_b10b_s`, `block_b12_s`, `block_b14_s`) |
+| `results_*.csv` | Row-level compact metrics |
+| `failures_*.jsonl` | Failed rows with `failure_reason` |
+
+**Reference results** (pbmc3k, 10 prompts, 2026-06-13):
+
+| Config | `exec_success_rate` | `view_has_charts_rate` | Notes |
+|--------|---------------------|------------------------|-------|
+| Ollama `qwen3-coder:latest` — pre-guard baseline | 80% | 80% | Functions agent, full prompt, no stub guards |
+| Ollama — ReAct default (regression) | 30% | 30% | ReAct-first caused iteration-limit failures |
+| Ollama — functions + compact + strict agent guard | 50% | 50% | Fail-fast on missing plan hurt success rate |
+| Ollama — **current** (functions + compact + question fallback + guards) | **90%** | **80%** | Run `20260613T102009Z`; 1 preflight failure (row 9, PCA) |
+| OpenAI `gpt-4.1` | 90% | 90% | Run `20260613T084756Z`; 1 runtime failure (row 10, GNLY) |
+
+**Design notes from benchmarking:**
+
+- ReAct as the **default** Ollama agent regressed success (80% → 30%); functions-first with ReAct **fallback** is required.
+- Strict fail-fast on missing agent plan regressed Ollama (80% → 50%); question-derived fallback restores parity while keeping stub/RAG guards.
+- Compact prompt alone did not beat full prompt; compact **with** do-not-recreate-datasource policy is the chosen Ollama default.
+- Remaining Ollama failures are mostly **codegen/preflight** quality (invalid chart kwargs), not pipeline guard false positives.
 
 ## Runnable Module Specification
 

--- a/python/mdvtools/llm/CHATMDV_PRD.md
+++ b/python/mdvtools/llm/CHATMDV_PRD.md
@@ -361,6 +361,8 @@ mkdir -p "$CHATMDV_CSV_EVAL_OUTPUT_DIR"
 | Ollama — **current** (functions + compact + question fallback + guards) | **90%** | **80%** | Run `20260613T102009Z`; 1 preflight failure (row 9, PCA) |
 | OpenAI `gpt-4.1` | 90% | 90% | Run `20260613T084756Z`; 1 runtime failure (row 10, GNLY) |
 
+**TAURUS baseline** (`prompts_TAURUS.csv`, Ollama `qwen3-coder:latest`, run `20260615T170752Z`): 40% exec / 40% charts. Failures included unnecessary `read_h5ad` / full `get_datasource_as_dataframe` on ~988k cells. MDV-first prompt rules target those OOM-class failures.
+
 **Design notes from benchmarking:**
 
 - ReAct as the **default** Ollama agent regressed success (80% → 30%); functions-first with ReAct **fallback** is required.

--- a/python/mdvtools/llm/chat_cli.py
+++ b/python/mdvtools/llm/chat_cli.py
@@ -13,6 +13,7 @@ from typing import Any, Optional
 from urllib.parse import urlparse
 
 from mdvtools.llm.chat_protocol import AskQuestionResult, ChatRequest, ProjectChat
+from mdvtools.llm.llm_providers import resolve_chat_model_id
 from mdvtools.mdvproject import MDVProject
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -52,6 +53,15 @@ def _build_parser() -> argparse.ArgumentParser:
         "--verbose",
         action="store_true",
         help="Print extra diagnostic context in human-readable mode.",
+    )
+    parser.add_argument(
+        "--model",
+        default=None,
+        help=(
+            "Chat model to use (canonical id or bare name, e.g. "
+            "openai:chat:gpt-4.1 or gpt-4o-mini). Defaults to CHATMDV_DEFAULT_MODEL "
+            "or the first discovered model."
+        ),
     )
     return parser
 
@@ -178,11 +188,13 @@ def run_chat_once(
     prompt: str,
     output_dir: Optional[str] = None,
     view_name: Optional[str] = None,
+    model_id: Optional[str] = None,
 ) -> tuple[dict[str, Any], int]:
     abs_project = str(Path(project_path).expanduser().resolve())
     views_file = str(Path(abs_project) / "views.json")
     debug_output_dir: Optional[str] = None
     timing_capture_start = time.perf_counter()
+    resolved_model_id = resolve_chat_model_id(model_id)
 
     try:
         captured_output = ""
@@ -215,6 +227,8 @@ def run_chat_once(
             "room": "chat-cli",
             "handle_error": _handle_error,
         }
+        if resolved_model_id:
+            chat_request["model_id"] = resolved_model_id
         from io import StringIO
         from contextlib import redirect_stdout, redirect_stderr
         out_stream = StringIO()
@@ -251,6 +265,7 @@ def run_chat_once(
         _ver = ask_result.get("verification")
         normalized["verification"] = _ver if isinstance(_ver, str) else ""
         normalized["needs_refresh"] = bool(ask_result.get("needs_refresh", False))
+        normalized["model_id"] = resolved_model_id
 
         if output_dir:
             debug_output_dir = _write_debug_artifacts(
@@ -278,6 +293,7 @@ def run_chat_once(
             "chart_count": 0,
             "verification": "",
             "needs_refresh": False,
+            "model_id": resolved_model_id,
         }
         if output_dir:
             try:
@@ -356,6 +372,7 @@ def run_batch_prompts(
     csv_log: str,
     base_url: str,
     output_dir: Optional[str] = None,
+    model_id: Optional[str] = None,
 ) -> tuple[list[dict[str, Any]], int]:
     prompts = _load_prompts(prompt_file)
     rows: list[dict[str, Any]] = []
@@ -374,6 +391,7 @@ def run_batch_prompts(
             prompt=prompt,
             output_dir=str(run_out) if run_out else None,
             view_name=None,
+            model_id=model_id,
         )
         finished = datetime.now(timezone.utc)
         if exit_code != 0:
@@ -411,9 +429,17 @@ def _print_human_result(result: dict[str, Any], *, verbose: bool = False) -> Non
     status = "SUCCESS" if result["success"] else "FAILED"
     print(status)
     print(f"Message: {result['message']}")
+    print(f"Duration: {float(result.get('duration_seconds', 0.0)):.3f}s")
     print(f"Project: {result['project_path']}")
     print(f"Views file: {result['views_file']}")
     print(f"View: {result['view_name']}")
+    if result.get("model_id"):
+        print(f"Model: {result['model_id']}")
+    block_timings = result.get("block_timings") or {}
+    if verbose and isinstance(block_timings, dict) and block_timings:
+        print("Block timings:")
+        for key in sorted(block_timings):
+            print(f"  {key}: {float(block_timings[key]):.3f}s")
     if result.get("debug_output_dir"):
         print(f"Debug output dir: {result['debug_output_dir']}")
     elif verbose:
@@ -425,6 +451,11 @@ def main(argv: Optional[list[str]] = None) -> int:
     try:
         args = parser.parse_args(argv)
         _validate_mode_args(args)
+        try:
+            resolve_chat_model_id(args.model)
+        except ValueError as exc:
+            print(f"Argument error: {exc}", file=sys.stderr)
+            return 2
         if args.prompt_file:
             rows, exit_code = run_batch_prompts(
                 project_path=args.project,
@@ -432,6 +463,7 @@ def main(argv: Optional[list[str]] = None) -> int:
                 csv_log=args.csv_log,
                 base_url=args.base_url,
                 output_dir=args.output_dir,
+                model_id=args.model,
             )
             summary = {
                 "batch_count": len(rows),
@@ -451,6 +483,7 @@ def main(argv: Optional[list[str]] = None) -> int:
             prompt=args.prompt,
             output_dir=args.output_dir,
             view_name=args.view_name,
+            model_id=args.model,
         )
 
         if args.json_output:

--- a/python/mdvtools/llm/chat_protocol.py
+++ b/python/mdvtools/llm/chat_protocol.py
@@ -9,6 +9,7 @@ class AskQuestionResult(TypedDict):
     message: str
     verification: Optional[str]
     data_preview: Optional[str]
+    guidance: Optional[str]
     needs_refresh: bool
 
 
@@ -70,6 +71,7 @@ except Exception as e:
                 message=f"Sorry, I can't help you right now\n\n{msg}",
                 verification=None,
                 data_preview=None,
+                guidance=None,
                 needs_refresh=False,
             )
 

--- a/python/mdvtools/llm/chat_protocol.py
+++ b/python/mdvtools/llm/chat_protocol.py
@@ -1,4 +1,4 @@
-from typing import Optional, Protocol, Any, TypedDict, Union
+from typing import NotRequired, Optional, Protocol, Any, TypedDict, Union
 from mdvtools.mdvproject import MDVProject
 
 
@@ -23,6 +23,7 @@ class ChatRequest(TypedDict):
     conversation_id: str
     room: str
     handle_error: HandleError
+    model_id: NotRequired[str]
 
 class ProjectChatProtocol(Protocol):
     def __init__(self, project: MDVProject): ...

--- a/python/mdvtools/llm/chat_server_extension.py
+++ b/python/mdvtools/llm/chat_server_extension.py
@@ -164,6 +164,7 @@ class MDVProjectChatServerExtension(MDVProjectServerExtension):
                         "id": id,
                         "verification": result.get("verification"),
                         "data_preview": result.get("data_preview"),
+                        "guidance": result.get("guidance"),
                         "needs_refresh": result.get("needs_refresh", False),
                     }
                     if result["view_name"] is not None:

--- a/python/mdvtools/llm/chat_server_extension.py
+++ b/python/mdvtools/llm/chat_server_extension.py
@@ -15,6 +15,7 @@ from flask import Flask, request
 from flask_socketio import join_room, leave_room
 from mdvtools.logging_config import get_logger
 from mdvtools.llm.chatlog import log_chat_item
+from mdvtools.llm.llm_providers import discover_models
 from mdvtools.server_extension import MDVProjectServerExtension
 from mdvtools.auth.authutils import is_authenticated
 
@@ -70,7 +71,13 @@ class MDVProjectChatServerExtension(MDVProjectServerExtension):
             # we want some suggested questions here.
             suggested_questions = bot.get_suggested_questions()
             logger.info(f"Suggested questions: {suggested_questions}")
-            return {"message": detailed_message, "suggested_questions": suggested_questions}
+            discovered = discover_models()
+            return {
+                "message": detailed_message,
+                "suggested_questions": suggested_questions,
+                "models": [m.to_dict() for m in discovered.all_models()],
+                "default_model_id": discovered.default_model_id,
+            }
 
         @socketio.on("chat_request", namespace=f"/project/{project.id}")
         def chat(data):
@@ -85,6 +92,7 @@ class MDVProjectChatServerExtension(MDVProjectServerExtension):
             message = data.get("message")
             id = data.get("id")
             conversation_id = data.get("conversation_id")
+            model_id = data.get("model_id")
             room = f"{sid}_{id}"
             join_room(room)
             def handle_error(error: Union[str, Exception], *, extra_metadata: Optional[dict] = None):
@@ -119,13 +127,15 @@ class MDVProjectChatServerExtension(MDVProjectServerExtension):
                 handle_error("Missing 'message' or 'id' in request JSON")
                 leave_room(room)
                 return
-            chat_request = ChatRequest(
-                message=message,
-                id=id,
-                conversation_id=conversation_id,
-                room=room,
-                handle_error=handle_error
-            )
+            chat_request: ChatRequest = {
+                "message": message,
+                "id": id,
+                "conversation_id": conversation_id,
+                "room": room,
+                "handle_error": handle_error,
+            }
+            if model_id:
+                chat_request["model_id"] = model_id
             try:
                 if bot is None:
                     # todo - allow this to be freed at some point if we're not using it anymore.

--- a/python/mdvtools/llm/chat_server_extension.py
+++ b/python/mdvtools/llm/chat_server_extension.py
@@ -75,7 +75,7 @@ class MDVProjectChatServerExtension(MDVProjectServerExtension):
             return {
                 "message": detailed_message,
                 "suggested_questions": suggested_questions,
-                "models": [m.to_dict() for m in discovered.all_models()],
+                "models": [m.to_dict() for m in discovered.chat_models],
                 "default_model_id": discovered.default_model_id,
             }
 

--- a/python/mdvtools/llm/chatlog.py
+++ b/python/mdvtools/llm/chatlog.py
@@ -164,6 +164,21 @@ class ChatSocketAPI:
 
     def log(self, msg: str):
         self.logger.info(msg)
+
+    def log_file_only(self, msg: str) -> None:
+        """Write to file handlers only; omit from the socket chat stream."""
+        record = logging.LogRecord(
+            name=self.logger.name,
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg=msg,
+            args=(),
+            exc_info=None,
+        )
+        for handler in self.logger.handlers:
+            if isinstance(handler, logging.FileHandler):
+                handler.handle(record)
     
     def update_chat_progress(
         self,

--- a/python/mdvtools/llm/chatlog.py
+++ b/python/mdvtools/llm/chatlog.py
@@ -42,6 +42,7 @@ class ChatLogItem:
     error: Optional[bool] = None
     verification: Optional[str] = None
     data_preview: Optional[str] = None
+    guidance: Optional[str] = None
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary for JSON serialization"""
@@ -56,6 +57,7 @@ class ChatLogItem:
             "error": self.error,
             "verification": self.verification,
             "data_preview": self.data_preview,
+            "guidance": self.guidance,
         }
 
     @classmethod
@@ -72,6 +74,7 @@ class ChatLogItem:
             error=data.get("error"),
             verification=data.get("verification"),
             data_preview=data.get("data_preview"),
+            guidance=data.get("guidance"),
         )
 
 class ChatLogger:
@@ -308,6 +311,7 @@ def log_chat_item(
     error: bool = False,
     verification: str | None = None,
     data_preview: str | None = None,
+    guidance: str | None = None,
 ):
     """
     Log a chat interaction to the chat log file.
@@ -319,8 +323,9 @@ def log_chat_item(
         conversation_id: ID to group messages from the same conversation
         context: Context of the response code generated which contains file names
         error: Whether this log is for an error
-        verification: Optional provenance text (same as the view TextBox), omitted on error
+        verification: Optional provenance text, omitted on error
         data_preview: Optional truncated script stdout for chat, omitted on error
+        guidance: Optional analysis summary (same as view TextBox), omitted on error
     """
     # Create a ChatLogger instance for this project
     chat_file = os.path.join(project.dir, "chat_log.json")
@@ -331,6 +336,7 @@ def log_chat_item(
         prompt_template = prompt_template or ""
         verification = None
         data_preview = None
+        guidance = None
 
     # Ensure context is always a non-optional string for ChatLogItem
     context_str: str = context if context is not None else "[]"
@@ -346,5 +352,6 @@ def log_chat_item(
         error=error,
         verification=verification,
         data_preview=data_preview,
+        guidance=guidance,
     )
     chat_logger.log_chat(chat_item)

--- a/python/mdvtools/llm/code_manipulation.py
+++ b/python/mdvtools/llm/code_manipulation.py
@@ -6,6 +6,7 @@ import pandas as pd
 import regex as re
 from mdvtools.llm.templates import packages_functions
 from mdvtools.llm.datasource_roles import build_chatmdv_roles_constants_block
+from mdvtools.llm.code_preflight import CHART_CLASS_MODULES
 import json
 import ast
 import subprocess
@@ -50,6 +51,18 @@ def extract_code_from_response(response: str):
     # return matches[-1].strip()
 
 
+def _chart_import_autofix_map() -> dict[str, str]:
+    """Map common hallucinated chart module paths to canonical preflight modules."""
+    fixes: dict[str, str] = {
+        "mdvtools.charts.stacked_row_chart": "mdvtools.charts.stacked_row_plot",
+    }
+    for class_name, module_path in CHART_CLASS_MODULES.items():
+        wrong = f"mdvtools.charts.{class_name}"
+        if wrong != module_path:
+            fixes.setdefault(wrong, module_path)
+    return fixes
+
+
 def _autofix_generated_code(code: str, log=print) -> str:
     """Best-effort fixes for common ChatMDV codegen mistakes before execution."""
     if "project.get_datasource_roles()" in code:
@@ -62,6 +75,10 @@ def _autofix_generated_code(code: str, log=print) -> str:
         if bad_attr in code:
             log(f"# Autofix: expr{bad_attr} -> expr.datasource_name")
             code = code.replace(bad_attr, ".datasource_name")
+    for wrong_module, correct_module in _chart_import_autofix_map().items():
+        if wrong_module in code:
+            log(f"# Autofix: chart import {wrong_module} -> {correct_module}")
+            code = code.replace(wrong_module, correct_module)
     return code
 
 

--- a/python/mdvtools/llm/code_preflight.py
+++ b/python/mdvtools/llm/code_preflight.py
@@ -638,12 +638,26 @@ def validate_generated_code_preflight(
             if not missing:
                 continue
             available_preview = sorted(list(available))[:30]
+            hint_parts: list[str] = []
+            for col in missing:
+                owners = sorted(
+                    ds
+                    for ds, flds in datasource_fields.items()
+                    if ds != datasource_name and col in flds
+                )
+                if owners:
+                    hint_parts.append(
+                        f"Column `{col}` exists on datasource(s): {owners}"
+                    )
+            hint_suffix = ""
+            if hint_parts:
+                hint_suffix = " " + " ".join(hint_parts) + "."
             issues.append(
                 PreflightIssue(
                     code="unknown_datasource_column",
                     message=(
                         f"Datasource `{datasource_name}` does not contain column(s) {missing}. "
-                        f"Available fields include: {available_preview}"
+                        f"Available fields include: {available_preview}.{hint_suffix}"
                     ),
                     line=getattr(call, "lineno", None),
                     column=getattr(call, "col_offset", None),

--- a/python/mdvtools/llm/code_preflight.py
+++ b/python/mdvtools/llm/code_preflight.py
@@ -62,6 +62,7 @@ _CHART_LIKE_SUFFIXES = ("Chart", "Plot", "Box")
 _CHART_NAME_HINTS: dict[str, str] = {
     "Histogram": "HistogramPlot",
     "MultilineChart": "MultiLinePlot",
+    "MultiLineChart": "MultiLinePlot",
 }
 
 

--- a/python/mdvtools/llm/column_field_resolve.py
+++ b/python/mdvtools/llm/column_field_resolve.py
@@ -371,3 +371,30 @@ def normalize_view_chart_params(
                 _normalize_chart_dict(ch, field_set, name_map)
                 _normalize_marker_alias_tokens(ch, ds_name, field_set)
     return out
+
+
+def ensure_view_gridstack_layout(view: dict[str, Any]) -> dict[str, Any]:
+    """
+    Ensure each datasource panel in a saved view uses gridstack layout.
+
+    ChatMDV-generated views often only set ``initialCharts``; the frontend defaults
+    missing layout to absolute positioning.
+    """
+    out = copy.deepcopy(view)
+    initial = out.get("initialCharts")
+    if not isinstance(initial, dict):
+        return out
+
+    data_sources = out.get("dataSources")
+    if not isinstance(data_sources, dict):
+        data_sources = {}
+        out["dataSources"] = data_sources
+
+    for ds_name in initial:
+        panel = data_sources.get(ds_name)
+        if not isinstance(panel, dict):
+            panel = {}
+            data_sources[ds_name] = panel
+        panel["layout"] = "gridstack"
+
+    return out

--- a/python/mdvtools/llm/dataset_scale.py
+++ b/python/mdvtools/llm/dataset_scale.py
@@ -156,11 +156,12 @@ def load_agent_dataframes(
     obs_ds = roles.obs_datasource
     if scale.is_large:
         obs_cols = agent_probe_columns_from_metadata(project, obs_ds)
-        df1 = (
-            project.get_datasource_as_dataframe(obs_ds, columns=obs_cols)
-            if obs_cols
-            else project.get_datasource_as_dataframe(obs_ds)
-        )
+        if not obs_cols:
+            raise ValueError(
+                f"Large project: no probe columns for obs datasource {obs_ds!r}; "
+                "refusing full table load"
+            )
+        df1 = project.get_datasource_as_dataframe(obs_ds, columns=obs_cols)
     else:
         df1 = project.get_datasource_as_dataframe(obs_ds)
 
@@ -178,7 +179,17 @@ def load_agent_dataframes(
             and "cells" not in names
         ):
             try:
-                df_extra = project.get_datasource_as_dataframe(extra_datasource)
+                if scale.is_large:
+                    extra_cols = agent_probe_columns_from_metadata(
+                        project, extra_datasource
+                    )
+                    if not extra_cols:
+                        return [df1]
+                    df_extra = project.get_datasource_as_dataframe(
+                        extra_datasource, columns=extra_cols
+                    )
+                else:
+                    df_extra = project.get_datasource_as_dataframe(extra_datasource)
                 return [df1, df_extra]
             except Exception:
                 pass
@@ -189,11 +200,9 @@ def load_agent_dataframes(
         expr_cols = agent_expression_probe_columns(
             project, expr_ds, primary_expr.name_column
         )
-        df2 = (
-            project.get_datasource_as_dataframe(expr_ds, columns=expr_cols)
-            if expr_cols
-            else project.get_datasource_as_dataframe(expr_ds)
-        )
+        if not expr_cols:
+            return [df1]
+        df2 = project.get_datasource_as_dataframe(expr_ds, columns=expr_cols)
     else:
         df2 = project.get_datasource_as_dataframe(expr_ds)
     return [df1, df2]

--- a/python/mdvtools/llm/dataset_scale.py
+++ b/python/mdvtools/llm/dataset_scale.py
@@ -143,11 +143,15 @@ def load_agent_dataframes(
     project: Any,
     roles: Any,
     scale: ProjectScale,
+    *,
+    extra_datasource: str | None = None,
 ) -> list[Any]:
     """
     Return [obs_df] or [obs_df, expr_df] for the pandas agent.
 
     Large projects load column subsets only; small projects load full tables.
+    When there is no expression datasource and the project has multiple tabular tables,
+    ``extra_datasource`` (typically question-resolved) is loaded as df2 for agent probing.
     """
     obs_ds = roles.obs_datasource
     if scale.is_large:
@@ -162,6 +166,22 @@ def load_agent_dataframes(
 
     primary_expr = roles.preferred_expression()
     if primary_expr is None:
+        names: list[str] = []
+        try:
+            names = list(project.get_datasource_names())
+        except Exception:
+            pass
+        if (
+            extra_datasource
+            and extra_datasource != obs_ds
+            and len(names) > 2
+            and "cells" not in names
+        ):
+            try:
+                df_extra = project.get_datasource_as_dataframe(extra_datasource)
+                return [df1, df_extra]
+            except Exception:
+                pass
         return [df1]
 
     expr_ds = primary_expr.datasource_name

--- a/python/mdvtools/llm/dataset_scale.py
+++ b/python/mdvtools/llm/dataset_scale.py
@@ -1,0 +1,204 @@
+"""
+Project scale and memory budget helpers for ChatMDV prompt routing.
+
+Used to inject MDV-first / Scanpy-last-resort guidance into agent and RAG prompts.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+from mdvtools.llm.datasource_roles import infer_datasource_roles
+
+_BYTES_PER_CELL_ESTIMATE = 16
+
+
+def _large_project_row_threshold() -> int:
+    raw = os.environ.get("CHATMDV_LARGE_PROJECT_ROWS", "100000").strip()
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return 100_000
+
+
+def _available_ram_mb() -> float:
+    try:
+        import psutil
+
+        return psutil.virtual_memory().available / (1024 * 1024)
+    except Exception:
+        return 0.0
+
+
+@dataclass(frozen=True)
+class ProjectScale:
+    obs_rows: int
+    obs_columns: int
+    estimated_obs_df_mb: float
+    available_ram_mb: float
+    is_large: bool
+    has_h5ad: bool
+    obs_datasource: str
+
+
+def assess_project_scale(project: Any, path_to_data: str) -> ProjectScale:
+    """Estimate observation-table scale and whether the project is 'large' for ChatMDV."""
+    roles = infer_datasource_roles(project)
+    obs_ds = roles.obs_datasource
+    obs_rows = 0
+    obs_columns = 0
+    try:
+        meta = project.get_datasource_metadata(obs_ds)
+        obs_rows = int(meta.get("size") or 0)
+        cols = meta.get("columns") or []
+        obs_columns = len(cols)
+    except Exception:
+        pass
+
+    estimated_obs_df_mb = (obs_rows * obs_columns * _BYTES_PER_CELL_ESTIMATE) / (1024 * 1024)
+    available_ram_mb = _available_ram_mb()
+    threshold = _large_project_row_threshold()
+    p = (path_to_data or "").strip()
+    has_h5ad = bool(p) and p.lower().endswith(".h5ad")
+
+    return ProjectScale(
+        obs_rows=obs_rows,
+        obs_columns=obs_columns,
+        estimated_obs_df_mb=round(estimated_obs_df_mb, 1),
+        available_ram_mb=round(available_ram_mb, 1),
+        is_large=obs_rows >= threshold,
+        has_h5ad=has_h5ad,
+        obs_datasource=obs_ds,
+    )
+
+
+_AGENT_OBS_COLUMN_CAP = 20
+_NUMERIC_DTYPES = frozenset({"integer", "double", "number", "float"})
+_CATEGORICAL_DTYPES = frozenset({"text", "string", "multitext", "category"})
+_EMBEDDING_HINTS = ("umap", "pca", "tsne", "embed")
+
+
+def agent_probe_columns_from_metadata(
+    project: Any,
+    datasource_name: str,
+    *,
+    cap: int = _AGENT_OBS_COLUMN_CAP,
+) -> list[str]:
+    """Field ids to load for the pandas agent on large projects (schema probing only)."""
+    try:
+        meta = project.get_datasource_metadata(datasource_name)
+    except Exception:
+        return []
+    columns = meta.get("columns") or []
+    picked: list[str] = []
+    for col in columns:
+        field = col.get("field")
+        if not field:
+            continue
+        dtype = str(col.get("datatype") or "").lower()
+        field_lower = field.lower()
+        if dtype in _CATEGORICAL_DTYPES or dtype in _NUMERIC_DTYPES:
+            picked.append(field)
+        elif any(hint in field_lower for hint in _EMBEDDING_HINTS):
+            picked.append(field)
+        if len(picked) >= cap:
+            break
+    if not picked and columns:
+        first = columns[0].get("field")
+        if first:
+            picked.append(first)
+    return picked
+
+
+def agent_expression_probe_columns(
+    project: Any,
+    expression_datasource: str,
+    name_column: str,
+    *,
+    cap: int = 12,
+) -> list[str]:
+    """Feature-table columns for agent probing (name column + stat columns, not gene matrix)."""
+    try:
+        meta = project.get_datasource_metadata(expression_datasource)
+    except Exception:
+        return [name_column] if name_column else []
+    columns = meta.get("columns") or []
+    picked: list[str] = []
+    if name_column:
+        picked.append(name_column)
+    for col in columns:
+        field = col.get("field")
+        if not field or field in picked:
+            continue
+        dtype = str(col.get("datatype") or "").lower()
+        if dtype in _NUMERIC_DTYPES:
+            picked.append(field)
+        if len(picked) >= cap:
+            break
+    return picked or ([name_column] if name_column else [])
+
+
+def load_agent_dataframes(
+    project: Any,
+    roles: Any,
+    scale: ProjectScale,
+) -> list[Any]:
+    """
+    Return [obs_df] or [obs_df, expr_df] for the pandas agent.
+
+    Large projects load column subsets only; small projects load full tables.
+    """
+    obs_ds = roles.obs_datasource
+    if scale.is_large:
+        obs_cols = agent_probe_columns_from_metadata(project, obs_ds)
+        df1 = (
+            project.get_datasource_as_dataframe(obs_ds, columns=obs_cols)
+            if obs_cols
+            else project.get_datasource_as_dataframe(obs_ds)
+        )
+    else:
+        df1 = project.get_datasource_as_dataframe(obs_ds)
+
+    primary_expr = roles.preferred_expression()
+    if primary_expr is None:
+        return [df1]
+
+    expr_ds = primary_expr.datasource_name
+    if scale.is_large:
+        expr_cols = agent_expression_probe_columns(
+            project, expr_ds, primary_expr.name_column
+        )
+        df2 = (
+            project.get_datasource_as_dataframe(expr_ds, columns=expr_cols)
+            if expr_cols
+            else project.get_datasource_as_dataframe(expr_ds)
+        )
+    else:
+        df2 = project.get_datasource_as_dataframe(expr_ds)
+    return [df1, df2]
+
+
+def format_scale_context_block(scale: ProjectScale) -> str:
+    """Markdown snippet for agent/RAG prompts."""
+    ram_note = (
+        f"available RAM ~{scale.available_ram_mb:.0f} MB"
+        if scale.available_ram_mb > 0
+        else "available RAM unknown"
+    )
+    size_note = (
+        f"~{scale.estimated_obs_df_mb:.0f} MB if all {scale.obs_columns} metadata columns are loaded"
+        if scale.obs_columns > 0
+        else "metadata column count unknown"
+    )
+    large_note = (
+        "Treat as a **large project**: prefer MDV chart APIs and column-subset loads; "
+        "avoid full `get_datasource_as_dataframe` and full in-memory AnnData."
+        if scale.is_large
+        else "Small/medium project: column-subset loads are still preferred when only a few fields are needed."
+    )
+    return (
+        f"- Observation datasource `{scale.obs_datasource}`: **{scale.obs_rows:,}** rows, "
+        f"**{scale.obs_columns}** metadata columns ({size_note}; {ram_note}).\n"
+        f"- {large_note}"
+    )

--- a/python/mdvtools/llm/datasource_roles.py
+++ b/python/mdvtools/llm/datasource_roles.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
+
+if TYPE_CHECKING:
+    from mdvtools.llm.dataset_scale import ProjectScale
 
 
 @dataclass(frozen=True)
@@ -378,7 +381,89 @@ def format_obs_table_chart_param_policy() -> str:
     )
 
 
-def format_marker_gene_scanpy_fallback_policy(path_to_data: str) -> str:
+def format_mdv_first_data_access_policy(
+    scale: ProjectScale,
+    path_to_data: str,
+    *,
+    compact: bool = False,
+) -> str:
+    """
+    Prompt text: MDV-first data access with Scanpy as last resort.
+
+    ``compact=True`` returns a shorter block for Ollama/local models.
+    """
+    from mdvtools.llm.dataset_scale import format_scale_context_block
+
+    scale_block = format_scale_context_block(scale)
+    large_rules = ""
+    if scale.is_large:
+        large_rules = (
+            "- **Large-project rules (mandatory):**\n"
+            "  - Do **not** call `sc.read_h5ad(data_path)` without `backed='r'`.\n"
+            "  - Do **not** call `project.get_datasource_as_dataframe(<name>)` without "
+            "`columns=[...]` listing only the Field IDs you need.\n"
+            "  - Do **not** materialize `pd.DataFrame(adata.obs)` — observation columns already exist on "
+            f"`{scale.obs_datasource}` in the MDV project.\n"
+            "  - Do **not** open `.h5ad` for chart-only questions (scatter/UMAP, proportions, stacked rows, "
+            "selection dialogs).\n"
+        )
+
+    scanpy_last_resort = (
+        "- **Scanpy last resort only** when MDV cannot answer: marker ranking (`sc.tl.rank_genes_groups`), "
+        "or DE stats missing from the expression feature table, and `data_path` is a `.h5ad` file.\n"
+    )
+    if scale.is_large:
+        scanpy_last_resort += (
+            "  - On large projects use `adata = sc.read_h5ad(data_path, backed='r')`; filter with obs masks "
+            "before any heavy step; never `.copy()` the full expression matrix.\n"
+        )
+    else:
+        scanpy_last_resort += (
+            "  - Prefer `backed='r'` when loading AnnData; avoid full in-memory loads unless necessary.\n"
+        )
+
+    if compact:
+        return (
+            "## Project scale and memory\n"
+            + scale_block
+            + "\n\n## MDV-first data access (mandatory)\n"
+            "- **1.** Use `MDVProject(project_path, delete_existing=False)`, chart classes, `CHATMDV_*` wrappers, "
+            "and `SelectionDialogPlot` for filtering — no Scanpy for chart-only views.\n"
+            "- **2.** Load tables with `project.get_datasource_as_dataframe(<ds>, columns=[field_ids...])` only.\n"
+            "- **3.** Gene expression on embeddings: expression wrapper tokens via `build_expression_wrapper_token`.\n"
+            "- **4.** Scanpy only for marker/DE workflows when MDV tables lack required columns.\n"
+            + large_rules
+            + scanpy_last_resort
+            + "- Do **not** `add_datasource` for datasources that already exist (except "
+            f"`{CHAT_RANK_GENES_DATASOURCE_NAME}` for optional in-view marker tables).\n"
+        )
+
+    return (
+        "## Project scale and memory\n"
+        + scale_block
+        + "\n\n## MDV-first data access (default for existing projects)\n"
+        "Follow this priority order before writing any data-loading code:\n"
+        "- **1. MDV chart APIs (preferred):** `MDVProject`, mdvtools chart classes, injected `CHATMDV_*` constants, "
+        "expression wrapper `params`, and `SelectionDialogPlot` for interactive filters. This path is fast and "
+        "memory-efficient on large projects.\n"
+        "- **2. Column-subset MDV tables:** When you need a pandas preview or aggregate, call "
+        "`project.get_datasource_as_dataframe(<datasource>, columns=[<field_id>, ...])` with only the Field IDs "
+        "required for the chart or printout.\n"
+        "- **3. Expression without AnnData:** For gene expression on embeddings, build wrapper tokens with "
+        "`build_expression_wrapper_token` — do not load `.h5ad`.\n"
+        "- **4. Scanpy last resort:** Use Scanpy only when steps 1–3 cannot answer the question (marker genes, "
+        "DE ranking, or expression stats absent from MDV metadata) and a `.h5ad` exists at `data_path`.\n"
+        + large_rules
+        + scanpy_last_resort
+        + "- Do **not** call `project.add_datasource(...)` for observation or expression datasources that already "
+        "exist in this project.\n"
+    )
+
+
+def format_marker_gene_scanpy_fallback_policy(
+    path_to_data: str,
+    scale: ProjectScale | None = None,
+) -> str:
     """
     Prompt text: marker-gene requests must not assume cluster/DE columns exist on the ``genes`` table.
 
@@ -400,14 +485,21 @@ def format_marker_gene_scanpy_fallback_policy(path_to_data: str) -> str:
     )
 
     ds = CHAT_RANK_GENES_DATASOURCE_NAME
+    is_large = scale is not None and scale.is_large
+    h5ad_load = (
+        "`adata = sc.read_h5ad(data_path, backed='r')`"
+        if is_large
+        else "`adata = sc.read_h5ad(data_path)` (prefer `backed='r'` on large datasets)"
+    )
     if has_h5ad:
         return (
             semantic
             + "- If the MDV `genes` table lacks columns needed for ranking (or you need full expression), and "
-            "`data_path` is a `.h5ad` file: load `adata = sc.read_h5ad(data_path)`, pick the cluster column from "
+            f"`data_path` is a `.h5ad` file: load {h5ad_load}, pick the cluster column from "
             "`adata.obs.columns`, then compute markers with Scanpy (e.g. `sc.tl.rank_genes_groups` with "
-            "`groupby=<cluster_key>`, or mean expression per group). Print a **bounded** table (top 5 per cluster) "
-            "via `print(...)` as the **primary** answer.\n"
+            "`groupby=<cluster_key>`, or mean expression per group). On large projects filter `adata` with obs "
+            "masks before heavy steps; avoid `.copy()` on the full matrix. Print a **bounded** table (top 5 per "
+            "cluster) via `print(...)` as the **primary** answer.\n"
             + "- **In-view table (optional):** When the user clearly needs the marker table **in the saved view**, you may "
             "call "
             f"`project.add_datasource('{ds}', marker_df, replace_data=True, add_to_view=view_name)` "

--- a/python/mdvtools/llm/datasource_roles.py
+++ b/python/mdvtools/llm/datasource_roles.py
@@ -105,11 +105,58 @@ def build_datasource_field_index(project: Any) -> dict[str, set[str]]:
     return index
 
 
+def _question_word_tokens(question: str) -> set[str]:
+    """Lowercased whole-word tokens from the question (underscore names stay one token)."""
+    return {t.lower() for t in re.findall(r"[\w_]+", question)}
+
+
+def _datasource_names_mentioned_in_question(
+    names: list[str], question: str
+) -> list[str]:
+    """
+    Datasource names explicitly mentioned as whole tokens in the question.
+
+    Uses token boundaries so ``genes`` does not match inside ``n_genes``.
+    """
+    tokens = _question_word_tokens(question)
+    return [n for n in names if n.lower() in tokens]
+
+
 def _question_field_tokens(question: str, field_index: dict[str, set[str]]) -> set[str]:
     """Field ids mentioned in the question (whole-token match against project fields)."""
     all_fields = {f for fields in field_index.values() for f in fields}
     tokens = set(re.findall(r"[\w_]+", question))
     return {t for t in tokens if t in all_fields}
+
+
+def _resolve_by_field_overlap(
+    project: Any,
+    mentioned: set[str],
+    field_index: dict[str, set[str]],
+) -> str | None:
+    """Pick datasource from field-id overlap; prefer tables that own all mentioned fields."""
+    full_matches = [
+        ds for ds, fields in field_index.items() if mentioned <= fields
+    ]
+    if full_matches:
+        if len(full_matches) == 1:
+            return full_matches[0]
+        try:
+            obs = infer_datasource_roles(project).obs_datasource
+            if obs in full_matches:
+                return obs
+        except Exception:
+            pass
+        return max(full_matches, key=lambda ds: (len(mentioned & field_index[ds]), ds))
+
+    scores: dict[str, int] = {}
+    for ds_name, fields in field_index.items():
+        overlap = len(mentioned & fields)
+        if overlap > 0:
+            scores[ds_name] = overlap
+    if not scores:
+        return None
+    return max(scores, key=lambda ds: (scores[ds], ds))
 
 
 def resolve_datasource_from_question(
@@ -121,33 +168,25 @@ def resolve_datasource_from_question(
     """
     Pick the datasource the user is asking about.
 
-    Priority: explicit datasource name in question, then datasource owning the most
-    mentioned field ids.
+    Priority: explicit datasource name (whole-token match), then a datasource that
+    contains all mentioned field ids, then partial field overlap.
     """
     names = _project_datasource_names(project)
     if not names:
         return None
 
-    q_lower = question.lower()
-    name_matches = [n for n in names if n.lower() in q_lower]
-    if name_matches:
-        return max(name_matches, key=len)
-
     if field_index is None:
         field_index = build_datasource_field_index(project)
+
+    name_matches = _datasource_names_mentioned_in_question(names, question)
+    if name_matches:
+        return max(name_matches, key=len)
 
     mentioned = _question_field_tokens(question, field_index)
     if not mentioned:
         return None
 
-    scores: dict[str, int] = {}
-    for ds_name, fields in field_index.items():
-        overlap = len(mentioned & fields)
-        if overlap > 0:
-            scores[ds_name] = overlap
-    if not scores:
-        return None
-    return max(scores, key=lambda ds: (scores[ds], ds))
+    return _resolve_by_field_overlap(project, mentioned, field_index)
 
 
 def find_datasources_for_fields(

--- a/python/mdvtools/llm/datasource_roles.py
+++ b/python/mdvtools/llm/datasource_roles.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -39,23 +40,174 @@ class InferredDatasourceRoles:
         return self.expressions[0]
 
 
-def _pick_obs_datasource(project: Any) -> str:
-    names = []
+_TABULAR_OBS_FALLBACK_NAMES = ("qc_runs", "qc_sessions", "runs", "sessions", "observations", "metadata")
+
+
+def _project_datasource_names(project: Any) -> list[str]:
     try:
-        names = list(project.get_datasource_names())
+        return list(project.get_datasource_names())
     except Exception:
-        # Fallback: MDVProject.datasources property
         try:
-            names = [ds.get("name") for ds in (project.datasources or []) if ds.get("name")]
+            return [str(ds.get("name")) for ds in (project.datasources or []) if ds.get("name")]
         except Exception:
-            names = []
+            return []
+
+
+def _pick_obs_datasource(project: Any) -> str:
+    names = _project_datasource_names(project)
 
     if "cells" in names:
         return "cells"
-    # last-resort: first datasource
+    if len(names) > 1:
+        names_lower = {n.lower(): n for n in names}
+        for preferred in _TABULAR_OBS_FALLBACK_NAMES:
+            if preferred in names_lower:
+                return names_lower[preferred]
     if names:
         return str(names[0])
     raise ValueError("Project has no datasources; cannot infer roles")
+
+
+def _field_set_from_column_dicts(columns: list[dict[str, Any]]) -> set[str]:
+    out: set[str] = set()
+    for col in columns:
+        if not isinstance(col, dict):
+            continue
+        field = col.get("field", col.get("name"))
+        if field is not None and str(field).strip():
+            out.add(str(field))
+    return out
+
+
+def build_datasource_field_index(project: Any) -> dict[str, set[str]]:
+    """Map each datasource name to its field ids (for preflight and question routing)."""
+    index: dict[str, set[str]] = {}
+    for ds in project.datasources or []:
+        if not isinstance(ds, dict):
+            continue
+        ds_name = ds.get("name")
+        if not isinstance(ds_name, str):
+            continue
+        fields: set[str] = set()
+        try:
+            md = project.get_datasource_metadata(ds_name)
+            if isinstance(md, dict):
+                md_cols = md.get("columns")
+                if isinstance(md_cols, list):
+                    fields |= _field_set_from_column_dicts(md_cols)
+        except Exception:
+            pass
+        cols = ds.get("columns")
+        if isinstance(cols, list):
+            fields |= _field_set_from_column_dicts(cols)
+        if fields:
+            index[ds_name] = fields
+    return index
+
+
+def _question_field_tokens(question: str, field_index: dict[str, set[str]]) -> set[str]:
+    """Field ids mentioned in the question (whole-token match against project fields)."""
+    all_fields = {f for fields in field_index.values() for f in fields}
+    tokens = set(re.findall(r"[\w_]+", question))
+    return {t for t in tokens if t in all_fields}
+
+
+def resolve_datasource_from_question(
+    project: Any,
+    question: str,
+    *,
+    field_index: dict[str, set[str]] | None = None,
+) -> str | None:
+    """
+    Pick the datasource the user is asking about.
+
+    Priority: explicit datasource name in question, then datasource owning the most
+    mentioned field ids.
+    """
+    names = _project_datasource_names(project)
+    if not names:
+        return None
+
+    q_lower = question.lower()
+    name_matches = [n for n in names if n.lower() in q_lower]
+    if name_matches:
+        return max(name_matches, key=len)
+
+    if field_index is None:
+        field_index = build_datasource_field_index(project)
+
+    mentioned = _question_field_tokens(question, field_index)
+    if not mentioned:
+        return None
+
+    scores: dict[str, int] = {}
+    for ds_name, fields in field_index.items():
+        overlap = len(mentioned & fields)
+        if overlap > 0:
+            scores[ds_name] = overlap
+    if not scores:
+        return None
+    return max(scores, key=lambda ds: (scores[ds], ds))
+
+
+def find_datasources_for_fields(
+    field_index: dict[str, set[str]],
+    fields: list[str],
+) -> dict[str, list[str]]:
+    """Map each field id to datasource name(s) that contain it."""
+    result: dict[str, list[str]] = {}
+    for field in fields:
+        owners = sorted(ds for ds, flds in field_index.items() if field in flds)
+        if owners:
+            result[field] = owners
+    return result
+
+
+def format_field_index_hint(
+    field_index: dict[str, set[str]],
+    *,
+    fields: list[str] | None = None,
+    max_datasources: int = 12,
+) -> str:
+    """Compact cross-datasource field map for preflight retry prompts."""
+    if not field_index:
+        return ""
+    lines: list[str] = ["Cross-datasource field index (use the datasource that owns each column):"]
+    shown = 0
+    for ds_name in sorted(field_index):
+        if shown >= max_datasources:
+            break
+        ds_fields = field_index[ds_name]
+        if fields is not None:
+            subset = sorted(f for f in fields if f in ds_fields)
+            if not subset:
+                continue
+            lines.append(f"- `{ds_name}`: {subset}")
+        else:
+            preview = sorted(ds_fields)[:20]
+            suffix = "..." if len(ds_fields) > 20 else ""
+            lines.append(f"- `{ds_name}`: {preview}{suffix}")
+        shown += 1
+    return "\n".join(lines)
+
+
+def is_multi_table_tabular_project(project: Any, roles: InferredDatasourceRoles) -> bool:
+    """True when the project has several independent tables and no expression link."""
+    names = _project_datasource_names(project)
+    return len(names) > 2 and "cells" not in names and not roles.expressions
+
+
+def format_multi_table_tabular_policy() -> str:
+    """Prompt text for projects with multiple independent tabular datasources."""
+    return (
+        "- **Multi-table tabular projects:** Each datasource is an independent table. "
+        "When the user names a datasource (e.g. `qc_field_uniformity`, `qc_runs`), use **that** "
+        "datasource for `get_datasource_as_dataframe(...)`, chart `initialCharts` keys, and "
+        "`datasource_name` — do **not** substitute `CHATMDV_OBS_DATASOURCE` or the first project table.\n"
+        "- Match every column in `columns=[...]` and chart `params` to field ids on **the same** "
+        "datasource. If a column is missing on one table, check Project Data Context for which table owns it.\n"
+        "- Do not invent column names (e.g. `assay_type` when the field is `assay` on `qc_runs`).\n"
+    )
 
 
 def _pick_default_subgroup(subgroups: dict[str, Any]) -> tuple[str, str]:

--- a/python/mdvtools/llm/datasource_roles.py
+++ b/python/mdvtools/llm/datasource_roles.py
@@ -381,6 +381,79 @@ def format_obs_table_chart_param_policy() -> str:
     )
 
 
+def format_obs_annadata_alignment_policy() -> str:
+    """Prompt text: never align MDV obs tables to AnnData via default DataFrame index."""
+    return (
+        "- **No hybrid MDV + AnnData alignment for chart views:** Do not subset `adata` using "
+        "`get_datasource_as_dataframe(...)` row positions or default `DataFrame.index` — MDV observation "
+        "tables use a positional index, not cell barcodes.\n"
+        "- If a join is unavoidable, use explicit id fields (`cell_id`, `cellbarcode`) present in both "
+        "MDV metadata and `adata.obs`; never use `obs_df.index`.\n"
+        "- Prefer avoiding AnnData entirely on existing MDV projects; use MDV charts and column-subset loads.\n"
+    )
+
+
+def format_gene_signature_chart_policy() -> str:
+    """Prompt text: gene signature / enrichment questions via MDV wrappers, not Scanpy means."""
+    return (
+        "- **Gene signatures / enrichment across cell types:** Use **DotPlot** or **HeatmapPlot** on the "
+        "observation datasource with expression **wrapper** `params` plus a categorical field id "
+        "(e.g. `sub_bucket`, `bucket`, `major`).\n"
+        "- Add **SelectionDialogPlot** filters for `Remission_status`, `Treatment`, `bucket`, or `sub_bucket` "
+        "instead of subsetting AnnData or pandas tables.\n"
+        "- Do **not** compute per-group Scanpy/pandas means solely to populate MDV charts; wrappers read the "
+        "project expression matrix directly.\n"
+        "- Use field ids from Project Data Context / `CHATMDV_CATEGORICAL_FIELD_IDS`; do **not** invent "
+        "category literals (e.g. do not guess `Monocyte` in `bucket` — use real values via selection UI).\n"
+    )
+
+
+def format_proportion_chart_policy() -> str:
+    """Prompt text: proportion / frequency questions via StackedRowChart or PieChart."""
+    return (
+        "- **Proportions, frequencies, relative abundance, before/after comparisons:** Prefer "
+        "**`StackedRowChart`** with two or three categorical field ids in `params` "
+        "(e.g. `Treatment`, `Remission_status`, `sub_bucket`).\n"
+        "- Import: `from mdvtools.charts.stacked_row_plot import StackedRowChart` "
+        "(not `mdvtools.charts.stacked_row_chart`).\n"
+        "- **`PieChart`** uses constructor kwarg **`param=`** (singular), not `params=`.\n"
+        "- Pair with **SelectionDialogPlot** on `major`, `bucket`, or `sub_bucket` to focus a cell type; "
+        "do not compute proportions in pandas/Scanpy when MDV charts aggregate in the view.\n"
+    )
+
+
+def format_column_subset_completeness_policy() -> str:
+    """Prompt text: every referenced field id must be listed in get_datasource_as_dataframe columns."""
+    return (
+        "- **Column-subset completeness:** Every field id you reference (`df['col']`, chart `params`, filters) "
+        "must appear in the `columns=[...]` list passed to `project.get_datasource_as_dataframe(...)`.\n"
+    )
+
+
+def format_targeted_chart_policies(*, compact: bool = False) -> str:
+    """Combined policies for signature, proportion, alignment, and column-subset codegen."""
+    if compact:
+        return (
+            "## Chart recipes (mandatory)\n"
+            "- Proportions / frequency / before-after → `StackedRowChart` from `mdvtools.charts.stacked_row_plot`; "
+            "`PieChart` uses `param=` not `params=`.\n"
+            "- Gene signatures / enrichment → `DotPlot` or `HeatmapPlot` + expression wrappers + "
+            "`SelectionDialogPlot` filters; no Scanpy means for charts.\n"
+            "- Never align `obs_df.index` to AnnData; avoid hybrid h5ad + MDV loads for chart-only views.\n"
+            "- Every `df['field']` used must be listed in `get_datasource_as_dataframe(..., columns=[...])`.\n"
+        )
+    return (
+        "## Observation / AnnData alignment (ChatMDV)\n"
+        + format_obs_annadata_alignment_policy()
+        + "\n## Gene signature / enrichment charts (ChatMDV)\n"
+        + format_gene_signature_chart_policy()
+        + "\n## Proportion / frequency charts (ChatMDV)\n"
+        + format_proportion_chart_policy()
+        + "\n## Column-subset completeness (ChatMDV)\n"
+        + format_column_subset_completeness_policy()
+    )
+
+
 def format_mdv_first_data_access_policy(
     scale: ProjectScale,
     path_to_data: str,
@@ -412,6 +485,12 @@ def format_mdv_first_data_access_policy(
         "- **Scanpy last resort only** when MDV cannot answer: marker ranking (`sc.tl.rank_genes_groups`), "
         "or DE stats missing from the expression feature table, and `data_path` is a `.h5ad` file.\n"
     )
+    hybrid_bans = (
+        "- Do **not** combine `read_h5ad` with `get_datasource_as_dataframe` filtering for chart-only views.\n"
+        "- Do **not** invent `bucket` / `major` / `sub_bucket` category literals — use field ids from context "
+        "and `SelectionDialogPlot` for interactive filtering.\n"
+        "- Gene expression on subsets: expression wrappers + `SelectionDialogPlot`, not AnnData `[:, gene].X.mean()`.\n"
+    )
     if scale.is_large:
         scanpy_last_resort += (
             "  - On large projects use `adata = sc.read_h5ad(data_path, backed='r')`; filter with obs masks "
@@ -433,6 +512,7 @@ def format_mdv_first_data_access_policy(
             "- **3.** Gene expression on embeddings: expression wrapper tokens via `build_expression_wrapper_token`.\n"
             "- **4.** Scanpy only for marker/DE workflows when MDV tables lack required columns.\n"
             + large_rules
+            + hybrid_bans
             + scanpy_last_resort
             + "- Do **not** `add_datasource` for datasources that already exist (except "
             f"`{CHAT_RANK_GENES_DATASOURCE_NAME}` for optional in-view marker tables).\n"
@@ -454,6 +534,7 @@ def format_mdv_first_data_access_policy(
         "- **4. Scanpy last resort:** Use Scanpy only when steps 1–3 cannot answer the question (marker genes, "
         "DE ranking, or expression stats absent from MDV metadata) and a `.h5ad` exists at `data_path`.\n"
         + large_rules
+        + hybrid_bans
         + scanpy_last_resort
         + "- Do **not** call `project.add_datasource(...)` for observation or expression datasources that already "
         "exist in this project.\n"

--- a/python/mdvtools/llm/guidance.py
+++ b/python/mdvtools/llm/guidance.py
@@ -1,0 +1,182 @@
+"""
+Post-execution analysis summary for ChatMDV.
+
+Builds user-facing guidance (why / what to look for / next steps), persists it as a
+view TextBox, and echoes the same markdown to the chat client.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any, Optional
+
+from mdvtools.charts.text_box_plot import TextBox
+from mdvtools.llm.verification import (
+    format_charts_from_saved_view,
+    parse_datasource_name,
+)
+
+ANALYSIS_SUMMARY_TITLE = "Analysis summary"
+CHATMDV_SUMMARY_TEXTBOX_ID = "chatmdv_analysis_summary"
+
+
+def _is_summary_textbox(chart: dict[str, Any]) -> bool:
+    if not isinstance(chart, dict):
+        return False
+    if chart.get("type") != "text_box_chart":
+        return False
+    if chart.get("id") == CHATMDV_SUMMARY_TEXTBOX_ID:
+        return True
+    title = chart.get("title")
+    return isinstance(title, str) and title.strip() == ANALYSIS_SUMMARY_TITLE
+
+
+def _plot_to_json(plot: TextBox) -> dict[str, Any]:
+    return json.loads(json.dumps(plot.plot_data))
+
+
+def _view_has_non_summary_charts(view: dict[str, Any], datasource_name: str) -> bool:
+    initial = view.get("initialCharts")
+    if not isinstance(initial, dict):
+        return False
+    charts = initial.get(datasource_name)
+    if not isinstance(charts, list):
+        return False
+    return any(isinstance(c, dict) and not _is_summary_textbox(c) for c in charts)
+
+
+def _suggest_next_steps(
+    project: Any,
+    question: str,
+    datasource_name: str | None,
+) -> list[str]:
+    names: list[str] = []
+    for ds in project.datasources or []:
+        if isinstance(ds, dict) and ds.get("name"):
+            names.append(str(ds["name"]))
+    q_lower = question.lower()
+    steps: list[str] = []
+    for name in names:
+        if name == datasource_name:
+            continue
+        if name.lower() in q_lower:
+            continue
+        steps.append(f"Compare with related table `{name}` (e.g. other QC metrics or run metadata).")
+        if len(steps) >= 2:
+            break
+    steps.append(
+        "Ask a follow-up to filter by session, channel, or assay—or to plot a related numeric column."
+    )
+    return steps[:3]
+
+
+def build_response_guidance(
+    project: Any,
+    question: str,
+    final_code: str,
+    view_name: Optional[str],
+    agent_plan: str,
+    data_preview: str | None,
+) -> str:
+    """
+    Markdown guidance echoed to chat and stored in the view TextBox.
+    """
+    ds_from_code = parse_datasource_name(final_code)
+    lines: list[str] = []
+
+    lines.append("## Why this visualization")
+    view = None
+    if view_name:
+        try:
+            view = project.get_view(view_name)
+        except Exception:
+            view = None
+    charts_md = ""
+    if isinstance(view, dict) and view.get("initialCharts"):
+        try:
+            charts_md, _ = format_charts_from_saved_view(project, view)
+        except Exception:
+            charts_md = ""
+    if charts_md.strip():
+        for part in charts_md.strip().splitlines():
+            if part.startswith("### Charts"):
+                lines.append(
+                    "The saved view uses the chart(s) below to answer your question "
+                    f"using datasource `{ds_from_code or 'see code'}`."
+                )
+            elif part.strip():
+                lines.append(part)
+    else:
+        lines.append(
+            f"This analysis addresses: **{question.strip()}**"
+        )
+        if agent_plan.strip():
+            lines.append(f"- Planned fields/charts: {agent_plan.strip()[:400]}")
+
+    lines.append("")
+    lines.append("## What to look for")
+    preview = (data_preview or "").strip()
+    if preview:
+        lines.append("- Review the **data preview** in chat for computed aggregates or row samples.")
+        snippet = preview[:1200]
+        if len(preview) > 1200:
+            snippet += "\n\n_(preview truncated)_"
+        lines.append("")
+        lines.append(snippet)
+    else:
+        lines.append("- Compare groups or categories on the chart axes.")
+        lines.append("- Note outliers, skew, or channels that differ strongly from others.")
+
+    lines.append("")
+    lines.append("## Suggested next steps")
+    for step in _suggest_next_steps(project, question, ds_from_code):
+        lines.append(f"- {step}")
+
+    return "\n".join(lines).strip()
+
+
+def append_guidance_textbox_to_view(
+    project: Any,
+    view_name: str,
+    datasource_name: str,
+    guidance_md: str,
+) -> bool:
+    """
+    Prepend (or replace) the ChatMDV analysis summary TextBox on a saved view.
+
+    Returns True when the view was updated.
+    """
+    if not guidance_md.strip():
+        return False
+    try:
+        view = project.get_view(view_name)
+    except Exception:
+        return False
+    if not isinstance(view, dict):
+        return False
+    if not _view_has_non_summary_charts(view, datasource_name):
+        return False
+
+    initial = view.get("initialCharts")
+    if not isinstance(initial, dict):
+        initial = {}
+        view = {**view, "initialCharts": initial}
+
+    charts = initial.get(datasource_name)
+    if not isinstance(charts, list):
+        charts = []
+
+    kept = [c for c in charts if isinstance(c, dict) and not _is_summary_textbox(c)]
+
+    summary = TextBox(
+        title=ANALYSIS_SUMMARY_TITLE,
+        param=[],
+        size=[900, 320],
+        position=[10, 10],
+        id=CHATMDV_SUMMARY_TEXTBOX_ID,
+    )
+    summary.set_text(guidance_md)
+    summary_json = _plot_to_json(summary)
+
+    initial[datasource_name] = [summary_json, *kept]
+    project.set_view(view_name, view)
+    return True

--- a/python/mdvtools/llm/langchain_mdv.py
+++ b/python/mdvtools/llm/langchain_mdv.py
@@ -48,7 +48,13 @@ from .column_field_resolve import (
     prune_view_charts_with_invalid_params,
 )
 from .verification import build_verification_summary
-from .datasource_roles import collect_wrapper_subgroup_keys_for_project, infer_datasource_roles
+from .datasource_roles import (
+    build_datasource_field_index,
+    collect_wrapper_subgroup_keys_for_project,
+    format_field_index_hint,
+    infer_datasource_roles,
+    resolve_datasource_from_question,
+)
 from .dataset_scale import (
     assess_project_scale,
     format_scale_context_block,
@@ -443,11 +449,6 @@ class ProjectChat(ProjectChatProtocol):
         self.suggested_questions: list[str] = []
         if len(project.datasources) == 0:
             raise ValueError("The project does not have any datasources")
-        elif len(project.datasources) > 1: # remove? or make it == 1 ?
-            # tempting to think we should just give the agent all of the datasources here
-            self.log("The project has more than one datasource, only the first one will be used")
-            self.ds_name1 = project.datasources[1]['name'] # maybe comment this out?
-            self.df1 = project.get_datasource_as_dataframe(self.ds_name1) # and maybe comment this out?
 
         self.ds_name = project.datasources[0]['name']
         self.discovered_models: DiscoveredModels = discover_models()
@@ -508,7 +509,7 @@ class ProjectChat(ProjectChatProtocol):
             del self.conversation_memories[conversation_id]
         chat_debug_logger.info(f"Cleared conversation history for conversation {conversation_id}")
 
-    def _build_role_hint(self) -> str:
+    def _build_role_hint(self, *, question_datasource: str | None = None) -> str:
         try:
             roles = getattr(self, "roles", None)
             scale = getattr(self, "scale", None)
@@ -533,7 +534,13 @@ class ProjectChat(ProjectChatProtocol):
                         f"(feature names in column '{exprs[0].name_column}', default subgroup '{exprs[0].subgroup_key}')"
                     )
                 else:
-                    expr_lines = "- No rows-as-columns expression datasource detected for this project."
+                    if question_datasource and question_datasource != roles.obs_datasource:
+                        expr_lines = (
+                            f"- df2 maps to question-resolved datasource '{question_datasource}' "
+                            "(use this table when the user names it or its columns)"
+                        )
+                    else:
+                        expr_lines = "- No rows-as-columns expression datasource detected for this project."
                 return (
                     "\n\nDatasource roles:\n"
                     f"- df1 maps to obs datasource '{roles.obs_datasource}'\n"
@@ -564,8 +571,9 @@ class ProjectChat(ProjectChatProtocol):
         verbose: bool,
         *,
         use_react: bool = False,
+        question_datasource: str | None = None,
     ) -> AgentExecutor:
-        role_hint = self._build_role_hint()
+        role_hint = self._build_role_hint(question_datasource=question_datasource)
         prompt_data_template = f"""You have access to the following Pandas DataFrames: 
         {', '.join(dfs.keys())}. These are preloaded, so do not redefine them.
         {role_hint}
@@ -614,6 +622,7 @@ class ProjectChat(ProjectChatProtocol):
         provider: ProviderKind,
         verbose=False,
         on_agent_fallback=None,
+        question_datasource: str | None = None,
     ):
         """
         Creates a LangChain agent that can interact with Pandas DataFrames using a Python REPL tool.
@@ -647,6 +656,7 @@ class ProjectChat(ProjectChatProtocol):
             provider,
             verbose,
             use_react=False,
+            question_datasource=question_datasource,
         )
 
         def agent_with_contextualization(question):
@@ -670,6 +680,7 @@ class ProjectChat(ProjectChatProtocol):
                     provider,
                     verbose,
                     use_react=True,
+                    question_datasource=question_datasource,
                 )
                 return fallback_executor.invoke({"input": standalone_question})
 
@@ -750,7 +761,24 @@ class ProjectChat(ProjectChatProtocol):
             )
         # there is a risk that these are out of date by the time we get here...
         # but it's a bit of an expensive operation, so avoiding it for now (in most cases we shouldn't need to refer to them)
-        df_list = self.df_list
+        field_index = build_datasource_field_index(self.project)
+        question_datasource = resolve_datasource_from_question(
+            self.project, question, field_index=field_index
+        )
+        df_list = load_agent_dataframes(
+            self.project,
+            self.roles,
+            self.scale,
+            extra_datasource=question_datasource,
+        )
+        default_datasource = str(self.project.datasources[0]["name"])
+        rag_datasource = question_datasource or default_datasource
+        if question_datasource:
+            chat_debug_logger.info(
+                "Resolved question datasource: %s (default would be %s)",
+                question_datasource,
+                default_datasource,
+            )
         
         progress = 0
 
@@ -780,6 +808,7 @@ class ProjectChat(ProjectChatProtocol):
                 chat_model.provider,
                 verbose=True,
                 on_agent_fallback=_notify_agent_fallback,
+                question_datasource=question_datasource,
             )
 
         total_steps = 6
@@ -868,7 +897,7 @@ class ProjectChat(ProjectChatProtocol):
                 prompt_RAG = get_createproject_prompt_RAG(
                     self.project,
                     path_to_data,
-                    datasource_names[0],
+                    rag_datasource,
                     agent_plan,
                     response["input"],
                     compact=chat_model.provider == "ollama",
@@ -957,38 +986,20 @@ class ProjectChat(ProjectChatProtocol):
                         final_code = final_code_retry
 
             with time_block("b13b: Preflight validate and retry"):
-                datasource_fields: dict[str, set[str]] = {}
-                for ds in self.project.datasources or []:
-                    if not isinstance(ds, dict):
-                        continue
-                    ds_name = ds.get("name")
-                    if not isinstance(ds_name, str):
-                        continue
-                    fields: set[str] = set()
-                    try:
-                        md = self.project.get_datasource_metadata(ds_name)
-                        if isinstance(md, dict):
-                            md_cols = md.get("columns")
-                            if isinstance(md_cols, list):
-                                fields |= field_set_from_columns(md_cols)
-                    except Exception:
-                        pass
-                    cols = ds.get("columns")
-                    if isinstance(cols, list):
-                        for c in cols:
-                            if isinstance(c, dict) and c.get("field"):
-                                fields.add(str(c.get("field")))
-                    if fields:
-                        datasource_fields[ds_name] = fields
+                datasource_fields = field_index or build_datasource_field_index(self.project)
 
                 def _regenerate_for_preflight(issue_text: str) -> str:
+                    field_map_hint = format_field_index_hint(datasource_fields)
                     retry_query = (
                         f"{rag_retrieval_query}\n\n"
                         "Fix this code preflight validation failure and return corrected runnable code only.\n"
                         "If issues mention set_x_axis or set_y_axis on BoxPlot, ViolinPlot, ScatterPlot, or DotPlot, "
                         "replace with set_axis_properties('x', {...}) and set_axis_properties('y', {...}) only.\n"
                         "On ScatterPlot use set_filter, not set_on_filter (set_on_filter is for ScatterPlot3D only).\n"
-                        f"Preflight issues:\n{issue_text}"
+                        "When a column exists on a different datasource, load it from that datasource — "
+                        "do not substitute CHATMDV_OBS_DATASOURCE.\n"
+                        f"Preflight issues:\n{issue_text}\n\n"
+                        f"{field_map_hint}"
                     )
                     output_qa_retry = qa_chain.invoke({"query": retry_query})
                     result_retry = output_qa_retry["result"]

--- a/python/mdvtools/llm/langchain_mdv.py
+++ b/python/mdvtools/llm/langchain_mdv.py
@@ -1,6 +1,8 @@
 from mdvtools._optional import require_extra
 require_extra("app", "langchain_openai")
 
+import langchain_openai
+
 import time
 import logging
 import re

--- a/python/mdvtools/llm/langchain_mdv.py
+++ b/python/mdvtools/llm/langchain_mdv.py
@@ -521,6 +521,9 @@ class ProjectChat(ProjectChatProtocol):
                     "Only suggest Scanpy in the plan if the question requires marker ranking or DE columns "
                     "not available in MDV metadata.\n"
                     "- Before suggesting columns, decide: obs metadata only, expression wrappers, or Scanpy markers.\n"
+                    "- Question-type routing: proportion / frequency / before-after → StackedRowChart; "
+                    "gene signature / enrichment / ISG genes → DotPlot or Heatmap + wrappers + SelectionDialogPlot.\n"
+                    "- On large projects df1 is a column subset — list every field id codegen will need in `fields`.\n"
                 )
             if roles is not None:
                 exprs = roles.expressions or []
@@ -569,6 +572,7 @@ class ProjectChat(ProjectChatProtocol):
         Before answering any user question, you must first run `df1.columns` and `df2.columns` to inspect available fields.
         On large projects, df1/df2 may be column subsets for schema probing — use Project Data Context field ids for planning.
         Prefer MDV chart field ids and expression wrappers; suggest Scanpy only for marker-ranking or DE questions when MDV metadata lacks required columns.
+        Route by question type: proportion/frequency/before-after → StackedRowChart; signature/enrichment/ISG expression → DotPlot or Heatmap with wrappers.
         Use these to correct the column names mentioned by the user.
         Before writing any `project.get_datasource_as_dataframe(datasource_name, columns=[...])` call, you must verify the datasource schema and only request columns that exist on that datasource.
         Never assume a `name` column exists on `cells`; if the task asks for genes/markers, use the expression datasource or explicit marker ranking outputs instead of `cells.name`.

--- a/python/mdvtools/llm/langchain_mdv.py
+++ b/python/mdvtools/llm/langchain_mdv.py
@@ -590,7 +590,7 @@ class ProjectChat(ProjectChatProtocol):
         Before writing any `project.get_datasource_as_dataframe(datasource_name, columns=[...])` call, you must verify the datasource schema and only request columns that exist on that datasource.
         Never assume a `name` column exists on `cells`; if the task asks for genes/markers, use the expression datasource or explicit marker ranking outputs instead of `cells.name`.
         You must always invoke the PythonAstREPLTool to check the DataFrames columns and explore the values of the DataFrames.
-        Use `df.info()` or `df.index()`.
+        Use `df.info()` or inspect `df.index`.
         Before running any code, check available variables using `list_globals()`.""" + prompt_data
 
         tools = [python_tool]

--- a/python/mdvtools/llm/langchain_mdv.py
+++ b/python/mdvtools/llm/langchain_mdv.py
@@ -14,8 +14,6 @@ from typing import Any, List, Optional
 from mdvtools.llm.chat_protocol import AskQuestionResult, ChatRequest, ProjectChatProtocol
 from mdvtools.mdvproject import MDVProject
 
-from langchain_openai import ChatOpenAI
-from langchain_openai import OpenAIEmbeddings
 from langchain.schema.document import Document
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain_community.vectorstores import FAISS
@@ -32,7 +30,8 @@ from mdvtools.llm.chatlog import ChatSocketAPI, LangchainLoggingHandler, log_cha
 # packages for custom langchain agent
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
 from langchain_experimental.tools.python.tool import PythonAstREPLTool
-from langchain.agents import create_openai_functions_agent, AgentExecutor
+from langchain.agents import create_openai_functions_agent, create_react_agent, AgentExecutor
+from langchain import hub
 from langchain.chains import LLMChain
 from .local_files_utils import crawl_local_repo, extract_python_code_from_py, extract_python_code_from_ipynb
 from .templates import get_createproject_prompt_RAG, prompt_data
@@ -63,6 +62,16 @@ from .execution_progress import (
     parse_explicit_progress_line,
 )
 from .preflight_flow import preflight_with_single_retry
+from .llm_providers import (
+    DiscoveredModels,
+    ModelSpec,
+    ProviderKind,
+    create_chat_llm,
+    create_embeddings,
+    discover_models,
+    ensure_any_provider_available,
+    resolve_embedding_model,
+)
 
 # packages for memory
 from langchain.chains import create_history_aware_retriever, create_retrieval_chain
@@ -191,28 +200,17 @@ def time_block(name):
 # but we can call `matplotlib.use('Agg')` before calling the agent (and any other code that might try to draw)
 matplotlib.use('Agg') # this should prevent it making any windows etc
 
-_rag_retriever: Optional[Any] = None
+_rag_retriever_cache: dict[str, Any] = {}
 
 # ... for testing basic mechanics without invoking the agent
 mock_agent = False
 
 
-def _ensure_openai_api_key() -> None:
-    load_dotenv()
-    if not os.getenv("OPENAI_API_KEY"):
-        raise ValueError(
-            "OPENAI_API_KEY is not set in the environment variables. "
-            "Please set it if LLM integration is required."
-        )
-
-
-def _get_rag_retriever():
-    """Build the code RAG retriever on first use (requires OPENAI_API_KEY)."""
-    global _rag_retriever
-    if _rag_retriever is not None:
-        return _rag_retriever
-
-    _ensure_openai_api_key()
+def _get_rag_retriever(embedding_spec: ModelSpec):
+    """Build the code RAG retriever on first use for the given embedding model."""
+    cache_key = embedding_spec.id
+    if cache_key in _rag_retriever_cache:
+        return _rag_retriever_cache[cache_key]
 
     print('# Crawl the local repository to get a list of relevant file paths')
     with time_block("b1: Local repo crawling"):
@@ -244,18 +242,19 @@ def _get_rag_retriever():
         texts = text_splitter.split_documents(code_strings)
 
     with time_block("b3: Embeddings creating"):
-        embeddings = OpenAIEmbeddings(model="text-embedding-3-large")
+        embeddings = create_embeddings(embedding_spec)
 
     with time_block("b4: FAISS database creating"):
         db = FAISS.from_documents(texts, embeddings)
 
     with time_block("b5: Retriever creating"):
-        _rag_retriever = db.as_retriever(
+        retriever = db.as_retriever(
             search_type="similarity",
             search_kwargs={"k": 5},
         )
 
-    return _rag_retriever
+    _rag_retriever_cache[cache_key] = retriever
+    return retriever
 
 
 class ProjectChat(ProjectChatProtocol):
@@ -284,9 +283,10 @@ class ProjectChat(ProjectChatProtocol):
             self.df1 = project.get_datasource_as_dataframe(self.ds_name1) # and maybe comment this out?
 
         self.ds_name = project.datasources[0]['name']
+        self.discovered_models: DiscoveredModels = discover_models()
         try:
             # raise ValueError("test error")
-            _ensure_openai_api_key()
+            ensure_any_provider_available()
             self.df = None
             # Prepare dataframes for the agent.
             # ChatMDV historically assumed df1=cells and df2=genes. Many projects instead use
@@ -303,7 +303,10 @@ class ProjectChat(ProjectChatProtocol):
 
             try:
                 with time_block("b_suggest: Generating suggested questions"):
-                    llm = ChatOpenAI(temperature=0.1, model="gpt-4.1")
+                    default_chat = self.discovered_models.get_chat_model(
+                        self.discovered_models.default_model_id
+                    )
+                    llm = create_chat_llm(default_chat)
                     structured_llm = llm.with_structured_output(SuggestedQuestions)
                     prompt_text = create_suggested_questions_prompt(self.project)
                     messages = [HumanMessage(content=prompt_text)]
@@ -342,39 +345,7 @@ class ProjectChat(ProjectChatProtocol):
             del self.conversation_memories[conversation_id]
         chat_debug_logger.info(f"Cleared conversation history for conversation {conversation_id}")
 
-    def create_custom_pandas_agent(self, llm, dfs: dict, prompt_data, memory, verbose=False):
-        """
-        Creates a LangChain agent that can interact with Pandas DataFrames using a Python REPL tool.
-        """
-        # Step 1: Create the Python REPL Tool
-        python_tool = PythonAstREPLTool()
-        
-        if python_tool.globals is None:
-            python_tool.globals = {}  # Ensure it's a dictionary
-        
-        # Make DataFrames available inside the REPL tool
-        python_tool.globals.update(dfs) 
-        
-        # New fixes:
-        python_tool.globals["list_globals"] = lambda: list(python_tool.globals.keys()) # type: ignore
-
-        # Step 3: Define Contextualization Chain
-        contextualize_q_system_prompt = """Given a chat history and the latest user question \
-        which might reference context in the chat history, formulate a standalone question \
-        which can be understood without the chat history. Do NOT answer the question, \
-        just reformulate it if needed and otherwise return it as is. \
-        """
-
-        contextualize_prompt = ChatPromptTemplate.from_messages([
-            ("system", contextualize_q_system_prompt),
-            ("human", "Chat History:\n{chat_history}\n\nUser Question:\n{input}"),])
-        
-        # > LangChainDeprecationWarning: The class `LLMChain` was deprecated in LangChain 0.1.17 and will be removed in 1.0. 
-        # Use RunnableSequence, e.g., `prompt | llm` instead.
-        contextualize_chain = LLMChain(llm=llm, prompt=contextualize_prompt, memory=memory)
-
-        # Step 3: Define the Agent Prompt
-        role_hint = ""
+    def _build_role_hint(self) -> str:
         try:
             roles = getattr(self, "roles", None)
             if roles is not None:
@@ -386,7 +357,7 @@ class ProjectChat(ProjectChatProtocol):
                     )
                 else:
                     expr_lines = "- No rows-as-columns expression datasource detected for this project."
-                role_hint = (
+                return (
                     "\n\nDatasource roles:\n"
                     f"- df1 maps to obs datasource '{roles.obs_datasource}'\n"
                     f"{expr_lines}\n"
@@ -401,8 +372,22 @@ class ProjectChat(ProjectChatProtocol):
                     "in RAG).\n"
                 )
         except Exception:
-            role_hint = ""
+            pass
+        return ""
 
+    def _build_agent_executor(
+        self,
+        llm,
+        python_tool: PythonAstREPLTool,
+        dfs: dict,
+        prompt_data,
+        memory,
+        provider: ProviderKind,
+        verbose: bool,
+        *,
+        use_react: bool = False,
+    ) -> AgentExecutor:
+        role_hint = self._build_role_hint()
         prompt_data_template = f"""You have access to the following Pandas DataFrames: 
         {', '.join(dfs.keys())}. These are preloaded, so do not redefine them.
         {role_hint}
@@ -414,29 +399,102 @@ class ProjectChat(ProjectChatProtocol):
         Use `df.info()` or `df.index()`.
         Before running any code, check available variables using `list_globals()`.""" + prompt_data
 
-        prompt = ChatPromptTemplate.from_messages([
-            ("system", prompt_data_template),
-            MessagesPlaceholder(variable_name="chat_history"),
-            ("human", prompt_data_template + "{input}"),
-            ("ai", "{agent_scratchpad}"),
-        ])
+        tools = [python_tool]
+        if use_react:
+            react_prompt = hub.pull("hwchase17/react")
+            system_prefix = prompt_data_template + "\n\n"
+            if hasattr(react_prompt, "template"):
+                react_prompt.template = system_prefix + react_prompt.template
+            agent = create_react_agent(llm, tools, react_prompt)
+        else:
+            prompt = ChatPromptTemplate.from_messages([
+                ("system", prompt_data_template),
+                MessagesPlaceholder(variable_name="chat_history"),
+                ("human", prompt_data_template + "{input}"),
+                ("ai", "{agent_scratchpad}"),
+            ])
+            agent = create_openai_functions_agent(llm, tools, prompt)
 
-        # Step 4: Create the Agent
-        agent = create_openai_functions_agent(llm, [python_tool], prompt)
+        return AgentExecutor(
+            agent=agent,
+            tools=tools,
+            memory=memory,
+            verbose=verbose,
+            return_intermediate_steps=True,
+            handle_parsing_errors=True,
+        )
 
-        # Step 5: Wrap in an Agent Executor (Finalized Agent)
-        agent_executor = AgentExecutor(agent=agent, tools=[python_tool], memory=memory, verbose=verbose, return_intermediate_steps=True)
+    def create_custom_pandas_agent(
+        self,
+        llm,
+        dfs: dict,
+        prompt_data,
+        memory,
+        provider: ProviderKind,
+        verbose=False,
+        on_agent_fallback=None,
+    ):
+        """
+        Creates a LangChain agent that can interact with Pandas DataFrames using a Python REPL tool.
+        """
+        python_tool = PythonAstREPLTool()
 
-        # Step 6: Wrapper Function to Use Contextualization and Preserve Memory
+        if python_tool.globals is None:
+            python_tool.globals = {}
+
+        python_tool.globals.update(dfs)
+        python_tool.globals["list_globals"] = lambda: list(python_tool.globals.keys()) # type: ignore
+
+        contextualize_q_system_prompt = """Given a chat history and the latest user question \
+        which might reference context in the chat history, formulate a standalone question \
+        which can be understood without the chat history. Do NOT answer the question, \
+        just reformulate it if needed and otherwise return it as is. \
+        """
+
+        contextualize_prompt = ChatPromptTemplate.from_messages([
+            ("system", contextualize_q_system_prompt),
+            ("human", "Chat History:\n{chat_history}\n\nUser Question:\n{input}"),])
+
+        contextualize_chain = LLMChain(llm=llm, prompt=contextualize_prompt, memory=memory)
+
+        agent_executor = self._build_agent_executor(
+            llm,
+            python_tool,
+            dfs,
+            prompt_data,
+            memory,
+            provider,
+            verbose,
+            use_react=False,
+        )
+
         def agent_with_contextualization(question):
             standalone_question = contextualize_chain.run(input=question)
-            # Point 1: Log reformulation
             chat_debug_logger.info(f"Original Question: {question}")
             chat_debug_logger.info(f"Standalone Reformulated Question: {standalone_question}")
-            # Point 2: Log what you're sending to the agent
             chat_debug_logger.info(f"Sending to agent_executor with input: {standalone_question}")
-            response = agent_executor.invoke({"input": standalone_question})
-            # Point 3: Log agent output
+            try:
+                response = agent_executor.invoke({"input": standalone_question})
+            except Exception as first_error:
+                if provider != "ollama":
+                    raise
+                chat_debug_logger.warning(
+                    "Ollama functions agent failed; falling back to ReAct: %s",
+                    first_error,
+                )
+                if on_agent_fallback:
+                    on_agent_fallback()
+                fallback_executor = self._build_agent_executor(
+                    llm,
+                    python_tool,
+                    dfs,
+                    prompt_data,
+                    memory,
+                    provider,
+                    verbose,
+                    use_react=True,
+                )
+                response = fallback_executor.invoke({"input": standalone_question})
             chat_debug_logger.info(f"Agent Raw Response: {response}")
             memory.save_context({"input": question}, {"output": response.get("output", str(response))})
             return response
@@ -453,6 +511,11 @@ class ProjectChat(ProjectChatProtocol):
         conversation_id = chat_request["conversation_id"]
         question = chat_request["message"]
         handle_error = chat_request["handle_error"]
+        model_id = chat_request.get("model_id")
+
+        discovered = discover_models()
+        chat_model = discovered.get_chat_model(model_id)
+        embedding_model = resolve_embedding_model(chat_model, discovered)
         
         # Create socket API for this request
         socket_api = ChatSocketAPI(self.project, id, room, conversation_id)
@@ -473,22 +536,30 @@ class ProjectChat(ProjectChatProtocol):
         langchain_logging_handler = LangchainLoggingHandler(socket_api.logger)
         
         with time_block("b6: Initialising LLM for RAG"):
-            code_llm = ChatOpenAI(
-                temperature=0.1, 
-                model="gpt-4.1",
-                callbacks=[langchain_logging_handler]
+            code_llm = create_chat_llm(
+                chat_model,
+                callbacks=[langchain_logging_handler],
             )
         
         with time_block("b7: Initialising LLM for agent"):
-            dataframe_llm = ChatOpenAI(
-                temperature=0.1, 
-                model="gpt-4.1",
-                callbacks=[langchain_logging_handler]
+            dataframe_llm = create_chat_llm(
+                chat_model,
+                callbacks=[langchain_logging_handler],
             )
         # there is a risk that these are out of date by the time we get here...
         # but it's a bit of an expensive operation, so avoiding it for now (in most cases we shouldn't need to refer to them)
         df_list = self.df_list
         
+        progress = 0
+
+        def _notify_agent_fallback() -> None:
+            socket_api.update_chat_progress(
+                "Local model does not support tool calling; using ReAct agent instead.",
+                id,
+                progress,
+                0,
+            )
+
         # Create agent with local LLM and memory
         with time_block("b8: Pandas agent creating"):
             agent = self.create_custom_pandas_agent(
@@ -496,10 +567,11 @@ class ProjectChat(ProjectChatProtocol):
                 {"df1": df_list[0], "df2": df_list[1] if len(df_list) > 1 else df_list[0]}, 
                 prompt_data, 
                 memory,
-                verbose=True
+                chat_model.provider,
+                verbose=True,
+                on_agent_fallback=_notify_agent_fallback,
             )
-        
-        progress = 0
+
         total_steps = 6
 
         def _step_message(step: int, text: str) -> str:
@@ -615,7 +687,7 @@ class ProjectChat(ProjectChatProtocol):
                 qa_chain = RetrievalQA.from_llm(
                     llm=code_llm, 
                     prompt=prompt_RAG_template, 
-                    retriever=_get_rag_retriever(),
+                    retriever=_get_rag_retriever(embedding_model),
                     return_source_documents=True,
                 )
                 output_qa = qa_chain.invoke({"query": rag_retrieval_query})

--- a/python/mdvtools/llm/langchain_mdv.py
+++ b/python/mdvtools/llm/langchain_mdv.py
@@ -44,6 +44,7 @@ from .code_manipulation import (
 )
 from .column_field_resolve import (
     field_set_from_columns,
+    ensure_view_gridstack_layout,
     normalize_view_chart_params,
     prune_view_charts_with_invalid_params,
 )
@@ -1164,6 +1165,7 @@ class ProjectChat(ProjectChatProtocol):
                         pruned, n_dropped = prune_view_charts_with_invalid_params(
                             normalized, self.project
                         )
+                        pruned = ensure_view_gridstack_layout(pruned)
                         if n_dropped:
                             log(
                                 f"pruned {n_dropped} chart(s) with param tokens not in datasource metadata"

--- a/python/mdvtools/llm/langchain_mdv.py
+++ b/python/mdvtools/llm/langchain_mdv.py
@@ -421,7 +421,7 @@ def _resolve_path_to_data(project_dir: str) -> str:
     csv_file = None
     h5ad_file = None
     try:
-        for file in os.listdir(project_dir):
+        for file in sorted(os.listdir(project_dir)):
             if file.endswith(".csv"):
                 csv_file = file
             elif file.endswith(".h5ad"):

--- a/python/mdvtools/llm/langchain_mdv.py
+++ b/python/mdvtools/llm/langchain_mdv.py
@@ -49,6 +49,11 @@ from .column_field_resolve import (
 )
 from .verification import build_verification_summary
 from .datasource_roles import collect_wrapper_subgroup_keys_for_project, infer_datasource_roles
+from .dataset_scale import (
+    assess_project_scale,
+    format_scale_context_block,
+    load_agent_dataframes,
+)
 from .code_execution import execute_code
 from .chat_preview import format_stdout_for_chat
 from .chatlog import LangchainLoggingHandler
@@ -400,6 +405,25 @@ def _get_rag_retriever(embedding_spec: ModelSpec):
     return retriever
 
 
+def _resolve_path_to_data(project_dir: str) -> str:
+    """Prefer .h5ad in the project directory, else .csv, else empty."""
+    csv_file = None
+    h5ad_file = None
+    try:
+        for file in os.listdir(project_dir):
+            if file.endswith(".csv"):
+                csv_file = file
+            elif file.endswith(".h5ad"):
+                h5ad_file = file
+    except OSError:
+        return ""
+    if h5ad_file:
+        return os.path.join(project_dir, h5ad_file)
+    if csv_file:
+        return os.path.join(project_dir, csv_file)
+    return ""
+
+
 class ProjectChat(ProjectChatProtocol):
     def __init__(self, project: MDVProject):
         self.project = project
@@ -436,13 +460,9 @@ class ProjectChat(ProjectChatProtocol):
             # wrapper-capable expression datasources (e.g. rna/protein) linked via rows-as-columns.
             roles = infer_datasource_roles(self.project)
             self.roles = roles
-            df1 = self.project.get_datasource_as_dataframe(roles.obs_datasource)
-            primary_expr = roles.preferred_expression()
-            if primary_expr is not None:
-                df2 = self.project.get_datasource_as_dataframe(primary_expr.datasource_name)
-                self.df_list = [df1, df2]
-            else:
-                self.df_list = [df1]
+            path_to_data = _resolve_path_to_data(self.project.dir)
+            self.scale = assess_project_scale(self.project, path_to_data)
+            self.df_list = load_agent_dataframes(self.project, roles, self.scale)
 
             try:
                 with time_block("b_suggest: Generating suggested questions"):
@@ -491,6 +511,17 @@ class ProjectChat(ProjectChatProtocol):
     def _build_role_hint(self) -> str:
         try:
             roles = getattr(self, "roles", None)
+            scale = getattr(self, "scale", None)
+            scale_hint = ""
+            if scale is not None:
+                scale_hint = (
+                    "\n\nProject scale (memory-aware planning):\n"
+                    + format_scale_context_block(scale)
+                    + "\n- For this project size, plan charts using MDV field ids and expression wrappers. "
+                    "Only suggest Scanpy in the plan if the question requires marker ranking or DE columns "
+                    "not available in MDV metadata.\n"
+                    "- Before suggesting columns, decide: obs metadata only, expression wrappers, or Scanpy markers.\n"
+                )
             if roles is not None:
                 exprs = roles.expressions or []
                 if exprs:
@@ -513,6 +544,7 @@ class ProjectChat(ProjectChatProtocol):
                     "- Do not pair other Scanpy summary tables with MDV wrapper-based expression charts for the "
                     "same metric unless values are guaranteed identical; prefer one pipeline (see ChatMDV viz consistency "
                     "in RAG).\n"
+                    + scale_hint
                 )
         except Exception:
             pass
@@ -534,7 +566,9 @@ class ProjectChat(ProjectChatProtocol):
         prompt_data_template = f"""You have access to the following Pandas DataFrames: 
         {', '.join(dfs.keys())}. These are preloaded, so do not redefine them.
         {role_hint}
-        Before answering any user question, you must first run `df1.columns` and `df2.columns` to inspect available fields. 
+        Before answering any user question, you must first run `df1.columns` and `df2.columns` to inspect available fields.
+        On large projects, df1/df2 may be column subsets for schema probing — use Project Data Context field ids for planning.
+        Prefer MDV chart field ids and expression wrappers; suggest Scanpy only for marker-ranking or DE questions when MDV metadata lacks required columns.
         Use these to correct the column names mentioned by the user.
         Before writing any `project.get_datasource_as_dataframe(datasource_name, columns=[...])` call, you must verify the datasource schema and only request columns that exist on that datasource.
         Never assume a `name` column exists on `cells`; if the task asks for genes/markers, use the expression datasource or explicit marker ranking outputs instead of `cells.name`.
@@ -822,35 +856,11 @@ class ProjectChat(ProjectChatProtocol):
                     step_total=total_steps,
                 )
                 # List all files in the directory
-                files_in_dir = os.listdir(self.project.dir)
-
-                # Initialize variables
-                csv_file = None
-                h5ad_file = None
-
-                # Identify the CSV or H5AD file (optional)
-                # subject to review...
-                for file in files_in_dir:
-                    if file.endswith(".csv"):
-                        csv_file = file
-                    elif file.endswith(".h5ad"):
-                        h5ad_file = file
-
-                # Determine the path_to_data (optional)
-                if h5ad_file:
-                    path_to_data = os.path.join(self.project.dir, h5ad_file)
-                elif csv_file:
-                    path_to_data = os.path.join(self.project.dir, csv_file)
-                else:
-                    path_to_data = ""  # fallback: no external file; operate on existing project datasources
+                path_to_data = _resolve_path_to_data(self.project.dir)
+                self.scale = assess_project_scale(self.project, path_to_data)
 
                 datasource_names = [ds['name'] for ds in self.project.datasources[:2]]  # Get names of up to 2 datasources
 
-                #!!!!!! for now, assuming there will be an anndata.h5ad file in the project directory and will fail ungacefully if there isn't!!!!
-                # we pass a reference to the actual project object and let figuring out the path be an internal implementation detail...
-                # this should be more robust, and also more flexible in terms of what reasoning this method may be able to do internally in the future
-                # I appear to have an issue though - the configuration of the devcontainer doesn't flag whether or not the thing we're passing is the right type
-                # and the assert in the function is being triggered even though it should be fine
                 prompt_RAG = get_createproject_prompt_RAG(
                     self.project,
                     path_to_data,
@@ -858,6 +868,7 @@ class ProjectChat(ProjectChatProtocol):
                     agent_plan,
                     response["input"],
                     compact=chat_model.provider == "ollama",
+                    scale=self.scale,
                 )
                 chat_debug_logger.info(f"=== RAG Base Prompt (before context injection) ===\n{prompt_RAG}\n=== End Base Prompt ===")
 

--- a/python/mdvtools/llm/langchain_mdv.py
+++ b/python/mdvtools/llm/langchain_mdv.py
@@ -126,6 +126,43 @@ chat_debug_handler.setFormatter(formatter)
 # attach the handler
 chat_debug_logger.addHandler(chat_debug_handler)
 
+_REACT_PROMPT_TEMPLATE = (
+    "Answer the following questions as best you can. You have access to the following tools:\n\n"
+    "{tools}\n\n"
+    "Use the following format:\n\n"
+    "Question: the input question you must answer\n"
+    "Thought: you should always think about what to do\n"
+    "Action: the action to take, should be one of [{tool_names}]\n"
+    "Action Input: the input to the action\n"
+    "Observation: the result of the action\n"
+    "... (this Thought/Action/Action Input/Observation can repeat N times)\n"
+    "Thought: I now know the final answer\n"
+    "Final Answer: the final answer to the original input question\n\n"
+    "Begin!\n\n"
+    "Question: {input}\n"
+    "Thought:{agent_scratchpad}"
+)
+_REACT_PROMPT_INPUT_VARIABLES = ["agent_scratchpad", "input", "tool_names", "tools"]
+_react_hub_prompt_cache = None
+
+
+def _get_react_prompt():
+    global _react_hub_prompt_cache
+    if _react_hub_prompt_cache is not None:
+        return _react_hub_prompt_cache
+    try:
+        _react_hub_prompt_cache = hub.pull("hwchase17/react")
+        return _react_hub_prompt_cache
+    except Exception as exc:
+        chat_debug_logger.warning(
+            "Failed to pull ReAct prompt from LangChain Hub; using local template: %s",
+            exc,
+        )
+        return PromptTemplate(
+            template=_REACT_PROMPT_TEMPLATE,
+            input_variables=_REACT_PROMPT_INPUT_VARIABLES,
+        )
+
 
 _CHART_CLASS_RE = re.compile(
     r"\b(DotPlot|ScatterPlot|HeatmapPlot|HistogramPlot|BoxPlot|ViolinPlot|"
@@ -595,7 +632,7 @@ class ProjectChat(ProjectChatProtocol):
 
         tools = [python_tool]
         if use_react:
-            react_prompt = hub.pull("hwchase17/react")
+            react_prompt = _get_react_prompt()
             system_prefix = prompt_data_template + "\n\n"
             if hasattr(react_prompt, "template"):
                 react_prompt.template = system_prefix + react_prompt.template

--- a/python/mdvtools/llm/langchain_mdv.py
+++ b/python/mdvtools/llm/langchain_mdv.py
@@ -36,6 +36,7 @@ from langchain.chains import LLMChain
 from .local_files_utils import crawl_local_repo, extract_python_code_from_py, extract_python_code_from_ipynb
 from .templates import get_createproject_prompt_RAG, prompt_data
 from .code_manipulation import (
+    extract_code_from_response,
     extract_explanation_from_response,
     parse_view_name,
     prepare_code,
@@ -176,6 +177,148 @@ def _build_rag_retrieval_query(user_question: str, charts_part: str) -> str:
     if question and charts:
         return f"User question: {question}\nSuggested chart types: {charts}"
     return question or charts
+
+
+_FIELDS_CHARTS_LINE_RE = re.compile(r"^\s*(fields|charts)\s+", re.IGNORECASE | re.MULTILINE)
+
+
+def _agent_fields_charts_output_valid(output: str) -> bool:
+    """True when the pandas agent returned a non-empty fields/charts plan."""
+    text = (output or "").strip()
+    if not text:
+        return False
+    return bool(_FIELDS_CHARTS_LINE_RE.search(text))
+
+
+def _extract_fields_charts_plan(text: str) -> str:
+    """Return fields/charts lines from agent text, ignoring ReAct scaffolding."""
+    lines: list[str] = []
+    for line in (text or "").splitlines():
+        stripped = line.strip()
+        lower = stripped.lower()
+        if lower.startswith("fields ") or lower.startswith("charts "):
+            lines.append(stripped)
+    return "\n".join(lines)
+
+
+def _resolve_agent_plan(response: dict) -> str:
+    """Resolve the agent fields/charts plan from output or ReAct intermediate steps."""
+    output = str(response.get("output", "") or "")
+    if _agent_fields_charts_output_valid(output):
+        plan = _extract_fields_charts_plan(output)
+        return plan or output.strip()
+
+    for step in response.get("intermediate_steps") or []:
+        if not step:
+            continue
+        action = step[0]
+        for candidate in (
+            getattr(action, "log", ""),
+            str(getattr(action, "tool_input", "") or ""),
+        ):
+            if _agent_fields_charts_output_valid(candidate):
+                plan = _extract_fields_charts_plan(candidate)
+                if plan:
+                    return plan
+
+    return output.strip()
+
+
+def _infer_chart_types_from_question(question: str) -> str:
+    """Best-effort chart hints from the user question when the agent plan is missing."""
+    q = question.lower()
+    hints: list[str] = []
+    rules: list[tuple[tuple[str, ...], str]] = [
+        (("heatmap",), "Heatmap"),
+        (("violin",), "Violin plot"),
+        (("histogram",), "Histogram"),
+        (("dot plot", "dotplot"), "Dot plot"),
+        (("box plot", "boxplot"), "Box plot"),
+        (("pca", "3d"), "Scatter plot (3D)"),
+        (("umap", "scatter"), "Scatter plot (2D)"),
+        (("density scatter",), "Density Scatter plot"),
+        (("sankey",), "Sankey plot"),
+        (("pie chart", "pie plot"), "Pie Chart"),
+        (("table", "list", "count", "how many"), "Table Plot"),
+    ]
+    for keywords, chart in rules:
+        if any(k in q for k in keywords) and chart not in hints:
+            hints.append(chart)
+    if not hints:
+        hints.append("Scatter plot (2D)")
+    return ", ".join(hints)
+
+
+def _fallback_agent_plan(question: str) -> str:
+    """Minimal plan stub when datasource agent output is unusable but RAG can proceed."""
+    charts = _infer_chart_types_from_question(question)
+    return (
+        'fields "(infer from Project Data Context — datasource agent plan unavailable)"\n'
+        f'charts "{charts}"'
+    )
+
+
+def _rag_source_doc_names(output_qa: dict) -> str:
+    docs = output_qa.get("source_documents") or []
+    names: list[str] = []
+    for doc in docs:
+        meta = getattr(doc, "metadata", None) or {}
+        url = meta.get("url", "")
+        if url:
+            names.append(os.path.basename(str(url)))
+    return ", ".join(names) if names else "(none)"
+
+
+_RAG_EMPTY_RETRY_SUFFIX = (
+    "\n\nReturn only one fenced ```python code block with the complete runnable script."
+)
+
+
+def _invoke_rag_with_empty_retry(
+    qa_chain,
+    rag_retrieval_query: str,
+    chat_model: ModelSpec,
+    model_id: Optional[str],
+) -> tuple[dict, str]:
+    """Run RAG once; retry once with a short instruction if result is empty."""
+    output_qa = qa_chain.invoke({"query": rag_retrieval_query})
+    result = (output_qa.get("result") or "").strip()
+    if result:
+        return output_qa, result
+
+    chat_debug_logger.warning(
+        "RAG returned empty result (model_id=%s provider=%s model=%s sources=%s); retrying once",
+        model_id or chat_model.id,
+        chat_model.provider,
+        chat_model.model,
+        _rag_source_doc_names(output_qa),
+    )
+    retry_query = rag_retrieval_query + _RAG_EMPTY_RETRY_SUFFIX
+    output_qa_retry = qa_chain.invoke({"query": retry_query})
+    result_retry = (output_qa_retry.get("result") or "").strip()
+    if result_retry:
+        return output_qa_retry, result_retry
+
+    raise ValueError(
+        "Code generation returned empty output "
+        f"(model_id={model_id or chat_model.id}, provider={chat_model.provider}, "
+        f"model={chat_model.model}, sources={_rag_source_doc_names(output_qa_retry)}). "
+        "Try a coding-focused Ollama model (e.g. qwen2.5-coder) or OpenAI."
+    )
+
+
+def _raise_if_no_extracted_code(result: str, final_code: str) -> None:
+    """Raise when prepare_code produced a stub instead of runnable Python."""
+    if "# WARNING:::: No code captured" in final_code:
+        raise ValueError(
+            "Code generation did not produce runnable Python. "
+            "The model returned no fenced ```python block."
+        )
+    if not extract_code_from_response(result):
+        raise ValueError(
+            "Code generation did not produce runnable Python. "
+            "The model returned no fenced ```python block."
+        )
 
 
 class SuggestedQuestions(BaseModel):
@@ -473,14 +616,10 @@ class ProjectChat(ProjectChatProtocol):
             chat_debug_logger.info(f"Original Question: {question}")
             chat_debug_logger.info(f"Standalone Reformulated Question: {standalone_question}")
             chat_debug_logger.info(f"Sending to agent_executor with input: {standalone_question}")
-            try:
-                response = agent_executor.invoke({"input": standalone_question})
-            except Exception as first_error:
-                if provider != "ollama":
-                    raise
+
+            def _run_react_fallback() -> dict:
                 chat_debug_logger.warning(
-                    "Ollama functions agent failed; falling back to ReAct: %s",
-                    first_error,
+                    "Ollama agent falling back to ReAct for datasource inspection"
                 )
                 if on_agent_fallback:
                     on_agent_fallback()
@@ -494,7 +633,26 @@ class ProjectChat(ProjectChatProtocol):
                     verbose,
                     use_react=True,
                 )
-                response = fallback_executor.invoke({"input": standalone_question})
+                return fallback_executor.invoke({"input": standalone_question})
+
+            try:
+                response = agent_executor.invoke({"input": standalone_question})
+            except Exception as first_error:
+                if provider != "ollama":
+                    raise
+                chat_debug_logger.warning(
+                    "Ollama functions agent failed; falling back to ReAct: %s",
+                    first_error,
+                )
+                response = _run_react_fallback()
+            else:
+                if provider == "ollama" and not _agent_fields_charts_output_valid(
+                    _resolve_agent_plan(response)
+                ):
+                    chat_debug_logger.warning(
+                        "Ollama functions agent returned no field/chart plan; falling back to ReAct"
+                    )
+                    response = _run_react_fallback()
             chat_debug_logger.info(f"Agent Raw Response: {response}")
             memory.save_context({"input": question}, {"output": response.get("output", str(response))})
             return response
@@ -516,10 +674,16 @@ class ProjectChat(ProjectChatProtocol):
         discovered = discover_models()
         chat_model = discovered.get_chat_model(model_id)
         embedding_model = resolve_embedding_model(chat_model, discovered)
-        
+
         # Create socket API for this request
         socket_api = ChatSocketAPI(self.project, id, room, conversation_id)
         log = chat_debug_logger.info
+        request_model_line = (
+            f"model_id={chat_model.id} provider={chat_model.provider} "
+            f"model={chat_model.model} embedding={embedding_model.model}"
+        )
+        chat_debug_logger.info(request_model_line)
+        socket_api.logger.info(request_model_line)
         chat_debug_logger.info("Asking question: %s", question)
 
         if question == "test error":
@@ -555,6 +719,14 @@ class ProjectChat(ProjectChatProtocol):
         def _notify_agent_fallback() -> None:
             socket_api.update_chat_progress(
                 "Local model does not support tool calling; using ReAct agent instead.",
+                id,
+                progress,
+                0,
+            )
+
+        if chat_model.provider == "ollama":
+            socket_api.update_chat_progress(
+                "Local model uses functions agent first; ReAct only if needed.",
                 id,
                 progress,
                 0,
@@ -621,8 +793,25 @@ class ProjectChat(ProjectChatProtocol):
                     step_total=total_steps,
                 )
                 response = agent(question)
-                chat_debug_logger.info(f"Agent Response - output: {response['output']}")
-            
+                agent_plan = _resolve_agent_plan(response)
+                chat_debug_logger.info(f"Agent Response - output: {response.get('output', '')}")
+                chat_debug_logger.info(f"Agent resolved plan: {agent_plan}")
+                if not _agent_fields_charts_output_valid(agent_plan):
+                    if question.strip():
+                        chat_debug_logger.warning(
+                            "Agent returned no field/chart plan; continuing with question-only "
+                            "RAG fallback. Raw response: %r",
+                            response,
+                        )
+                        agent_plan = _fallback_agent_plan(question)
+                        chat_debug_logger.info("Agent fallback plan: %s", agent_plan)
+                    else:
+                        chat_debug_logger.error("Agent returned invalid output: %r", response)
+                        raise ValueError(
+                            "Datasource agent returned no field/chart plan. "
+                            "Try a coding-focused Ollama model (e.g. qwen2.5-coder) or OpenAI."
+                        )
+
             with time_block("b11: RAG prompt preparation"):  # ~0.003% of time
                 socket_api.update_chat_progress(
                     _step_message(3, "Preparing analysis context"),
@@ -662,7 +851,14 @@ class ProjectChat(ProjectChatProtocol):
                 # this should be more robust, and also more flexible in terms of what reasoning this method may be able to do internally in the future
                 # I appear to have an issue though - the configuration of the devcontainer doesn't flag whether or not the thing we're passing is the right type
                 # and the assert in the function is being triggered even though it should be fine
-                prompt_RAG = get_createproject_prompt_RAG(self.project, path_to_data, datasource_names[0], response['output'], response['input'])
+                prompt_RAG = get_createproject_prompt_RAG(
+                    self.project,
+                    path_to_data,
+                    datasource_names[0],
+                    agent_plan,
+                    response["input"],
+                    compact=chat_model.provider == "ollama",
+                )
                 chat_debug_logger.info(f"=== RAG Base Prompt (before context injection) ===\n{prompt_RAG}\n=== End Base Prompt ===")
 
                 prompt_RAG_template = PromptTemplate(
@@ -680,8 +876,8 @@ class ProjectChat(ProjectChatProtocol):
                 )
                 progress += 60
 
-                match = re.search(r'charts\s+(.*)', response['output'])
-                charts_part = match.group(1) if match else response['output']
+                match = re.search(r'charts\s+(.*)', agent_plan)
+                charts_part = match.group(1) if match else agent_plan
                 rag_retrieval_query = _build_rag_retrieval_query(question, charts_part)
 
                 qa_chain = RetrievalQA.from_llm(
@@ -690,7 +886,12 @@ class ProjectChat(ProjectChatProtocol):
                     retriever=_get_rag_retriever(embedding_model),
                     return_source_documents=True,
                 )
-                output_qa = qa_chain.invoke({"query": rag_retrieval_query})
+                output_qa, result = _invoke_rag_with_empty_retry(
+                    qa_chain,
+                    rag_retrieval_query,
+                    chat_model,
+                    model_id,
+                )
                 # Log the complete prompt after context injection
                 if "source_documents" in output_qa:
                     retrieved_context = "\n".join(doc.page_content for doc in output_qa["source_documents"])
@@ -698,7 +899,6 @@ class ProjectChat(ProjectChatProtocol):
                         context=retrieved_context, question=rag_retrieval_query
                     )
                     chat_debug_logger.info(f"=== Complete RAG Prompt (with injected context) ===\n{complete_prompt}\n=== End Complete Prompt ===")
-                result = output_qa["result"]
 
             with time_block("b13: Prepare code"):  # <0.1% of time
                 final_code = prepare_code(
@@ -797,6 +997,8 @@ class ProjectChat(ProjectChatProtocol):
                     allowed_wrapper_subgroup_keys=allowed_wrapper_subgroup_keys,
                 )
                 chat_debug_logger.info("Preflight metadata: %s", preflight_meta)
+
+            _raise_if_no_extracted_code(result, final_code)
 
             chat_debug_logger.info(f"Prepared Code for Execution:\n{final_code}")
             chat_debug_logger.info(f"RAG output:\n{output_qa}")

--- a/python/mdvtools/llm/langchain_mdv.py
+++ b/python/mdvtools/llm/langchain_mdv.py
@@ -47,7 +47,11 @@ from .column_field_resolve import (
     normalize_view_chart_params,
     prune_view_charts_with_invalid_params,
 )
-from .verification import build_verification_summary
+from .verification import build_verification_summary, parse_datasource_name
+from .guidance import (
+    append_guidance_textbox_to_view,
+    build_response_guidance,
+)
 from .datasource_roles import (
     build_datasource_field_index,
     collect_wrapper_subgroup_keys_for_project,
@@ -826,6 +830,7 @@ class ProjectChat(ProjectChatProtocol):
                 "message": "Success",
                 "verification": None,
                 "data_preview": format_stdout_for_chat(strdout),
+                "guidance": None,
                 "needs_refresh": False,
             }
         
@@ -1172,6 +1177,45 @@ class ProjectChat(ProjectChatProtocol):
                         exc_info=True,
                     )
 
+            guidance_text = ""
+            with time_block("b15d: Analysis summary (guidance TextBox + chat echo)"):
+                try:
+                    guidance_text = build_response_guidance(
+                        self.project,
+                        question,
+                        final_code,
+                        view_name,
+                        agent_plan,
+                        data_preview_text,
+                    )
+                    ds_for_summary = parse_datasource_name(final_code)
+                    if not ds_for_summary and view_name:
+                        try:
+                            view_for_ds = self.project.get_view(view_name)
+                            ic = (
+                                view_for_ds.get("initialCharts")
+                                if isinstance(view_for_ds, dict)
+                                else None
+                            )
+                            if isinstance(ic, dict) and ic:
+                                ds_for_summary = next(iter(ic.keys()), None)
+                        except Exception:
+                            ds_for_summary = None
+                    if view_name and ds_for_summary and guidance_text.strip():
+                        append_guidance_textbox_to_view(
+                            self.project,
+                            view_name,
+                            ds_for_summary,
+                            guidance_text,
+                        )
+                except Exception as guide_ex:
+                    chat_debug_logger.warning(
+                        "build_response_guidance failed for view %s: %s",
+                        view_name,
+                        guide_ex,
+                        exc_info=True,
+                    )
+
             verification_text = ""
             with time_block("b15b: Verification summary"):
                 try:
@@ -1224,6 +1268,7 @@ class ProjectChat(ProjectChatProtocol):
                     view_name=view_name,
                     verification=verification_text or None,
                     data_preview=data_preview_text,
+                    guidance=guidance_text or None,
                 )
                 log(final_code_updated)
                 socket_api.update_chat_progress(
@@ -1242,6 +1287,7 @@ class ProjectChat(ProjectChatProtocol):
                     "message": "Success",
                     "verification": verification_text or None,
                     "data_preview": data_preview_text,
+                    "guidance": guidance_text or None,
                     "needs_refresh": client_needs_refresh_after_chat(final_code),
                 }
         except Exception as e:
@@ -1264,5 +1310,6 @@ class ProjectChat(ProjectChatProtocol):
                 "message": f"ERROR: {error_message}",
                 "verification": None,
                 "data_preview": None,
+                "guidance": None,
                 "needs_refresh": False,
             }

--- a/python/mdvtools/llm/langchain_mdv.py
+++ b/python/mdvtools/llm/langchain_mdv.py
@@ -776,7 +776,7 @@ class ProjectChat(ProjectChatProtocol):
             f"model={chat_model.model} embedding={embedding_model.model}"
         )
         chat_debug_logger.info(request_model_line)
-        socket_api.logger.info(request_model_line)
+        socket_api.log_file_only(request_model_line)
         chat_debug_logger.info("Asking question: %s", question)
 
         if question == "test error":

--- a/python/mdvtools/llm/llm_providers.py
+++ b/python/mdvtools/llm/llm_providers.py
@@ -1,0 +1,304 @@
+"""LLM provider discovery and factory helpers for ChatMDV."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any, Literal, Optional
+
+import requests
+from dotenv import load_dotenv
+from langchain_core.callbacks import BaseCallbackHandler
+from langchain_openai import ChatOpenAI, OpenAIEmbeddings
+
+from mdvtools._optional import require_extra
+
+require_extra("app", "langchain_community")
+
+from langchain_community.embeddings import OllamaEmbeddings  # noqa: E402
+
+ProviderKind = Literal["openai", "ollama"]
+ModelKind = Literal["chat", "embedding"]
+
+OPENAI_CHAT_MODELS = ("gpt-4.1", "gpt-4o", "gpt-4o-mini")
+OPENAI_EMBEDDING_MODEL = "text-embedding-3-large"
+
+DEFAULT_OLLAMA_BASE_URL = "http://localhost:11434"
+DEFAULT_OLLAMA_EMBEDDING_MODEL = "nomic-embed-text"
+
+# Common Ollama embedding model name substrings when capabilities are absent.
+_EMBEDDING_NAME_HINTS = ("embed", "nomic", "mxbai", "bge")
+
+
+@dataclass(frozen=True)
+class ModelSpec:
+    id: str
+    label: str
+    provider: ProviderKind
+    model: str
+    kind: ModelKind
+    available: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "label": self.label,
+            "provider": self.provider,
+            "model": self.model,
+            "kind": self.kind,
+            "available": self.available,
+        }
+
+
+def _model_id(provider: ProviderKind, model: str, kind: ModelKind) -> str:
+    return f"{provider}:{kind}:{model}"
+
+
+def _default_ollama_base_url() -> str:
+    """Default Ollama URL; inside Docker, localhost is the container, not the host."""
+    if os.path.exists("/.dockerenv"):
+        return "http://host.docker.internal:11434"
+    return DEFAULT_OLLAMA_BASE_URL
+
+
+def _ollama_base_url() -> str:
+    load_dotenv()
+    explicit = os.getenv("OLLAMA_BASE_URL")
+    if explicit:
+        return explicit.rstrip("/")
+    return _default_ollama_base_url()
+
+
+def _ollama_embedding_model_name() -> str:
+    load_dotenv()
+    return os.getenv("OLLAMA_EMBEDDING_MODEL", DEFAULT_OLLAMA_EMBEDDING_MODEL)
+
+
+def _has_openai_api_key() -> bool:
+    load_dotenv()
+    return bool(os.getenv("OPENAI_API_KEY"))
+
+
+def _fetch_ollama_tags(base_url: str) -> list[dict[str, Any]]:
+    try:
+        response = requests.get(f"{base_url}/api/tags", timeout=3)
+        response.raise_for_status()
+        payload = response.json()
+        models = payload.get("models", [])
+        if isinstance(models, list):
+            return [m for m in models if isinstance(m, dict)]
+    except (requests.RequestException, ValueError):
+        pass
+    return []
+
+
+def _ollama_capabilities(entry: dict[str, Any]) -> set[str]:
+    raw = entry.get("capabilities")
+    if isinstance(raw, list):
+        return {str(item).lower() for item in raw}
+    return set()
+
+
+def _is_ollama_embedding_model(name: str, entry: dict[str, Any]) -> bool:
+    caps = _ollama_capabilities(entry)
+    if caps:
+        return "embedding" in caps and "completion" not in caps
+    lowered = name.lower()
+    return any(hint in lowered for hint in _EMBEDDING_NAME_HINTS)
+
+
+def _is_ollama_chat_model(name: str, entry: dict[str, Any]) -> bool:
+    caps = _ollama_capabilities(entry)
+    if caps:
+        if "embedding" in caps and "completion" not in caps:
+            return False
+        return "completion" in caps or "vision" in caps or not caps
+    return not _is_ollama_embedding_model(name, entry)
+
+
+def _openai_chat_models() -> list[ModelSpec]:
+    if not _has_openai_api_key():
+        return []
+    return [
+        ModelSpec(
+            id=_model_id("openai", model, "chat"),
+            label=f"OpenAI {model}",
+            provider="openai",
+            model=model,
+            kind="chat",
+        )
+        for model in OPENAI_CHAT_MODELS
+    ]
+
+
+def _openai_embedding_model() -> ModelSpec:
+    return ModelSpec(
+        id=_model_id("openai", OPENAI_EMBEDDING_MODEL, "embedding"),
+        label=f"OpenAI {OPENAI_EMBEDDING_MODEL}",
+        provider="openai",
+        model=OPENAI_EMBEDDING_MODEL,
+        kind="embedding",
+        available=_has_openai_api_key(),
+    )
+
+
+def _ollama_models_from_tags(tags: list[dict[str, Any]]) -> tuple[list[ModelSpec], list[ModelSpec]]:
+    chat_models: list[ModelSpec] = []
+    embedding_models: list[ModelSpec] = []
+    for entry in tags:
+        name = entry.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+        if _is_ollama_embedding_model(name, entry):
+            embedding_models.append(
+                ModelSpec(
+                    id=_model_id("ollama", name, "embedding"),
+                    label=f"Ollama {name}",
+                    provider="ollama",
+                    model=name,
+                    kind="embedding",
+                )
+            )
+        if _is_ollama_chat_model(name, entry):
+            chat_models.append(
+                ModelSpec(
+                    id=_model_id("ollama", name, "chat"),
+                    label=f"Ollama {name}",
+                    provider="ollama",
+                    model=name,
+                    kind="chat",
+                )
+            )
+    return chat_models, embedding_models
+
+
+@dataclass
+class DiscoveredModels:
+    chat_models: list[ModelSpec]
+    embedding_models: list[ModelSpec]
+    default_model_id: Optional[str]
+
+    def all_models(self) -> list[ModelSpec]:
+        return [*self.chat_models, *self.embedding_models]
+
+    def get_chat_model(self, model_id: Optional[str]) -> ModelSpec:
+        if model_id:
+            for spec in self.chat_models:
+                if spec.id == model_id:
+                    return spec
+        if self.default_model_id:
+            for spec in self.chat_models:
+                if spec.id == self.default_model_id:
+                    return spec
+        if self.chat_models:
+            return self.chat_models[0]
+        raise ValueError(
+            "No chat models are available. Set OPENAI_API_KEY or start Ollama "
+            f"({DEFAULT_OLLAMA_BASE_URL}). In Docker, set OLLAMA_BASE_URL to reach the host."
+        )
+
+
+def discover_models() -> DiscoveredModels:
+    """Probe OpenAI env and Ollama /api/tags for available models."""
+    chat_models = _openai_chat_models()
+    embedding_models: list[ModelSpec] = []
+    if _has_openai_api_key():
+        embedding_models.append(_openai_embedding_model())
+
+    ollama_tags = _fetch_ollama_tags(_ollama_base_url())
+    ollama_chat, ollama_embed = _ollama_models_from_tags(ollama_tags)
+    chat_models.extend(ollama_chat)
+    embedding_models.extend(ollama_embed)
+
+    load_dotenv()
+    default_env = os.getenv("CHATMDV_DEFAULT_MODEL")
+    default_model_id: Optional[str] = None
+    if default_env:
+        for spec in chat_models:
+            if spec.id == default_env or spec.model == default_env:
+                default_model_id = spec.id
+                break
+    if default_model_id is None and chat_models:
+        default_model_id = chat_models[0].id
+
+    return DiscoveredModels(
+        chat_models=chat_models,
+        embedding_models=embedding_models,
+        default_model_id=default_model_id,
+    )
+
+
+def ensure_any_provider_available() -> None:
+    """Raise if neither OpenAI nor Ollama chat models are reachable."""
+    discovered = discover_models()
+    if not discovered.chat_models:
+        raise ValueError(
+            "No LLM providers are available. Set OPENAI_API_KEY or start Ollama "
+            f"at {_ollama_base_url()}. In Docker, set OLLAMA_BASE_URL to reach the host."
+        )
+
+
+def resolve_embedding_model(
+    chat_model: ModelSpec,
+    discovered: Optional[DiscoveredModels] = None,
+) -> ModelSpec:
+    """Pair a chat model with its embedding backend for RAG."""
+    if discovered is None:
+        discovered = discover_models()
+
+    if chat_model.provider == "openai":
+        spec = _openai_embedding_model()
+        if not spec.available:
+            raise ValueError(
+                "OpenAI embeddings require OPENAI_API_KEY. "
+                "Select an Ollama chat model for a fully local setup."
+            )
+        return spec
+
+    preferred_name = _ollama_embedding_model_name()
+    for spec in discovered.embedding_models:
+        if spec.provider == "ollama" and spec.model == preferred_name:
+            return spec
+    for spec in discovered.embedding_models:
+        if spec.provider == "ollama":
+            return spec
+    raise ValueError(
+        f"No Ollama embedding model is available for RAG. "
+        f"Pull one with: ollama pull {preferred_name}"
+    )
+
+
+def create_chat_llm(
+    model: ModelSpec,
+    callbacks: Optional[list[BaseCallbackHandler]] = None,
+) -> ChatOpenAI:
+    """Create a LangChain chat model for the given spec."""
+    cb = callbacks or []
+    if model.provider == "openai":
+        if not _has_openai_api_key():
+            raise ValueError("OPENAI_API_KEY is not set.")
+        return ChatOpenAI(
+            temperature=0.1,
+            model=model.model,
+            callbacks=cb,
+        )
+    base_url = f"{_ollama_base_url()}/v1"
+    return ChatOpenAI(
+        temperature=0.1,
+        model=model.model,
+        base_url=base_url,
+        api_key="ollama",
+        callbacks=cb,
+    )
+
+
+def create_embeddings(model: ModelSpec):
+    """Create a LangChain embeddings instance for the given spec."""
+    if model.provider == "openai":
+        if not _has_openai_api_key():
+            raise ValueError("OPENAI_API_KEY is not set.")
+        return OpenAIEmbeddings(model=model.model)
+    return OllamaEmbeddings(
+        model=model.model,
+        base_url=_ollama_base_url(),
+    )

--- a/python/mdvtools/llm/llm_providers.py
+++ b/python/mdvtools/llm/llm_providers.py
@@ -228,6 +228,26 @@ def discover_models() -> DiscoveredModels:
     )
 
 
+def resolve_chat_model_id(model: Optional[str]) -> Optional[str]:
+    """Resolve a CLI/API model selector to a canonical chat model id.
+
+    Accepts full ids (``openai:chat:gpt-4.1``) or bare model names (``gpt-4.1``).
+    Returns ``None`` when ``model`` is empty so callers use ``CHATMDV_DEFAULT_MODEL``
+    / discovery defaults.
+    """
+    if model is None:
+        return None
+    raw = model.strip()
+    if not raw:
+        return None
+    discovered = discover_models()
+    for spec in discovered.chat_models:
+        if spec.id == raw or spec.model == raw:
+            return spec.id
+    available = ", ".join(spec.id for spec in discovered.chat_models) or "(none)"
+    raise ValueError(f"Unknown chat model {raw!r}. Available: {available}")
+
+
 def ensure_any_provider_available() -> None:
     """Raise if neither OpenAI nor Ollama chat models are reachable."""
     discovered = discover_models()

--- a/python/mdvtools/llm/llm_providers.py
+++ b/python/mdvtools/llm/llm_providers.py
@@ -8,6 +8,7 @@ from typing import Any, Literal, Optional
 
 import requests
 from dotenv import load_dotenv
+from pydantic import SecretStr
 from langchain_core.callbacks import BaseCallbackHandler
 from langchain_openai import ChatOpenAI, OpenAIEmbeddings
 
@@ -307,7 +308,7 @@ def create_chat_llm(
         temperature=0.1,
         model=model.model,
         base_url=base_url,
-        api_key="ollama",
+        api_key=SecretStr("ollama"),
         callbacks=cb,
     )
 

--- a/python/mdvtools/llm/templates.py
+++ b/python/mdvtools/llm/templates.py
@@ -11,11 +11,13 @@ from mdvtools.llm.datasource_roles import (
     format_marker_ranking_viz_policy,
     format_metadata_column_schema_policy,
     format_mdv_first_data_access_policy,
+    format_multi_table_tabular_policy,
     format_no_hallucination_chart_policy,
     format_obs_table_chart_param_policy,
     format_scanpy_hybrid_routing_policy,
     format_targeted_chart_policies,
     format_visualization_consistency_policy,
+    is_multi_table_tabular_project,
 )
 prompt_data = """
 Your task is to:  
@@ -121,6 +123,36 @@ import sys
 #     return json.loads(json.dumps(plot.plot_data, indent=2).replace("\\\\", ""))
 
 
+def _build_rag_context_markdown(project: CreateProjectPromptProject, datasource_name: str) -> str:
+    """Project Data Context block for RAG prompts."""
+    try:
+        names = list(project.get_datasource_names())
+    except Exception:
+        names = []
+
+    has_cells = "cells" in names
+    if len(names) > 1 and not has_cells:
+        try:
+            ds_meta = project.get_datasource_metadata(datasource_name)
+            primary = (
+                f"## Primary datasource for this question: **{datasource_name}** "
+                f"({ds_meta['size']} rows)\n\n"
+                + create_column_markdown(ds_meta["columns"])
+            )
+        except Exception:
+            primary = f"## Primary datasource for this question: **{datasource_name}**\n\n"
+        all_tables = create_project_markdown(project, wrap_in_details=False)
+        return primary + "\n\n## All project datasources\n\n" + all_tables
+
+    try:
+        ds_meta = project.get_datasource_metadata(datasource_name)
+        return (
+            f"## **{datasource_name}:** ({ds_meta['size']} rows)\n\n"
+            + create_column_markdown(ds_meta["columns"])
+        )
+    except Exception:
+        return create_project_markdown(project)
+
 
 def get_createproject_prompt_RAG(
     project: CreateProjectPromptProject,
@@ -142,13 +174,21 @@ def get_createproject_prompt_RAG(
         scale, path_to_data, compact=compact
     )
     chart_policies = format_targeted_chart_policies(compact=compact)
-    # Build markdown context for the selected datasource; fall back to whole project if needed
-    try:
-        ds_meta = project.get_datasource_metadata(datasource_name)
-        context_md = f"## **{datasource_name}:** ({ds_meta['size']} rows)\n\n" + create_column_markdown(ds_meta["columns"])
-    except Exception:
-        context_md = create_project_markdown(project)
     roles = infer_datasource_roles(project)
+    multi_table_policy = ""
+    if is_multi_table_tabular_project(project, roles):
+        multi_table_policy = format_multi_table_tabular_policy()
+    context_md = _build_rag_context_markdown(project, datasource_name)
+    datasource_name_guidance = (
+        f"- datasource_name = '{datasource_name}'  "
+        "(use this datasource for charts and dataframe loads when it matches the user question; "
+        "do not substitute CHATMDV_OBS_DATASOURCE when the user names a different table)\n"
+    )
+    datasource_name_guidance_indented = (
+        f"            - datasource_name = '{datasource_name}'  "
+        "(use this datasource for charts and dataframe loads when it matches the user question; "
+        "do not substitute CHATMDV_OBS_DATASOURCE when the user names a different table)\n"
+    )
     if compact:
         expr_lines = ""
         if roles.expressions:
@@ -176,6 +216,7 @@ def get_createproject_prompt_RAG(
             + """
 
 """
+            + multi_table_policy
             + mdv_first_policy
             + """
 
@@ -210,10 +251,9 @@ def get_createproject_prompt_RAG(
     - data_path = '"""
             + path_to_data
             + """'
-    - datasource_name = '"""
-            + datasource_name
-            + """'
-    - view_name = a descriptive string for the visualization.
+    """
+            + datasource_name_guidance
+            + """    - view_name = a descriptive string for the visualization.
 
     Chart type requirements (use agent-suggested types when valid):
     - Abundance Box plot: three categorical columns (repeat if fewer available).
@@ -271,7 +311,7 @@ def get_createproject_prompt_RAG(
         - When modifying an existing project (the default in this chat context), do NOT recreate or delete the project.
 
     2. Data Access (MDV-first; Scanpy last resort):
-"""+mdv_first_policy+"""
+"""+mdv_first_policy+multi_table_policy+"""
         - Observation/metadata datasource: `"""+roles.obs_datasource+"""`
         - Wrapper-capable expression datasources (feature tables):
 """+expr_lines+"""
@@ -423,7 +463,7 @@ def get_createproject_prompt_RAG(
             - project_path = '"""+project.dir+"""'
             - data_path = '"""+path_to_data+"""'  # may be empty; if empty or HAS_SCANPY is False, DO NOT use scanpy except for marker-gene workflows when this path is a `.h5ad` file (see section 2).
             - view_name = a string, in double quotes, describing what is being visualized.
-            - datasource_name = '"""+datasource_name+"""'
+            """+datasource_name_guidance_indented+"""
         - The possible charts are given by """+final_answer+""" and should follow the following visualisation guidelines for each type of chart:
             - Abundance Box plot: Requires three categorical columns.  
                 - If only one categorical variable is available, use it three times.  

--- a/python/mdvtools/llm/templates.py
+++ b/python/mdvtools/llm/templates.py
@@ -51,7 +51,7 @@ Your task is to:
     - Dot plot: Requires only one categorical column and any number of numerical columns.  
     - Heatmap: Requires only one categorical column and any number of numerical columns.  
     - Histogram: Requires one numerical column.  
-    - Multiline chart: Requires one numerical column and one categorical column.  
+    - Multiline chart (`MultiLinePlot`): Requires one numerical column and one categorical column.  
     - Pie Chart: Requires one categorical column.  
     - Row Chart: Requires one categorical column.  
     - Row summary box: Requires any column(s).  
@@ -287,7 +287,7 @@ def get_createproject_prompt_RAG(
     - Density Scatter plot: two numerical + one categorical column.
     - Dot plot / Heatmap: one categorical + numerical columns.
     - Histogram: one numerical column.
-    - Multiline chart: one numerical + one categorical column.
+    - Multiline chart (`MultiLinePlot`): one numerical + one categorical column.
     - Pie Chart / Row Chart / Wordcloud: one categorical column.
     - Row summary box / Table Plot: any column(s).
     - Sankey / Stacked row chart: two categorical columns (repeat if only one).
@@ -500,7 +500,7 @@ def get_createproject_prompt_RAG(
             - Dot plot: Requires only one categorical column and any number of numerical columns.  
             - Heatmap: Requires only one categorical column and any number of numerical columns.  
             - Histogram: Requires one numerical column.  
-            - Multiline chart: Requires one numerical column and one categorical column.  
+            - Multiline chart (`MultiLinePlot`): Requires one numerical column and one categorical column.  
             - Pie Chart: Requires one categorical column.  
             - Row Chart: Requires one categorical column.  
             - Row summary box: Requires any column(s).  

--- a/python/mdvtools/llm/templates.py
+++ b/python/mdvtools/llm/templates.py
@@ -123,6 +123,21 @@ import sys
 #     return json.loads(json.dumps(plot.plot_data, indent=2).replace("\\\\", ""))
 
 
+def _datasource_context_section(
+    project: CreateProjectPromptProject,
+    ds_name: str,
+    heading: str,
+) -> str:
+    try:
+        ds_meta = project.get_datasource_metadata(ds_name)
+        return (
+            f"## {heading}: **{ds_name}** ({ds_meta['size']} rows)\n\n"
+            + create_column_markdown(ds_meta["columns"])
+        )
+    except Exception:
+        return f"## {heading}: **{ds_name}**\n\n"
+
+
 def _build_rag_context_markdown(project: CreateProjectPromptProject, datasource_name: str) -> str:
     """Project Data Context block for RAG prompts."""
     try:
@@ -132,26 +147,37 @@ def _build_rag_context_markdown(project: CreateProjectPromptProject, datasource_
 
     has_cells = "cells" in names
     if len(names) > 1 and not has_cells:
-        try:
-            ds_meta = project.get_datasource_metadata(datasource_name)
-            primary = (
-                f"## Primary datasource for this question: **{datasource_name}** "
-                f"({ds_meta['size']} rows)\n\n"
-                + create_column_markdown(ds_meta["columns"])
-            )
-        except Exception:
-            primary = f"## Primary datasource for this question: **{datasource_name}**\n\n"
+        primary = _datasource_context_section(
+            project,
+            datasource_name,
+            "Primary datasource for this question",
+        )
         all_tables = create_project_markdown(project, wrap_in_details=False)
         return primary + "\n\n## All project datasources\n\n" + all_tables
 
-    try:
-        ds_meta = project.get_datasource_metadata(datasource_name)
-        return (
-            f"## **{datasource_name}:** ({ds_meta['size']} rows)\n\n"
-            + create_column_markdown(ds_meta["columns"])
+    if has_cells and len(names) > 1:
+        roles = infer_datasource_roles(project)
+        obs = roles.obs_datasource
+        sections: list[str] = []
+        if datasource_name != obs:
+            sections.append(
+                _datasource_context_section(
+                    project,
+                    obs,
+                    "Observation datasource (cell metadata — use for leiden, QC metrics, embeddings)",
+                )
+            )
+        primary_heading = (
+            "Primary datasource for this question"
+            if datasource_name != obs
+            else "Observation datasource"
         )
-    except Exception:
-        return create_project_markdown(project)
+        sections.append(
+            _datasource_context_section(project, datasource_name, primary_heading)
+        )
+        return "\n\n".join(sections)
+
+    return _datasource_context_section(project, datasource_name, datasource_name)
 
 
 def get_createproject_prompt_RAG(

--- a/python/mdvtools/llm/templates.py
+++ b/python/mdvtools/llm/templates.py
@@ -3,12 +3,14 @@ from typing import Any
 from mdvtools.project_protocols import CreateProjectPromptProject
 from mdvtools.mdvproject import MDVProject
 from mdvtools.markdown_utils import create_project_markdown, create_column_markdown
+from mdvtools.llm.dataset_scale import ProjectScale, assess_project_scale
 from mdvtools.llm.datasource_roles import (
     infer_datasource_roles,
     format_feature_table_field_policy,
     format_marker_gene_scanpy_fallback_policy,
     format_marker_ranking_viz_policy,
     format_metadata_column_schema_policy,
+    format_mdv_first_data_access_policy,
     format_no_hallucination_chart_policy,
     format_obs_table_chart_param_policy,
     format_scanpy_hybrid_routing_policy,
@@ -126,12 +128,18 @@ def get_createproject_prompt_RAG(
     final_answer: str,
     question: str,
     compact: bool = False,
+    scale: ProjectScale | None = None,
 ) -> str:
     """
     Constructs a RAG prompt to guide LLM code generation for creating MDV plots.
     Handles both standard and gene-related queries.
     When ``compact=True``, omits long policy blocks for local models (Ollama).
     """
+    if scale is None:
+        scale = assess_project_scale(project, path_to_data)
+    mdv_first_policy = format_mdv_first_data_access_policy(
+        scale, path_to_data, compact=compact
+    )
     # Build markdown context for the selected datasource; fall back to whole project if needed
     try:
         ds_meta = project.get_datasource_metadata(datasource_name)
@@ -165,16 +173,16 @@ def get_createproject_prompt_RAG(
             + expr_lines
             + """
 
+"""
+            + mdv_first_policy
+            + """
+
     Context: {context}
 
     The provided scripts demonstrate MDV chart construction patterns. Follow this workflow:
     1. Use MDVProject(project_path, delete_existing=False) when editing this project — never delete or recreate it.
-    2. Do NOT call `project.add_datasource(...)` for datasources that already exist (e.g. `"""
-            + datasource_name
-            + """`, `"""
-            + roles.obs_datasource
-            + """`). Load existing tables with `project.get_datasource_as_dataframe(...)`.
-    3. Load datasources with **Field ID** values from the context tables.
+    2. Follow the MDV-first data access rules above — do not load `.h5ad` or full datasources for chart-only views.
+    3. Load existing tables with `project.get_datasource_as_dataframe(<ds>, columns=[field_ids...])` when a pandas preview is needed.
     4. Build charts with mdvtools chart classes; set `params` from field ids (not display names).
     5. Print bounded markdown previews before `project.set_view(...)` when showing tabular results.
     6. Use injected CHATMDV_* constants when present; do not call `project.get_datasource_roles()`.
@@ -225,7 +233,7 @@ def get_createproject_prompt_RAG(
 """
         )
     feature_field_policy = format_feature_table_field_policy(roles)
-    marker_gene_policy = format_marker_gene_scanpy_fallback_policy(path_to_data)
+    marker_gene_policy = format_marker_gene_scanpy_fallback_policy(path_to_data, scale)
     table_chart_param_policy = format_obs_table_chart_param_policy()
     marker_ranking_viz_policy = format_marker_ranking_viz_policy()
     hybrid_routing_policy = format_scanpy_hybrid_routing_policy()
@@ -256,23 +264,17 @@ def get_createproject_prompt_RAG(
         - Initialize an MDVProject instance using the method: MDVProject(project_path, delete_existing=True) when creating a new project.
         - When modifying an existing project (the default in this chat context), do NOT recreate or delete the project.
 
-    2. Data Access (scanpy optional):
-        - If HAS_SCANPY is True and `data_path` points to a valid .h5ad file, you MAY load AnnData:
-            adata = sc.read_h5ad(data_path)
-            data_frame_obs = adata.obs
-            data_frame_var = adata.var.assign(name=adata.var_names.to_list())
-        - Exception: for **marker genes / top genes per cluster** when MDV tables lack needed columns, if `data_path`
-          is a `.h5ad` file, you SHOULD use `sc.read_h5ad` and Scanpy as described under "Marker genes" below.
-        - OTHERWISE (no scanpy or no .h5ad):
-            - DO NOT use scanpy.
-            - Use the existing MDV datasources already registered in the project:
-                - Observation/metadata datasource (df1): `"""+roles.obs_datasource+"""`
-                - Wrapper-capable expression datasources (feature tables): 
+    2. Data Access (MDV-first; Scanpy last resort):
+"""+mdv_first_policy+"""
+        - Observation/metadata datasource: `"""+roles.obs_datasource+"""`
+        - Wrapper-capable expression datasources (feature tables):
 """+expr_lines+"""
-            - Use `project.get_datasource_as_dataframe(<datasource_name>)` to load these tables, or
-              `project.get_datasource_as_dataframe(<datasource_name>, columns=[...])` to load a subset. Each entry may be a metadata **field id** (e.g. cluster column on `cells`) or a **chart FieldName wrapper** string for expression columns on the **observation (row) datasource** (same format as chart `params`, e.g. `rna_expr|GENE(rna_expr)|12`). Do not pass wrappers to the feature-table datasource dataframe.
+        - Use `project.get_datasource_as_dataframe(<datasource_name>, columns=[...])` with only the Field IDs you need.
+          Each entry may be a metadata **field id** (e.g. cluster column on `cells`) or a **chart FieldName wrapper** string
+          for expression columns on the **observation (row) datasource** (same format as chart `params`, e.g.
+          `rna_expr|GENE(rna_expr)|12`). Do not pass wrappers to the feature-table datasource dataframe.
 
-        - Marker genes and missing columns (ChatMDV):
+        - Marker genes and missing columns (Scanpy last resort only):
 """+marker_gene_policy+"""
 
     3. Datasource Registration:

--- a/python/mdvtools/llm/templates.py
+++ b/python/mdvtools/llm/templates.py
@@ -432,6 +432,7 @@ def get_createproject_prompt_RAG(
             (a) the markdown explanation text, and
             (b) bounded script stdout via `print(...)` before any `project.set_view(...)`.
         - Do NOT create `TextBox` or `TablePlot` by default when the user intent is primarily textual/table output.
+        - Do NOT add an analysis-summary `TextBox` in generated code; the ChatMDV orchestrator appends that after execution.
 
     8. Selection dialog usage:
         - Add `SelectionDialogPlot` when interactive filtering materially helps answer the question—for example,

--- a/python/mdvtools/llm/templates.py
+++ b/python/mdvtools/llm/templates.py
@@ -125,10 +125,12 @@ def get_createproject_prompt_RAG(
     datasource_name: str,
     final_answer: str,
     question: str,
+    compact: bool = False,
 ) -> str:
     """
     Constructs a RAG prompt to guide LLM code generation for creating MDV plots.
     Handles both standard and gene-related queries.
+    When ``compact=True``, omits long policy blocks for local models (Ollama).
     """
     # Build markdown context for the selected datasource; fall back to whole project if needed
     try:
@@ -137,6 +139,91 @@ def get_createproject_prompt_RAG(
     except Exception:
         context_md = create_project_markdown(project)
     roles = infer_datasource_roles(project)
+    if compact:
+        expr_lines = ""
+        if roles.expressions:
+            expr_lines = "\n".join(
+                f"- `{e.datasource_name}` (name_column=`{e.name_column}`, default_subgroup=`{e.subgroup_key}`)"
+                for e in roles.expressions
+            )
+        else:
+            expr_lines = "- (none detected)"
+        return (
+            """
+    Project Data Context:
+
+    """
+            + context_md
+            + """
+
+    Datasource roles:
+    - Observation/metadata datasource: `"""
+            + roles.obs_datasource
+            + """`
+    - Expression datasources (feature tables):
+"""
+            + expr_lines
+            + """
+
+    Context: {context}
+
+    The provided scripts demonstrate MDV chart construction patterns. Follow this workflow:
+    1. Use MDVProject(project_path, delete_existing=False) when editing this project — never delete or recreate it.
+    2. Do NOT call `project.add_datasource(...)` for datasources that already exist (e.g. `"""
+            + datasource_name
+            + """`, `"""
+            + roles.obs_datasource
+            + """`). Load existing tables with `project.get_datasource_as_dataframe(...)`.
+    3. Load datasources with **Field ID** values from the context tables.
+    4. Build charts with mdvtools chart classes; set `params` from field ids (not display names).
+    5. Print bounded markdown previews before `project.set_view(...)` when showing tabular results.
+    6. Use injected CHATMDV_* constants when present; do not call `project.get_datasource_roles()`.
+
+    Agent-suggested columns and chart types:
+    """
+            + final_answer
+            + """
+
+    User question: """
+            + question
+            + final_answer
+            + """
+
+    Update these variables in generated code:
+    - project_path = '"""
+            + project.dir
+            + """'
+    - data_path = '"""
+            + path_to_data
+            + """'
+    - datasource_name = '"""
+            + datasource_name
+            + """'
+    - view_name = a descriptive string for the visualization.
+
+    Chart type requirements (use agent-suggested types when valid):
+    - Abundance Box plot: three categorical columns (repeat if fewer available).
+    - Box plot / Violin plot: one categorical + one numerical column.
+    - Density Scatter plot: two numerical + one categorical column.
+    - Dot plot / Heatmap: one categorical + numerical columns.
+    - Histogram: one numerical column.
+    - Multiline chart: one numerical + one categorical column.
+    - Pie Chart / Row Chart / Wordcloud: one categorical column.
+    - Row summary box / Table Plot: any column(s).
+    - Sankey / Stacked row chart: two categorical columns (repeat if only one).
+    - Scatter plot (2D): two numerical + one color column.
+    - Scatter plot (3D): three numerical + one color column.
+    - Selection dialog plot: any column.
+    - Text box plot: text only.
+
+    Output format:
+    - Return only one fenced ```python code block with the complete runnable script.
+    - Do not add markdown narrative before or after the code block.
+    - For chart requests, create the view(s) described above; for text/table-first requests use bounded print(...) calls.
+
+
+"""
+        )
     feature_field_policy = format_feature_table_field_policy(roles)
     marker_gene_policy = format_marker_gene_scanpy_fallback_policy(path_to_data)
     table_chart_param_policy = format_obs_table_chart_param_policy()

--- a/python/mdvtools/llm/templates.py
+++ b/python/mdvtools/llm/templates.py
@@ -344,7 +344,7 @@ def get_createproject_prompt_RAG(
         - Convert the chart to JSON using `convert_plot_to_json(plot)`
         - **Before** `project.set_view(...)`, print a concise preview of any table, aggregate, or subset the charts depend on using **GitHub-flavored markdown tables** so the chat UI can render them (for example `print(df_result.head(40).to_markdown(index=False))` or `print(grouped.head(20).to_markdown())`). Do **not** use `DataFrame.to_string()` for chat previews. Keep rows/columns bounded so the output stays readable; this stdout is shown in the chat window.
         - **Before** `project.set_view(...)`, ensure saved charts use the **same data pipeline** as those printed previews (see "Visualization vs analysis consistency" below).
-        - Set the view using `project.set_view(view_name, view_object)`
+        - Set the view using `project.set_view(view_name, view_object)` with `initialCharts` only; ChatMDV applies gridstack layout when saving the view.
         - IMPORTANT: Chart objects (including `TablePlot`) do not support row-subsetting methods like `set_row_indices(...)`
           or invented filter setters such as `set_background_filter(...)`. Only call `set_*` (and other public) methods
           that exist on the chart class in `mdvtools.charts.*` (preflight validates this before execution).

--- a/python/mdvtools/llm/templates.py
+++ b/python/mdvtools/llm/templates.py
@@ -14,6 +14,7 @@ from mdvtools.llm.datasource_roles import (
     format_no_hallucination_chart_policy,
     format_obs_table_chart_param_policy,
     format_scanpy_hybrid_routing_policy,
+    format_targeted_chart_policies,
     format_visualization_consistency_policy,
 )
 prompt_data = """
@@ -140,6 +141,7 @@ def get_createproject_prompt_RAG(
     mdv_first_policy = format_mdv_first_data_access_policy(
         scale, path_to_data, compact=compact
     )
+    chart_policies = format_targeted_chart_policies(compact=compact)
     # Build markdown context for the selected datasource; fall back to whole project if needed
     try:
         ds_meta = project.get_datasource_metadata(datasource_name)
@@ -175,6 +177,10 @@ def get_createproject_prompt_RAG(
 
 """
             + mdv_first_policy
+            + """
+
+"""
+            + chart_policies
             + """
 
     Context: {context}
@@ -276,6 +282,8 @@ def get_createproject_prompt_RAG(
 
         - Marker genes and missing columns (Scanpy last resort only):
 """+marker_gene_policy+"""
+        - Targeted chart recipes (ChatMDV):
+"""+chart_policies+"""
 
     3. Datasource Registration:
         - When modifying an existing project, do **not** call `project.add_datasource(...)` for arbitrary new tables **except**

--- a/python/mdvtools/test_projects/chatmdv_csv_eval/run_prompt_csv.py
+++ b/python/mdvtools/test_projects/chatmdv_csv_eval/run_prompt_csv.py
@@ -21,6 +21,7 @@ Create it reproducibly with::
   python mdvtools/test_projects/chatmdv_csv_eval/setup_pbmc3k_chat.py
 
 Environment: same as Chat MDV (e.g. ``OPENAI_API_KEY`` in ``.env`` if used).
+Use ``--model`` (or env ``CHATMDV_DEFAULT_MODEL``) to select the chat model for the run.
 
 Default report directory for outputs: ``$TMPDIR/chatmdv_csv_eval`` (on Linux usually
 under ``/tmp``). Override with ``--output-dir /path``, env ``CHATMDV_CSV_EVAL_OUTPUT_DIR``,
@@ -41,11 +42,15 @@ Outputs
   compact per-row metrics only:
 
   - ``exec_success``, ``exit_code``, ``duration_seconds``
+  - ``started_at_utc``, ``finished_at_utc``, ``timing_jsonl_path``
   - ``view_name``, ``view_snapshot_present``, ``chart_count``, ``view_has_charts``,
     ``needs_refresh``
   - ``details_jsonl_path`` — path to the sidecar details file for this run
+  - optional ``block_*_s`` columns when ChatMDV block timings are captured
 
-  Verbose fields are **not** in the results CSV (see details JSONL below).
+- **Timing JSONL** (``timing_<stem>_<timestamp>.jsonl``): one JSON object per processed row
+  with ``duration_seconds``, ``row_wall_seconds``, ``started_at_utc``, ``finished_at_utc``,
+  ``block_timings``, and row identity fields.
 
 - **Details JSONL** (``details_<stem>_<timestamp>.jsonl``): one JSON object per processed
   row with ``failure_reason``, ``captured_output_excerpt``, ``captured_output``,
@@ -118,12 +123,15 @@ SLIM_RESULT_FIELDS = [
     "exec_success",
     "exit_code",
     "duration_seconds",
+    "started_at_utc",
+    "finished_at_utc",
     "view_name",
     "view_snapshot_present",
     "chart_count",
     "view_has_charts",
     "needs_refresh",
     "details_jsonl_path",
+    "timing_jsonl_path",
 ]
 
 
@@ -176,6 +184,10 @@ def _row_detail_payload(
     exec_success: bool,
     exit_code: int,
     duration_seconds: float,
+    row_wall_seconds: float,
+    started_at_utc: str,
+    finished_at_utc: str,
+    block_timings: dict[str, float],
     failure_reason: str,
     captured_output: str,
     captured_output_excerpt: str,
@@ -196,6 +208,10 @@ def _row_detail_payload(
         "exec_success": exec_success,
         "exit_code": exit_code,
         "duration_seconds": duration_seconds,
+        "row_wall_seconds": row_wall_seconds,
+        "started_at_utc": started_at_utc,
+        "finished_at_utc": finished_at_utc,
+        "block_timings": block_timings,
         "failure_reason": failure_reason,
         "captured_output_excerpt": captured_output_excerpt,
         "captured_output": captured_output,
@@ -207,6 +223,76 @@ def _row_detail_payload(
         "needs_refresh": needs_refresh,
         "debug_output_dir": debug_output_dir,
     }
+
+
+def _timing_record_payload(
+    *,
+    row_index: int,
+    dataset: str,
+    question: str,
+    complexity_score: str,
+    exec_success: bool,
+    exit_code: int,
+    duration_seconds: float,
+    row_wall_seconds: float,
+    started_at_utc: str,
+    finished_at_utc: str,
+    block_timings: dict[str, float],
+) -> dict[str, object]:
+    return {
+        "row_index": row_index,
+        "dataset": dataset,
+        "question": question,
+        "complexity_score": complexity_score,
+        "exec_success": exec_success,
+        "exit_code": exit_code,
+        "duration_seconds": duration_seconds,
+        "row_wall_seconds": row_wall_seconds,
+        "started_at_utc": started_at_utc,
+        "finished_at_utc": finished_at_utc,
+        "block_timings": block_timings,
+    }
+
+
+def _normalize_block_timings(raw: object) -> dict[str, float]:
+    if not isinstance(raw, dict):
+        return {}
+    timings: dict[str, float] = {}
+    for key, value in raw.items():
+        if not isinstance(key, str) or not key.startswith("block_") or not key.endswith("_s"):
+            continue
+        try:
+            timings[key] = float(value)
+        except (TypeError, ValueError):
+            continue
+    return timings
+
+
+def _collect_block_timing_keys(rows: list[dict[str, object]]) -> list[str]:
+    keys: set[str] = set()
+    for row in rows:
+        for key in row:
+            if isinstance(key, str) and key.startswith("block_") and key.endswith("_s"):
+                keys.add(key)
+    return sorted(keys)
+
+
+def _log_row_timing(
+    *,
+    row_index: int,
+    n_rows: int,
+    exit_code: int,
+    exec_success: bool,
+    duration_seconds: float,
+    row_wall_seconds: float,
+) -> None:
+    status = "OK" if exec_success else "FAIL"
+    print(
+        f"[{status}] row={row_index}/{n_rows} exit={exit_code} "
+        f"duration={duration_seconds:.3f}s wall={row_wall_seconds:.3f}s",
+        file=sys.stderr,
+        flush=True,
+    )
 
 
 def _parse_args() -> argparse.Namespace:
@@ -267,6 +353,14 @@ def _parse_args() -> argparse.Namespace:
         help=(
             "Per-row worker subprocess wall-clock timeout (default: ROW_TIMEOUT_SECONDS "
             f"env or {ROW_TIMEOUT_SECONDS:g}s). Ignored with --in-process-rows."
+        ),
+    )
+    parser.add_argument(
+        "--model",
+        default=None,
+        help=(
+            "Chat model for every row (canonical id or bare name, e.g. "
+            "openai:chat:gpt-4.1). Defaults to CHATMDV_DEFAULT_MODEL or discovery."
         ),
     )
     return parser.parse_args()
@@ -345,6 +439,8 @@ def _csv_eval_worker_main() -> int:
     prompt = str(payload.get("prompt") or "")
     output_dir = payload.get("output_dir")
     out_dir: str | None = str(output_dir) if output_dir else None
+    model_id = payload.get("model_id")
+    resolved_model_id: str | None = str(model_id) if model_id else None
 
     from mdvtools.llm.chat_cli import run_chat_once
 
@@ -354,6 +450,7 @@ def _csv_eval_worker_main() -> int:
             prompt=prompt,
             output_dir=out_dir,
             view_name=None,
+            model_id=resolved_model_id,
         )
     except Exception as exc:
         sys.stdout.write(
@@ -380,6 +477,7 @@ def _run_chat_row_subprocess(
     prompt: str,
     output_dir: str | None,
     timeout_seconds: float | None = None,
+    model_id: str | None = None,
 ) -> tuple[dict[str, object], int, str]:
     """Run ``run_chat_once`` in a child process.
 
@@ -388,7 +486,12 @@ def _run_chat_row_subprocess(
     (common for Linux OOM), ``\"signal_other\"`` for another fatal signal, or
     ``\"timeout\"`` when the worker exceeded ``timeout_seconds``.
     """
-    payload = {"project_path": project_path, "prompt": prompt, "output_dir": output_dir}
+    payload = {
+        "project_path": project_path,
+        "prompt": prompt,
+        "output_dir": output_dir,
+        "model_id": model_id,
+    }
     cmd = [sys.executable, str(_SCRIPT_PATH), "--csv-eval-worker"]
     run_kwargs: dict[str, object] = {
         "input": json.dumps(payload, ensure_ascii=False).encode("utf-8"),
@@ -519,6 +622,14 @@ def main() -> int:
         args.row_timeout if args.row_timeout is not None else ROW_TIMEOUT_SECONDS
     )
 
+    from mdvtools.llm.llm_providers import resolve_chat_model_id
+
+    try:
+        resolved_model_id = resolve_chat_model_id(args.model)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
     csv_path = args.csv.expanduser().resolve()
     if not csv_path.is_file():
         print(f"Not found: {csv_path}", file=sys.stderr)
@@ -544,6 +655,9 @@ def main() -> int:
         details_log_path = details_log_path.expanduser().resolve()
     details_log_path.parent.mkdir(parents=True, exist_ok=True)
     details_log_path_str = str(details_log_path)
+
+    timing_log_path = results_path.parent / f"timing_{stem}_{utc_now}.jsonl"
+    timing_log_path_str = str(timing_log_path)
 
     failure_log_path = args.failure_log
     if failure_log_path is None:
@@ -573,6 +687,7 @@ def main() -> int:
 
     result_rows: list[dict[str, object]] = []
     detail_records: list[dict[str, object]] = []
+    timing_records: list[dict[str, object]] = []
     complexity_pairs: dict[str, list[tuple[bool, bool]]] = defaultdict(list)
     failure_count = 0
     failure_payloads: list[dict[str, object]] = []
@@ -592,8 +707,13 @@ def main() -> int:
         file=sys.stderr,
         flush=True,
     )
+    if resolved_model_id:
+        print(f"Using chat model: {resolved_model_id}", file=sys.stderr, flush=True)
 
     for idx, row in enumerate(rows_in, start=1):
+        row_started_at = datetime.now(timezone.utc)
+        row_t0 = time.perf_counter()
+
         path = _resolve_row_field(row, "path")
         question = _resolve_row_field(row, "question")
         dataset = _resolve_row_field(row, "dataset") or ""
@@ -607,8 +727,11 @@ def main() -> int:
         )
 
         if not path or not question:
+            row_finished_at = datetime.now(timezone.utc)
+            row_wall_seconds = round(time.perf_counter() - row_t0, 6)
+            started_iso = row_started_at.isoformat()
+            finished_iso = row_finished_at.isoformat()
             msg = f"missing Path or Question (path={path!r}, question={question!r})"
-            print(f"[FAIL] row={idx} {msg}", file=sys.stderr, flush=True)
             detail = _row_detail_payload(
                 row_index=idx,
                 path=path or "",
@@ -618,6 +741,10 @@ def main() -> int:
                 exec_success=False,
                 exit_code=2,
                 duration_seconds=0.0,
+                row_wall_seconds=row_wall_seconds,
+                started_at_utc=started_iso,
+                finished_at_utc=finished_iso,
+                block_timings={},
                 failure_reason=f"Row {idx}: {msg}",
                 captured_output="",
                 captured_output_excerpt="",
@@ -630,23 +757,50 @@ def main() -> int:
                 debug_output_dir="",
             )
             detail_records.append(detail)
+            timing_records.append(
+                _timing_record_payload(
+                    row_index=idx,
+                    dataset=dataset,
+                    question=question or "",
+                    complexity_score=complexity_val,
+                    exec_success=False,
+                    exit_code=2,
+                    duration_seconds=0.0,
+                    row_wall_seconds=row_wall_seconds,
+                    started_at_utc=started_iso,
+                    finished_at_utc=finished_iso,
+                    block_timings={},
+                )
+            )
             out_row = {
                 **{k: row.get(k, "") for k in raw_fieldnames},
                 "exec_success": False,
                 "exit_code": 2,
                 "duration_seconds": 0.0,
+                "started_at_utc": started_iso,
+                "finished_at_utc": finished_iso,
                 "view_name": "",
                 "view_snapshot_present": False,
                 "chart_count": 0,
                 "view_has_charts": False,
                 "needs_refresh": False,
                 "details_jsonl_path": details_log_path_str,
+                "timing_jsonl_path": timing_log_path_str,
             }
             result_rows.append(out_row)
             failure_count += 1
             if complexity_val:
                 complexity_pairs[complexity_val].append((False, False))
             failure_payloads.append(detail)
+            _log_row_timing(
+                row_index=idx,
+                n_rows=n_rows,
+                exit_code=2,
+                exec_success=False,
+                duration_seconds=0.0,
+                row_wall_seconds=row_wall_seconds,
+            )
+            print(f"       reason: {msg}", file=sys.stderr, flush=True)
             continue
 
         run_out = None
@@ -662,6 +816,7 @@ def main() -> int:
                 prompt=question,
                 output_dir=out_dir_str,
                 timeout_seconds=row_timeout,
+                model_id=resolved_model_id,
             )
             if term_tag == "timeout":
                 print(
@@ -693,11 +848,18 @@ def main() -> int:
                 prompt=question,
                 output_dir=out_dir_str,
                 view_name=None,
+                model_id=resolved_model_id,
             )
+        row_finished_at = datetime.now(timezone.utc)
+        row_wall_seconds = round(time.perf_counter() - row_t0, 6)
+        started_iso = row_started_at.isoformat()
+        finished_iso = row_finished_at.isoformat()
+
         success = bool(result.get("success"))
         message = str(result.get("message", ""))
         cap = str(result.get("captured_output", ""))
         duration = float(result.get("duration_seconds", 0.0))
+        block_timings = _normalize_block_timings(result.get("block_timings"))
         view_name = result.get("view_name") or ""
         debug_dir = result.get("debug_output_dir") or ""
         view_snapshot_present = bool(result.get("view_snapshot_present", False))
@@ -719,6 +881,10 @@ def main() -> int:
             exec_success=success,
             exit_code=exit_code,
             duration_seconds=duration,
+            row_wall_seconds=row_wall_seconds,
+            started_at_utc=started_iso,
+            finished_at_utc=finished_iso,
+            block_timings=block_timings,
             failure_reason=failure_reason,
             captured_output=cap,
             captured_output_excerpt=excerpt,
@@ -731,39 +897,65 @@ def main() -> int:
             debug_output_dir=str(debug_dir) if debug_dir else "",
         )
         detail_records.append(detail)
+        timing_records.append(
+            _timing_record_payload(
+                row_index=idx,
+                dataset=dataset,
+                question=question,
+                complexity_score=complexity_val,
+                exec_success=success,
+                exit_code=exit_code,
+                duration_seconds=duration,
+                row_wall_seconds=row_wall_seconds,
+                started_at_utc=started_iso,
+                finished_at_utc=finished_iso,
+                block_timings=block_timings,
+            )
+        )
 
         out_row = {
             **{k: row.get(k, "") for k in raw_fieldnames},
             "exec_success": success,
             "exit_code": exit_code,
             "duration_seconds": duration,
+            "started_at_utc": started_iso,
+            "finished_at_utc": finished_iso,
             "view_name": view_name,
             "view_snapshot_present": view_snapshot_present,
             "chart_count": chart_count,
             "view_has_charts": view_has_charts,
             "needs_refresh": needs_refresh,
             "details_jsonl_path": details_log_path_str,
+            "timing_jsonl_path": timing_log_path_str,
+            **block_timings,
         }
         result_rows.append(out_row)
 
         if complexity_val:
             complexity_pairs[complexity_val].append((success, view_has_charts))
 
+        _log_row_timing(
+            row_index=idx,
+            n_rows=n_rows,
+            exit_code=exit_code,
+            exec_success=success,
+            duration_seconds=duration,
+            row_wall_seconds=row_wall_seconds,
+        )
         if success:
             view_bit = f" view={view_name!r}" if view_name else ""
             charts_bit = f" charts={chart_count}" if view_has_charts else ""
-            print(
-                f"[OK] row={idx}/{n_rows} exit={exit_code} duration={duration:.1f}s"
-                f"{view_bit}{charts_bit}",
-                file=sys.stderr,
-                flush=True,
-            )
+            if view_bit or charts_bit:
+                print(
+                    f"       {view_bit.strip()}{charts_bit}".strip(),
+                    file=sys.stderr,
+                    flush=True,
+                )
         else:
             failure_count += 1
             q_short = question[:120] + ("..." if len(question) > 120 else "")
             print(
-                f"[FAIL] row={idx}/{n_rows} exit={exit_code} path={path} q={q_short!r}\n"
-                f"       reason: {failure_reason}",
+                f"       path={path} q={q_short!r}\n       reason: {failure_reason}",
                 file=sys.stderr,
                 flush=True,
             )
@@ -772,6 +964,10 @@ def main() -> int:
     with details_log_path.open("w", encoding="utf-8") as dlog:
         for record in detail_records:
             dlog.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+    with timing_log_path.open("w", encoding="utf-8") as tlog:
+        for record in timing_records:
+            tlog.write(json.dumps(record, ensure_ascii=False) + "\n")
 
     if failure_payloads:
         with failure_log_path.open("w", encoding="utf-8") as flog:
@@ -804,10 +1000,12 @@ def main() -> int:
         "run_completed_at_utc": completion_iso,
         "run_wall_seconds_total": wall_seconds,
         "run_cli_limit": args.limit,
+        "run_model_id": resolved_model_id,
         "run_artifacts_base_dir": str(base_artifacts) if base_artifacts else None,
         "input_csv": str(csv_path),
         "results_csv": str(results_path),
         "details_jsonl": str(details_log_path),
+        "timing_jsonl": str(timing_log_path),
         "failure_log": str(failure_log_path) if failure_count > 0 else None,
         "benchmark_summary": str(benchmark_summary_path),
         "totals": {
@@ -826,6 +1024,9 @@ def main() -> int:
     for f in SLIM_RESULT_FIELDS:
         if f not in out_fieldnames:
             out_fieldnames.append(f)
+    for block_key in _collect_block_timing_keys(result_rows):
+        if block_key not in out_fieldnames:
+            out_fieldnames.append(block_key)
 
     with results_path.open("w", newline="", encoding="utf-8") as wf:
         w = csv.DictWriter(wf, fieldnames=out_fieldnames, extrasaction="ignore")
@@ -852,6 +1053,7 @@ def main() -> int:
     print(f"  {report_dir}")
     print("Files written:")
     print(f"  results_csv               {results_path}")
+    print(f"  timing_jsonl              {timing_log_path}")
     print(f"  details_jsonl             {details_log_path}")
     print(f"  benchmark_summary_json    {benchmark_summary_path}")
     if failure_count:
@@ -864,12 +1066,14 @@ def main() -> int:
         print("  artifacts_dir             (none — pass --artifacts-dir for per-row debug dirs)")
     print("")
     print(
-        "During the run: [START]/[OK]/[FAIL] lines on stderr (flushed per row)."
+        "During the run: [START]/[OK|FAIL] timing lines on stderr (flushed per row)."
         + (
-            f' Verbose per-row fields: see details_jsonl ("{details_log_path.name}").'
+            f' Per-row timings: see timing_jsonl ("{timing_log_path.name}").'
+            f' Verbose fields: details_jsonl ("{details_log_path.name}").'
             f' Failed-row payloads also in failures_jsonl ("{failure_log_path.name}").'
             if failure_count
-            else f' Verbose per-row fields: see details_jsonl ("{details_log_path.name}").'
+            else f' Per-row timings: see timing_jsonl ("{timing_log_path.name}").'
+            f' Verbose fields: details_jsonl ("{details_log_path.name}").'
         )
     )
 

--- a/python/mdvtools/tests/test_chat_cli_batch.py
+++ b/python/mdvtools/tests/test_chat_cli_batch.py
@@ -34,8 +34,8 @@ def test_batch_prompts_continue_on_error_and_write_csv(tmp_path, monkeypatch):
 
     calls = {"n": 0}
 
-    def fake_run_chat_once(*, project_path, prompt, output_dir=None, view_name=None):
-        del project_path, view_name
+    def fake_run_chat_once(*, project_path, prompt, output_dir=None, view_name=None, model_id=None):
+        del project_path, view_name, model_id
         calls["n"] += 1
         if output_dir is None:
             raise ValueError("output_dir is required")

--- a/python/mdvtools/tests/test_chat_cli_module.py
+++ b/python/mdvtools/tests/test_chat_cli_module.py
@@ -1,6 +1,7 @@
 import json
 
 from mdvtools.llm import chat_cli
+from mdvtools.llm.chat_protocol import ChatRequest
 from mdvtools.mdvproject import MDVProject
 
 
@@ -141,7 +142,7 @@ def test_run_chat_once_installs_socketio_shim_when_missing(tmp_path, monkeypatch
 
 def test_run_chat_once_passes_model_id_to_ask_question(tmp_path, monkeypatch):
     project = _make_project(tmp_path)
-    captured: dict[str, object] = {}
+    captured: dict[str, ChatRequest] = {}
 
     class FakeProjectChat:
         def __init__(self, incoming_project):
@@ -174,7 +175,7 @@ def test_run_chat_once_passes_model_id_to_ask_question(tmp_path, monkeypatch):
     )
 
     assert exit_code == 0
-    assert captured["chat_request"]["model_id"] == "openai:chat:gpt-4o-mini"
+    assert captured["chat_request"].get("model_id") == "openai:chat:gpt-4o-mini"
     assert result["model_id"] == "openai:chat:gpt-4o-mini"
 
 

--- a/python/mdvtools/tests/test_chat_cli_module.py
+++ b/python/mdvtools/tests/test_chat_cli_module.py
@@ -139,6 +139,67 @@ def test_run_chat_once_installs_socketio_shim_when_missing(tmp_path, monkeypatch
     assert mdv_websocket.socketio is not None
 
 
+def test_run_chat_once_passes_model_id_to_ask_question(tmp_path, monkeypatch):
+    project = _make_project(tmp_path)
+    captured: dict[str, object] = {}
+
+    class FakeProjectChat:
+        def __init__(self, incoming_project):
+            self.project = incoming_project
+            self.init_error = False
+
+        def ask_question(self, chat_request):
+            captured["chat_request"] = chat_request
+            return {
+                "code": "```python\nprint('ok')\n```",
+                "view_name": "v_model",
+                "error": False,
+                "message": "Success",
+                "verification": None,
+                "data_preview": None,
+                "needs_refresh": False,
+            }
+
+    monkeypatch.setattr(chat_cli, "ProjectChat", FakeProjectChat)
+    monkeypatch.setattr(
+        chat_cli,
+        "resolve_chat_model_id",
+        lambda model: "openai:chat:gpt-4o-mini" if model == "gpt-4o-mini" else None,
+    )
+
+    result, exit_code = chat_cli.run_chat_once(
+        project_path=str(project.dir),
+        prompt="run",
+        model_id="gpt-4o-mini",
+    )
+
+    assert exit_code == 0
+    assert captured["chat_request"]["model_id"] == "openai:chat:gpt-4o-mini"
+    assert result["model_id"] == "openai:chat:gpt-4o-mini"
+
+
+def test_main_rejects_unknown_model(tmp_path, monkeypatch, capsys):
+    project = _make_project(tmp_path)
+    monkeypatch.setattr(
+        chat_cli,
+        "resolve_chat_model_id",
+        lambda _model: (_ for _ in ()).throw(ValueError("Unknown chat model 'bad'")),
+    )
+
+    exit_code = chat_cli.main(
+        [
+            "--project",
+            str(project.dir),
+            "--prompt",
+            "run",
+            "--model",
+            "bad",
+        ]
+    )
+    assert exit_code == 2
+    assert "Unknown chat model" in capsys.readouterr().err
+
+
 def test_run_chat_once_renames_view_with_view_name(tmp_path, monkeypatch):
     project = _make_project(tmp_path)
 

--- a/python/mdvtools/tests/test_chat_ollama_pipeline.py
+++ b/python/mdvtools/tests/test_chat_ollama_pipeline.py
@@ -9,8 +9,10 @@ from mdvtools.llm import templates
 from mdvtools.llm.dataset_scale import ProjectScale
 from mdvtools.llm.langchain_mdv import (
     ProjectChat,
+    _REACT_PROMPT_INPUT_VARIABLES,
     _agent_fields_charts_output_valid,
     _fallback_agent_plan,
+    _get_react_prompt,
     _infer_chart_types_from_question,
     _invoke_rag_with_empty_retry,
     _raise_if_no_extracted_code,
@@ -70,6 +72,18 @@ def test_infer_chart_types_from_question_heatmap():
     assert "Heatmap" in _infer_chart_types_from_question(
         "Compare NKG7 and GNLY across clusters using a heatmap."
     )
+
+
+def test_get_react_prompt_falls_back_when_hub_unavailable():
+    import mdvtools.llm.langchain_mdv as lcm
+
+    lcm._react_hub_prompt_cache = None
+    with patch.object(lcm.hub, "pull", side_effect=OSError("offline")):
+        prompt = _get_react_prompt()
+
+    assert hasattr(prompt, "template")
+    assert "{tools}" in prompt.template
+    assert prompt.input_variables == _REACT_PROMPT_INPUT_VARIABLES
 
 
 def test_create_custom_pandas_agent_uses_functions_first_for_ollama():

--- a/python/mdvtools/tests/test_chat_ollama_pipeline.py
+++ b/python/mdvtools/tests/test_chat_ollama_pipeline.py
@@ -1,0 +1,239 @@
+"""Tests for Ollama-specific ChatMDV pipeline guards and compact RAG prompts."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mdvtools.llm import templates
+from mdvtools.llm.langchain_mdv import (
+    ProjectChat,
+    _agent_fields_charts_output_valid,
+    _fallback_agent_plan,
+    _infer_chart_types_from_question,
+    _invoke_rag_with_empty_retry,
+    _raise_if_no_extracted_code,
+    _resolve_agent_plan,
+)
+from mdvtools.llm.llm_providers import ModelSpec
+
+
+class _FakeProject:
+    def __init__(self):
+        self.datasources = [{"name": "cells"}]
+        self.dir = "/tmp/fake-project"
+
+    def get_datasource_metadata(self, name: str):
+        if name == "cells":
+            return {"name": "cells", "size": 10, "columns": [{"field": "mean_counts", "name": "mean_counts"}]}
+        raise KeyError(name)
+
+    def get_datasource_names(self) -> list[str]:
+        return [str(ds["name"]) for ds in self.datasources]
+
+
+def test_agent_fields_charts_output_valid_accepts_plan():
+    assert _agent_fields_charts_output_valid('fields "mean_counts"\ncharts "Histogram"') is True
+
+
+def test_agent_fields_charts_output_valid_rejects_empty():
+    assert _agent_fields_charts_output_valid("") is False
+    assert _agent_fields_charts_output_valid("   ") is False
+    assert _agent_fields_charts_output_valid("no plan here") is False
+    assert _agent_fields_charts_output_valid("Agent stopped due to iteration limit or time limit.") is False
+
+
+def test_resolve_agent_plan_from_react_intermediate_steps():
+    action = SimpleNamespace(
+        log='fields "X_umap_1", "X_umap_2", "leiden"\ncharts "Scatter plot (2D)"',
+        tool_input="Invalid Format: Missing 'Action:' after 'Thought:'",
+    )
+    response = {
+        "output": "Agent stopped due to iteration limit or time limit.",
+        "intermediate_steps": [(action, "obs")],
+    }
+    plan = _resolve_agent_plan(response)
+    assert 'fields "X_umap_1"' in plan
+    assert 'charts "Scatter plot (2D)"' in plan
+    assert _agent_fields_charts_output_valid(plan)
+
+
+def test_fallback_agent_plan_from_question():
+    plan = _fallback_agent_plan("Show a UMAP plot colored by Leiden clusters.")
+    assert _agent_fields_charts_output_valid(plan)
+    assert "Scatter plot (2D)" in plan
+    assert "infer from Project Data Context" in plan
+
+
+def test_infer_chart_types_from_question_heatmap():
+    assert "Heatmap" in _infer_chart_types_from_question(
+        "Compare NKG7 and GNLY across clusters using a heatmap."
+    )
+
+
+def test_create_custom_pandas_agent_uses_functions_first_for_ollama():
+    chat = ProjectChat.__new__(ProjectChat)
+    captured: dict = {}
+
+    def fake_build(*args, **kwargs):
+        captured["use_react"] = kwargs.get("use_react")
+        mock_executor = MagicMock()
+        mock_executor.invoke.return_value = {"output": 'fields "x"\ncharts "Histogram"'}
+        return mock_executor
+
+    with patch.object(ProjectChat, "_build_agent_executor", side_effect=fake_build):
+        with patch("mdvtools.llm.langchain_mdv.LLMChain") as mock_chain_cls:
+            mock_chain_cls.return_value.run.return_value = "question"
+            agent = chat.create_custom_pandas_agent(
+                llm=MagicMock(),
+                dfs={"df1": MagicMock(), "df2": MagicMock()},
+                prompt_data="",
+                memory=MagicMock(),
+                provider="ollama",
+            )
+            agent("histogram of mean_counts")
+
+    assert captured.get("use_react") is False
+
+
+def test_create_custom_pandas_agent_falls_back_to_react_when_ollama_plan_empty():
+    chat = ProjectChat.__new__(ProjectChat)
+    use_react_calls: list[bool] = []
+
+    def fake_build(*args, **kwargs):
+        use_react = kwargs.get("use_react")
+        use_react_calls.append(use_react is True)
+        mock_executor = MagicMock()
+        if use_react:
+            action = SimpleNamespace(
+                log='fields "leiden"\ncharts "Histogram"',
+                tool_input="",
+            )
+            mock_executor.invoke.return_value = {
+                "output": "Agent stopped due to iteration limit or time limit.",
+                "intermediate_steps": [(action, "obs")],
+            }
+        else:
+            mock_executor.invoke.return_value = {"output": ""}
+        return mock_executor
+
+    with patch.object(ProjectChat, "_build_agent_executor", side_effect=fake_build):
+        with patch("mdvtools.llm.langchain_mdv.LLMChain") as mock_chain_cls:
+            mock_chain_cls.return_value.run.return_value = "question"
+            agent = chat.create_custom_pandas_agent(
+                llm=MagicMock(),
+                dfs={"df1": MagicMock(), "df2": MagicMock()},
+                prompt_data="",
+                memory=MagicMock(),
+                provider="ollama",
+            )
+            response = agent("histogram")
+
+    assert use_react_calls == [False, True]
+    assert _agent_fields_charts_output_valid(_resolve_agent_plan(response))
+
+
+def test_create_custom_pandas_agent_uses_functions_for_openai():
+    chat = ProjectChat.__new__(ProjectChat)
+    captured: dict = {}
+
+    def fake_build(*args, **kwargs):
+        captured["use_react"] = kwargs.get("use_react")
+        mock_executor = MagicMock()
+        mock_executor.invoke.return_value = {"output": 'fields "x"\ncharts "Histogram"'}
+        return mock_executor
+
+    with patch.object(ProjectChat, "_build_agent_executor", side_effect=fake_build):
+        with patch("mdvtools.llm.langchain_mdv.LLMChain") as mock_chain_cls:
+            mock_chain_cls.return_value.run.return_value = "question"
+            agent = chat.create_custom_pandas_agent(
+                llm=MagicMock(),
+                dfs={"df1": MagicMock(), "df2": MagicMock()},
+                prompt_data="",
+                memory=MagicMock(),
+                provider="openai",
+            )
+            agent("histogram of mean_counts")
+
+    assert captured.get("use_react") is False
+
+
+def test_invoke_rag_with_empty_retry_raises_after_second_empty():
+    chat_model = ModelSpec(
+        id="ollama:chat:qwen3-coder:latest",
+        label="Qwen3 Coder",
+        provider="ollama",
+        model="qwen3-coder:latest",
+        kind="chat",
+        available=True,
+    )
+    qa_chain = MagicMock()
+    qa_chain.invoke.side_effect = [
+        {"result": "", "source_documents": []},
+        {"result": "   ", "source_documents": []},
+    ]
+
+    with pytest.raises(ValueError, match="Code generation returned empty output"):
+        _invoke_rag_with_empty_retry(qa_chain, "User question: hist", chat_model, None)
+
+    assert qa_chain.invoke.call_count == 2
+
+
+def test_invoke_rag_with_empty_retry_succeeds_on_retry():
+    chat_model = ModelSpec(
+        id="ollama:chat:qwen3-coder:latest",
+        label="Qwen3 Coder",
+        provider="ollama",
+        model="qwen3-coder:latest",
+        kind="chat",
+        available=True,
+    )
+    qa_chain = MagicMock()
+    qa_chain.invoke.side_effect = [
+        {"result": "", "source_documents": []},
+        {"result": "```python\nprint('ok')\n```", "source_documents": []},
+    ]
+
+    output_qa, result = _invoke_rag_with_empty_retry(
+        qa_chain, "User question: hist", chat_model, None
+    )
+    assert "print('ok')" in result
+    assert output_qa["result"].startswith("```python")
+
+
+def test_raise_if_no_extracted_code_rejects_warning_stub():
+    stub = "# WARNING:::: No code captured from the response when calling prepare_code().\n"
+    with pytest.raises(ValueError, match="did not produce runnable Python"):
+        _raise_if_no_extracted_code("", stub)
+
+
+def test_raise_if_no_extracted_code_rejects_empty_extraction():
+    with pytest.raises(ValueError, match="did not produce runnable Python"):
+        _raise_if_no_extracted_code("no fenced code here", "def main(): pass\n")
+
+
+def test_compact_rag_prompt_is_shorter_than_full(monkeypatch):
+    fake_roles = SimpleNamespace(
+        expressions=[],
+        obs_datasource="cells",
+    )
+    monkeypatch.setattr(templates, "infer_datasource_roles", lambda _project: fake_roles)
+    monkeypatch.setattr(templates, "create_column_markdown", lambda _cols: "columns-md")
+
+    project = _FakeProject()
+    kwargs = dict(
+        project=project,
+        path_to_data="",
+        datasource_name="cells",
+        final_answer='fields "mean_counts"\ncharts "Histogram"',
+        question="Which genes have highest mean_counts?",
+    )
+    full = templates.get_createproject_prompt_RAG(**kwargs, compact=False)
+    compact = templates.get_createproject_prompt_RAG(**kwargs, compact=True)
+
+    assert len(compact) < len(full)
+    assert "columns-md" in compact
+    assert "Return only one fenced ```python code block" in compact
+    assert "Do NOT call `project.add_datasource(...)`" in compact
+    assert "Marker ranking vs DotPlot" not in compact
+    assert "Visualization vs analysis consistency" not in compact

--- a/python/mdvtools/tests/test_chat_ollama_pipeline.py
+++ b/python/mdvtools/tests/test_chat_ollama_pipeline.py
@@ -236,15 +236,22 @@ def test_compact_rag_prompt_is_shorter_than_full(monkeypatch):
     monkeypatch.setattr(templates, "create_column_markdown", lambda _cols: "columns-md")
 
     project = _FakeProject()
-    kwargs = dict(
+    full = templates.get_createproject_prompt_RAG(
         project=project,
         path_to_data="",
         datasource_name="cells",
         final_answer='fields "mean_counts"\ncharts "Histogram"',
         question="Which genes have highest mean_counts?",
+        compact=False,
     )
-    full = templates.get_createproject_prompt_RAG(**kwargs, compact=False)
-    compact = templates.get_createproject_prompt_RAG(**kwargs, compact=True)
+    compact = templates.get_createproject_prompt_RAG(
+        project=project,
+        path_to_data="",
+        datasource_name="cells",
+        final_answer='fields "mean_counts"\ncharts "Histogram"',
+        question="Which genes have highest mean_counts?",
+        compact=True,
+    )
 
     assert len(compact) < len(full)
     assert "columns-md" in compact

--- a/python/mdvtools/tests/test_chat_ollama_pipeline.py
+++ b/python/mdvtools/tests/test_chat_ollama_pipeline.py
@@ -236,6 +236,7 @@ def test_compact_rag_prompt_is_shorter_than_full(monkeypatch):
     assert "columns-md" in compact
     assert "Return only one fenced ```python code block" in compact
     assert "MDV-first data access" in compact
+    assert "Chart recipes" in compact
     assert "Visualization vs analysis consistency" not in compact
 
 
@@ -267,4 +268,4 @@ def test_compact_rag_prompt_includes_mdv_first_for_large_scale(monkeypatch):
     )
     assert "987,743" in compact
     assert "backed='r'" in compact
-    assert "Scanpy last resort" in compact
+    assert "Chart recipes" in compact

--- a/python/mdvtools/tests/test_chat_ollama_pipeline.py
+++ b/python/mdvtools/tests/test_chat_ollama_pipeline.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from mdvtools.llm import templates
+from mdvtools.llm.dataset_scale import ProjectScale
 from mdvtools.llm.langchain_mdv import (
     ProjectChat,
     _agent_fields_charts_output_valid,
@@ -234,6 +235,36 @@ def test_compact_rag_prompt_is_shorter_than_full(monkeypatch):
     assert len(compact) < len(full)
     assert "columns-md" in compact
     assert "Return only one fenced ```python code block" in compact
-    assert "Do NOT call `project.add_datasource(...)`" in compact
-    assert "Marker ranking vs DotPlot" not in compact
+    assert "MDV-first data access" in compact
     assert "Visualization vs analysis consistency" not in compact
+
+
+def test_compact_rag_prompt_includes_mdv_first_for_large_scale(monkeypatch):
+    fake_roles = SimpleNamespace(
+        expressions=[],
+        obs_datasource="cells",
+    )
+    monkeypatch.setattr(templates, "infer_datasource_roles", lambda _project: fake_roles)
+    monkeypatch.setattr(templates, "create_column_markdown", lambda _cols: "columns-md")
+
+    large_scale = ProjectScale(
+        obs_rows=987_743,
+        obs_columns=45,
+        estimated_obs_df_mb=675.0,
+        available_ram_mb=2700.0,
+        is_large=True,
+        has_h5ad=True,
+        obs_datasource="cells",
+    )
+    compact = templates.get_createproject_prompt_RAG(
+        project=_FakeProject(),
+        path_to_data="/data/TAURUS.h5ad",
+        datasource_name="cells",
+        final_answer='fields "Patient"\ncharts "Scatter plot"',
+        question="UMAP by patient",
+        compact=True,
+        scale=large_scale,
+    )
+    assert "987,743" in compact
+    assert "backed='r'" in compact
+    assert "Scanpy last resort" in compact

--- a/python/mdvtools/tests/test_chatlog_handler.py
+++ b/python/mdvtools/tests/test_chatlog_handler.py
@@ -5,6 +5,34 @@ from langchain_core.outputs import LLMResult
 from mdvtools.llm.chatlog import LangchainLoggingHandler
 
 
+def test_chat_socket_api_log_file_only_skips_socket_handler():
+    from unittest.mock import MagicMock, patch
+
+    from mdvtools.llm.chatlog import ChatSocketAPI, ChatSocketIOHandler
+
+    emitted: list[str] = []
+
+    class FakeSocketIO:
+        def emit(self, event, msg, namespace=None, to=None):
+            emitted.append(msg)
+
+    project = MagicMock()
+    project.id = "proj1"
+    project.dir = "/tmp/chatlog_test_project"
+
+    with patch("mdvtools.websocket.socketio", FakeSocketIO()):
+        api = ChatSocketAPI(project, "req1", "room1", "conv1")
+        socket_handlers = [
+            h for h in api.logger.handlers if isinstance(h, ChatSocketIOHandler)
+        ]
+        assert socket_handlers, "expected a ChatSocketIOHandler on the request logger"
+
+        api.log_file_only("model_id=openai:chat:gpt-4.1 provider=openai")
+        api.logger.info("visible on socket")
+
+        assert emitted == ["visible on socket"]
+
+
 def test_langchain_logging_handler_avoids_info_noise(caplog):
     logger = logging.getLogger("test_langchain_logging_handler")
     logger.handlers = []

--- a/python/mdvtools/tests/test_code_manipulation.py
+++ b/python/mdvtools/tests/test_code_manipulation.py
@@ -2,8 +2,10 @@ from mdvtools.llm.code_manipulation import (
     parse_view_name,
     patch_viewname,
     resolve_persisted_view_name,
+    _autofix_generated_code,
 )
 from mdvtools.llm.code_manipulation import prepare_code, _defines_function_named_main
+from mdvtools.llm.code_preflight import validate_generated_code_preflight
 
 
 class _FakeProjectViews:
@@ -81,6 +83,18 @@ def test_resolve_persisted_view_name_omits_missing_view():
 
     assert resolve_persisted_view_name(project, "Saved view") == "Saved view"
     assert resolve_persisted_view_name(project, "Print-only answer") is None
+
+
+def test_autofix_stacked_row_chart_import_path():
+    code = (
+        "from mdvtools.charts.stacked_row_chart import StackedRowChart\n"
+        "chart = StackedRowChart(title='t', params=['a', 'b'], size=[100, 100], position=[0, 0])\n"
+    )
+    fixed = _autofix_generated_code(code, log=lambda _m: None)
+    assert "mdvtools.charts.stacked_row_plot" in fixed
+    assert "mdvtools.charts.stacked_row_chart" not in fixed
+    result = validate_generated_code_preflight(fixed)
+    assert result.ok
 
 
 def test_prepare_code_does_not_append_else_when_llm_includes_else_main(tmp_path):

--- a/python/mdvtools/tests/test_code_preflight.py
+++ b/python/mdvtools/tests/test_code_preflight.py
@@ -126,6 +126,27 @@ def main():
     assert any("Datasource `cells` does not contain column(s) ['name']" in i.message for i in res.issues)
 
 
+def test_preflight_hints_owner_datasource_for_missing_column():
+    code = """
+from mdvtools.mdvproject import MDVProject
+
+def main():
+    project = MDVProject("/tmp/project", delete_existing=False)
+    df = project.get_datasource_as_dataframe("qc_channels", columns=["channel_name", "cv_pct"])
+"""
+    res = validate_generated_code_preflight(
+        code,
+        datasource_fields={
+            "qc_channels": {"channel_name", "run_id"},
+            "qc_field_uniformity": {"channel_name", "cv_pct", "uniformity_score"},
+        },
+    )
+    assert res.ok is False
+    msgs = " | ".join(i.message for i in res.issues)
+    assert "cv_pct" in msgs
+    assert "qc_field_uniformity" in msgs
+
+
 def test_preflight_rejects_set_row_indices_on_scatter_plot():
     code = """
 from mdvtools.charts.scatter_plot import ScatterPlot

--- a/python/mdvtools/tests/test_code_preflight.py
+++ b/python/mdvtools/tests/test_code_preflight.py
@@ -13,6 +13,7 @@ def main():
     assert res.ok is False
     msgs = " | ".join(i.message for i in res.issues)
     assert "Unknown chart class `MultilineChart`" in msgs
+    assert "did you mean `MultiLinePlot`?" in msgs
 
 
 def test_preflight_rejects_unknown_chart_class():
@@ -23,6 +24,18 @@ def main():
     res = validate_generated_code_preflight(code)
     assert res.ok is False
     assert any(i.code == "unknown_chart_class" for i in res.issues)
+
+
+def test_preflight_rejects_multiline_chart_camelcase_alias():
+    code = """
+def main():
+    c = MultiLineChart(title="x", params=["a", "b"])
+"""
+    res = validate_generated_code_preflight(code)
+    assert res.ok is False
+    msgs = " | ".join(i.message for i in res.issues)
+    assert "Unknown chart class `MultiLineChart`" in msgs
+    assert "did you mean `MultiLinePlot`?" in msgs
 
 
 def test_preflight_rejects_unknown_histogram_alias():

--- a/python/mdvtools/tests/test_column_field_resolve.py
+++ b/python/mdvtools/tests/test_column_field_resolve.py
@@ -1,5 +1,6 @@
 from mdvtools.llm.column_field_resolve import (
     build_expression_wrapper_token,
+    ensure_view_gridstack_layout,
     expression_wrapper_subgroup_key,
     normalize_view_chart_params,
     prune_view_charts_with_invalid_params,
@@ -294,3 +295,25 @@ def test_client_needs_refresh_after_chat():
     assert client_needs_refresh_after_chat("delete_datasource('x')")
     assert not client_needs_refresh_after_chat("print('add_datasource')")
     assert not client_needs_refresh_after_chat("")
+
+
+def test_ensure_view_gridstack_layout_adds_missing_data_sources():
+    view = {
+        "initialCharts": {
+            "qc_field_uniformity": [{"type": "box_plot", "param": ["channel_name", "cv_pct"]}],
+            "qc_runs": [],
+        }
+    }
+    out = ensure_view_gridstack_layout(view)
+    assert out["dataSources"]["qc_field_uniformity"]["layout"] == "gridstack"
+    assert out["dataSources"]["qc_runs"]["layout"] == "gridstack"
+
+
+def test_ensure_view_gridstack_layout_overrides_absolute():
+    view = {
+        "initialCharts": {"cells": [{"type": "scatter_plot", "param": ["x", "y"]}]},
+        "dataSources": {"cells": {"layout": "absolute", "panelWidth": 100}},
+    }
+    out = ensure_view_gridstack_layout(view)
+    assert out["dataSources"]["cells"]["layout"] == "gridstack"
+    assert out["dataSources"]["cells"]["panelWidth"] == 100

--- a/python/mdvtools/tests/test_dataset_scale.py
+++ b/python/mdvtools/tests/test_dataset_scale.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import pytest
+
+from mdvtools.llm.dataset_scale import (
+    ProjectScale,
+    agent_probe_columns_from_metadata,
+    load_agent_dataframes,
+)
+from mdvtools.llm.datasource_roles import InferredDatasourceRoles, RowsAsColumnsExpression
+
+
+class _ScaleProject:
+    def __init__(self, *, metadata_by_name: dict[str, dict] | None = None):
+        self._metadata_by_name = metadata_by_name or {}
+        self.loads: list[tuple[str, list[str] | None]] = []
+
+    def get_datasource_metadata(self, name: str) -> dict:
+        return self._metadata_by_name.get(name, {"columns": [], "size": 200_000})
+
+    def get_datasource_as_dataframe(self, name: str, columns: list[str] | None = None):
+        self.loads.append((name, columns))
+        return f"df:{name}"
+
+    def get_datasource_names(self) -> list[str]:
+        return ["table_a", "table_b", "table_c"]
+
+
+_LARGE_SCALE = ProjectScale(
+    obs_rows=200_000,
+    obs_columns=10,
+    estimated_obs_df_mb=30.0,
+    available_ram_mb=8000.0,
+    is_large=True,
+    has_h5ad=False,
+    obs_datasource="cells",
+)
+
+_OBS_COLUMNS = [{"field": "leiden", "datatype": "text"}]
+
+
+def test_agent_probe_columns_returns_empty_when_metadata_has_no_columns():
+    project = _ScaleProject()
+    assert agent_probe_columns_from_metadata(project, "cells") == []
+
+
+def test_load_agent_dataframes_large_obs_refuses_full_load_when_no_probe_columns():
+    project = _ScaleProject()
+    roles = InferredDatasourceRoles(obs_datasource="cells", expressions=[])
+
+    with pytest.raises(ValueError, match="refusing full table load"):
+        load_agent_dataframes(project, roles, _LARGE_SCALE)
+
+    assert project.loads == []
+
+
+def test_load_agent_dataframes_large_obs_uses_column_subset():
+    project = _ScaleProject(metadata_by_name={"cells": {"columns": _OBS_COLUMNS}})
+    roles = InferredDatasourceRoles(obs_datasource="cells", expressions=[])
+
+    result = load_agent_dataframes(project, roles, _LARGE_SCALE)
+
+    assert result == ["df:cells"]
+    assert project.loads == [("cells", ["leiden"])]
+
+
+def test_load_agent_dataframes_large_extra_skips_when_no_probe_columns():
+    project = _ScaleProject(
+        metadata_by_name={
+            "cells": {"columns": _OBS_COLUMNS},
+            "table_b": {"columns": []},
+        }
+    )
+    roles = InferredDatasourceRoles(obs_datasource="cells", expressions=[])
+
+    result = load_agent_dataframes(
+        project, roles, _LARGE_SCALE, extra_datasource="table_b"
+    )
+
+    assert result == ["df:cells"]
+    assert project.loads == [("cells", ["leiden"])]
+
+
+def test_load_agent_dataframes_large_expr_skips_when_no_probe_columns():
+    project = _ScaleProject(
+        metadata_by_name={
+            "cells": {"columns": _OBS_COLUMNS},
+            "rna": {"columns": []},
+        }
+    )
+    roles = InferredDatasourceRoles(
+        obs_datasource="cells",
+        expressions=[
+            RowsAsColumnsExpression(
+                datasource_name="rna",
+                name_column="",
+                subgroup_key="rna_expr",
+                subgroup_label="rna_expr",
+            )
+        ],
+    )
+
+    result = load_agent_dataframes(project, roles, _LARGE_SCALE)
+
+    assert result == ["df:cells"]
+    assert project.loads == [("cells", ["leiden"])]

--- a/python/mdvtools/tests/test_datasource_roles.py
+++ b/python/mdvtools/tests/test_datasource_roles.py
@@ -3,8 +3,10 @@ import inspect
 from mdvtools.llm.datasource_roles import (
     CHAT_RANK_GENES_DATASOURCE_NAME,
     build_chatmdv_roles_constants_block,
+    build_datasource_field_index,
     categorical_field_ids_from_metadata,
     column_field_id,
+    find_datasources_for_fields,
     format_feature_table_field_policy,
     format_marker_gene_scanpy_fallback_policy,
     format_marker_ranking_viz_policy,
@@ -20,6 +22,8 @@ from mdvtools.llm.datasource_roles import (
     format_scanpy_hybrid_routing_policy,
     format_visualization_consistency_policy,
     infer_datasource_roles,
+    is_multi_table_tabular_project,
+    resolve_datasource_from_question,
 )
 from mdvtools.llm.dataset_scale import ProjectScale, assess_project_scale
 
@@ -324,4 +328,89 @@ def test_format_scanpy_hybrid_routing_policy():
     assert "cluster distribution" in text.lower()
     assert "predicted_cell_type" in text
     assert "Marker table strictness" in text
+
+
+class MicronLikeProject:
+    """Minimal metadata shaped like MICRON-scanr-02 for routing tests."""
+
+    datasources = [
+        {"name": "qc_channels", "columns": [{"field": "channel_name"}, {"field": "run_id"}]},
+        {
+            "name": "qc_field_uniformity",
+            "columns": [{"field": "channel_name"}, {"field": "cv_pct"}, {"field": "uniformity_score"}],
+        },
+        {"name": "qc_runs", "columns": [{"field": "assay"}, {"field": "run_id"}]},
+        {"name": "qc_sessions", "columns": [{"field": "session_id"}]},
+    ]
+
+    dir = "/app/mdv/MICRON-scanr-02"
+
+    def get_datasource_names(self):
+        return [ds["name"] for ds in self.datasources]
+
+    def get_datasource_metadata(self, name):
+        for ds in self.datasources:
+            if ds["name"] == name:
+                return {"name": name, "size": 10, "columns": ds["columns"]}
+        raise KeyError(name)
+
+    def get_links(self, *_a, **_k):
+        return []
+
+
+def test_micron_resolve_datasource_from_question_by_name():
+    project = MicronLikeProject()
+    q = (
+        "What is the distribution of cv_pct across different channel_name values "
+        "in qc_field_uniformity?"
+    )
+    assert resolve_datasource_from_question(project, q) == "qc_field_uniformity"
+
+
+def test_micron_resolve_datasource_from_question_by_fields():
+    project = MicronLikeProject()
+    q = "Show cv_pct and uniformity_score by channel"
+    assert resolve_datasource_from_question(project, q) == "qc_field_uniformity"
+
+
+def test_micron_resolve_datasource_qc_runs():
+    project = MicronLikeProject()
+    q = "What is the breakdown of assay types present in qc_runs?"
+    assert resolve_datasource_from_question(project, q) == "qc_runs"
+
+
+def test_find_datasources_for_fields_maps_cv_pct():
+    project = MicronLikeProject()
+    index = build_datasource_field_index(project)
+    owners = find_datasources_for_fields(index, ["cv_pct"])
+    assert owners["cv_pct"] == ["qc_field_uniformity"]
+
+
+def test_micron_infer_obs_datasource_prefers_qc_runs():
+    project = MicronLikeProject()
+    roles = infer_datasource_roles(project)
+    assert roles.obs_datasource == "qc_runs"
+
+
+def test_is_multi_table_tabular_project_for_micron():
+    project = MicronLikeProject()
+    roles = infer_datasource_roles(project)
+    assert is_multi_table_tabular_project(project, roles) is True
+
+
+def test_rag_prompt_includes_all_tables_and_resolved_datasource():
+    from mdvtools.llm.templates import get_createproject_prompt_RAG
+
+    project = MicronLikeProject()
+    prompt = get_createproject_prompt_RAG(
+        project,
+        "",
+        "qc_field_uniformity",
+        'fields "channel_name", "cv_pct"\ncharts "Violin plot"',
+        "What is the distribution of cv_pct in qc_field_uniformity?",
+        compact=True,
+    )
+    assert "Primary datasource for this question: **qc_field_uniformity**" in prompt
+    assert "qc_runs" in prompt
+    assert "datasource_name = 'qc_field_uniformity'" in prompt
 

--- a/python/mdvtools/tests/test_datasource_roles.py
+++ b/python/mdvtools/tests/test_datasource_roles.py
@@ -379,6 +379,39 @@ def test_micron_resolve_datasource_qc_runs():
     assert resolve_datasource_from_question(project, q) == "qc_runs"
 
 
+def test_resolve_datasource_n_genes_does_not_match_genes_substring():
+    """``genes`` must not match inside the field token ``n_genes``."""
+
+    class PbmcLikeProject:
+        datasources = [{"name": "cells"}, {"name": "genes"}]
+
+        def get_datasource_names(self):
+            return ["cells", "genes"]
+
+        def get_datasource_metadata(self, name):
+            if name == "cells":
+                return {
+                    "name": "cells",
+                    "size": 2700,
+                    "columns": [
+                        {"field": "leiden", "name": "leiden", "datatype": "text"},
+                        {"field": "n_genes", "name": "n genes", "datatype": "integer"},
+                    ],
+                }
+            return {
+                "name": "genes",
+                "size": 1838,
+                "columns": [
+                    {"field": "gene_ids", "name": "gene ids", "datatype": "text"},
+                    {"field": "n_cells_by_counts", "name": "n cells", "datatype": "integer"},
+                ],
+            }
+
+    project = PbmcLikeProject()
+    q = "What is the distribution of n_genes across different leiden clusters?"
+    assert resolve_datasource_from_question(project, q) == "cells"
+
+
 def test_find_datasources_for_fields_maps_cv_pct():
     project = MicronLikeProject()
     index = build_datasource_field_index(project)

--- a/python/mdvtools/tests/test_datasource_roles.py
+++ b/python/mdvtools/tests/test_datasource_roles.py
@@ -11,7 +11,12 @@ from mdvtools.llm.datasource_roles import (
     format_metadata_column_schema_policy,
     format_mdv_first_data_access_policy,
     format_no_hallucination_chart_policy,
+    format_obs_annadata_alignment_policy,
     format_obs_table_chart_param_policy,
+    format_proportion_chart_policy,
+    format_gene_signature_chart_policy,
+    format_column_subset_completeness_policy,
+    format_targeted_chart_policies,
     format_scanpy_hybrid_routing_policy,
     format_visualization_consistency_policy,
     infer_datasource_roles,
@@ -187,6 +192,34 @@ def test_format_marker_ranking_viz_policy():
     assert CHAT_RANK_GENES_DATASOURCE_NAME in text
     assert "project.add_datasource(" in text
     assert "IndentationError" in text
+
+
+def test_format_targeted_chart_policies():
+    compact = format_targeted_chart_policies(compact=True)
+    assert "StackedRowChart" in compact
+    assert "stacked_row_plot" in compact
+    assert "param=" in compact
+    assert "obs_df.index" in compact or "AnnData" in compact
+
+    full = format_targeted_chart_policies(compact=False)
+    assert "Gene signature" in full or "signature" in full.lower()
+    assert format_obs_annadata_alignment_policy()[:20] in full
+    assert "PieChart" in format_proportion_chart_policy()
+
+
+def test_format_mdv_first_includes_hybrid_bans():
+    large = ProjectScale(
+        obs_rows=500_000,
+        obs_columns=40,
+        estimated_obs_df_mb=300.0,
+        available_ram_mb=2048.0,
+        is_large=True,
+        has_h5ad=True,
+        obs_datasource="cells",
+    )
+    text = format_mdv_first_data_access_policy(large, "/data/x.h5ad", compact=True)
+    assert "combine `read_h5ad`" in text
+    assert "invent `bucket`" in text
 
 
 def test_format_marker_gene_scanpy_fallback_with_h5ad():

--- a/python/mdvtools/tests/test_datasource_roles.py
+++ b/python/mdvtools/tests/test_datasource_roles.py
@@ -9,12 +9,14 @@ from mdvtools.llm.datasource_roles import (
     format_marker_gene_scanpy_fallback_policy,
     format_marker_ranking_viz_policy,
     format_metadata_column_schema_policy,
+    format_mdv_first_data_access_policy,
     format_no_hallucination_chart_policy,
     format_obs_table_chart_param_policy,
     format_scanpy_hybrid_routing_policy,
     format_visualization_consistency_policy,
     infer_datasource_roles,
 )
+from mdvtools.llm.dataset_scale import ProjectScale, assess_project_scale
 
 
 class FakeProject:
@@ -196,6 +198,65 @@ def test_format_marker_gene_scanpy_fallback_with_h5ad():
     assert "**Primary** answer" in text or "Primary" in text
     assert CHAT_RANK_GENES_DATASOURCE_NAME in text
     assert "add_datasource" in text
+
+
+def test_format_marker_gene_scanpy_fallback_large_project_requires_backed():
+    large = ProjectScale(
+        obs_rows=500_000,
+        obs_columns=40,
+        estimated_obs_df_mb=300.0,
+        available_ram_mb=2048.0,
+        is_large=True,
+        has_h5ad=True,
+        obs_datasource="cells",
+    )
+    text = format_marker_gene_scanpy_fallback_policy("/data/adata.h5ad", large)
+    assert "backed='r'" in text
+    assert ".copy()" in text or "copy" in text.lower()
+
+
+def test_format_mdv_first_data_access_policy_large_project():
+    large = ProjectScale(
+        obs_rows=987_743,
+        obs_columns=45,
+        estimated_obs_df_mb=675.0,
+        available_ram_mb=2700.0,
+        is_large=True,
+        has_h5ad=True,
+        obs_datasource="cells",
+    )
+    text = format_mdv_first_data_access_policy(large, "/data/adata.h5ad", compact=False)
+    assert "MDV-first" in text
+    assert "backed='r'" in text
+    assert "columns=[...]" in text
+    assert "Scanpy last resort" in text
+    assert "987,743" in text
+
+    compact = format_mdv_first_data_access_policy(large, "/data/adata.h5ad", compact=True)
+    assert "MDV-first data access" in compact
+    assert "backed='r'" in compact
+    assert "add_datasource" in compact
+
+
+def test_assess_project_scale_marks_large_obs_table():
+    scale = assess_project_scale(FakeProject(), "")
+    assert scale.obs_datasource == "cells"
+    assert scale.obs_rows == 100
+    assert scale.is_large is False
+
+    class LargeProject(FakeProject):
+        def get_datasource_metadata(self, name):
+            if name == "cells":
+                return {
+                    "name": "cells",
+                    "size": 250_000,
+                    "columns": [{"field": f"c{i}", "datatype": "text"} for i in range(10)],
+                }
+            return super().get_datasource_metadata(name)
+
+    large = assess_project_scale(LargeProject(), "/data/x.h5ad")
+    assert large.is_large is True
+    assert large.has_h5ad is True
 
 
 def test_format_marker_gene_scanpy_fallback_without_h5ad():

--- a/python/mdvtools/tests/test_guidance.py
+++ b/python/mdvtools/tests/test_guidance.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import json
+
+from mdvtools.llm.guidance import (
+    ANALYSIS_SUMMARY_TITLE,
+    CHATMDV_SUMMARY_TEXTBOX_ID,
+    append_guidance_textbox_to_view,
+    build_response_guidance,
+)
+
+
+class FakeProject:
+    def __init__(self):
+        self.datasources = [
+            {"name": "qc_field_uniformity"},
+            {"name": "qc_runs"},
+            {"name": "qc_channels"},
+        ]
+        self._views: dict[str, dict] = {}
+        self._columns = {
+            "channel_name": {"field": "channel_name", "name": "channel_name"},
+            "cv_pct": {"field": "cv_pct", "name": "cv_pct"},
+        }
+
+    def get_view(self, view_name: str):
+        return self._views[view_name]
+
+    def set_view(self, view_name: str, view: dict):
+        self._views[view_name] = view
+
+    def get_column_metadata(self, datasource_name: str, field: str):
+        return self._columns.get(field, {"field": field, "name": field})
+
+    def get_datasource_metadata(self, name: str):
+        return {"name": name, "size": 11, "columns": list(self._columns.values())}
+
+
+def test_build_response_guidance_includes_sections():
+    proj = FakeProject()
+    proj._views["v1"] = {
+        "initialCharts": {
+            "qc_field_uniformity": [
+                {
+                    "title": "cv_pct by channel",
+                    "type": "box_plot",
+                    "param": ["channel_name", "cv_pct"],
+                }
+            ]
+        }
+    }
+    code = "datasource_name = 'qc_field_uniformity'\n"
+    md = build_response_guidance(
+        proj,
+        "What is the distribution of cv_pct across channel_name in qc_field_uniformity?",
+        code,
+        "v1",
+        'fields "channel_name", "cv_pct"\ncharts "Box plot"',
+        "| channel | cv_pct |\n|---|---|\n| C405 | 12 |",
+    )
+    assert "## Why this visualization" in md
+    assert "## What to look for" in md
+    assert "## Suggested next steps" in md
+    assert "qc_runs" in md or "follow-up" in md.lower()
+
+
+def test_append_guidance_textbox_prepends_and_replaces_summary():
+    proj = FakeProject()
+    proj._views["v1"] = {
+        "initialCharts": {
+            "qc_field_uniformity": [
+                {
+                    "title": ANALYSIS_SUMMARY_TITLE,
+                    "type": "text_box_chart",
+                    "id": CHATMDV_SUMMARY_TEXTBOX_ID,
+                    "text": "old summary",
+                },
+                {
+                    "title": "cv_pct by channel",
+                    "type": "box_plot",
+                    "param": ["channel_name", "cv_pct"],
+                },
+            ]
+        }
+    }
+    guidance = "## Why this visualization\n\nTest summary.\n"
+    ok = append_guidance_textbox_to_view(
+        proj, "v1", "qc_field_uniformity", guidance
+    )
+    assert ok is True
+    charts = proj._views["v1"]["initialCharts"]["qc_field_uniformity"]
+    assert len(charts) == 2
+    assert charts[0]["type"] == "text_box_chart"
+    assert charts[0]["id"] == CHATMDV_SUMMARY_TEXTBOX_ID
+    assert charts[0]["text"] == guidance
+    assert charts[1]["type"] == "box_plot"
+
+
+def test_append_guidance_skips_when_no_plot_charts():
+    proj = FakeProject()
+    proj._views["empty"] = {"initialCharts": {"qc_field_uniformity": []}}
+    ok = append_guidance_textbox_to_view(
+        proj, "empty", "qc_field_uniformity", "summary"
+    )
+    assert ok is False

--- a/python/mdvtools/tests/test_langchain_mdv_helpers.py
+++ b/python/mdvtools/tests/test_langchain_mdv_helpers.py
@@ -41,8 +41,19 @@ def test_project_chat_initialization_fails_without_openai_key(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.setattr("mdvtools.llm.langchain_mdv.load_dotenv", lambda: False)
 
+    def _no_providers() -> None:
+        raise ValueError(
+            "No LLM providers are available. Set OPENAI_API_KEY or start Ollama "
+            "at http://localhost:11434."
+        )
+
+    monkeypatch.setattr(
+        "mdvtools.llm.langchain_mdv.ensure_any_provider_available",
+        _no_providers,
+    )
+
     chat = ProjectChat(cast(MDVProject, FakeProject()))
 
     assert chat.init_error is True
     assert chat.error_message is not None
-    assert "OPENAI_API_KEY is not set" in chat.error_message
+    assert "No LLM providers are available" in chat.error_message

--- a/python/mdvtools/tests/test_llm_providers.py
+++ b/python/mdvtools/tests/test_llm_providers.py
@@ -63,6 +63,36 @@ def test_discover_models_ollama_only(monkeypatch):
     assert discovered.default_model_id == "ollama:chat:llama3.2"
 
 
+def test_resolve_chat_model_id_by_full_id(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    with patch.object(llm_providers, "_fetch_ollama_tags", return_value=[]):
+        assert (
+            llm_providers.resolve_chat_model_id("openai:chat:gpt-4.1")
+            == "openai:chat:gpt-4.1"
+        )
+
+
+def test_resolve_chat_model_id_by_bare_name(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    with patch.object(llm_providers, "_fetch_ollama_tags", return_value=[]):
+        assert llm_providers.resolve_chat_model_id("gpt-4o-mini") == "openai:chat:gpt-4o-mini"
+
+
+def test_resolve_chat_model_id_empty_uses_default(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    with patch.object(llm_providers, "_fetch_ollama_tags", return_value=[]):
+        assert llm_providers.resolve_chat_model_id(None) is None
+        assert llm_providers.resolve_chat_model_id("") is None
+        assert llm_providers.resolve_chat_model_id("   ") is None
+
+
+def test_resolve_chat_model_id_unknown_raises(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    with patch.object(llm_providers, "_fetch_ollama_tags", return_value=[]):
+        with pytest.raises(ValueError, match="Unknown chat model"):
+            llm_providers.resolve_chat_model_id("not-a-real-model")
+
+
 def test_resolve_embedding_model_openai(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
     discovered = llm_providers.discover_models()

--- a/python/mdvtools/tests/test_llm_providers.py
+++ b/python/mdvtools/tests/test_llm_providers.py
@@ -1,0 +1,147 @@
+"""Tests for ChatMDV LLM provider discovery and pairing."""
+
+from unittest.mock import patch
+
+import pytest
+
+from mdvtools.llm import llm_providers
+
+
+def test_ollama_base_url_defaults_to_host_docker_internal_in_container(monkeypatch):
+    monkeypatch.delenv("OLLAMA_BASE_URL", raising=False)
+    monkeypatch.setattr(llm_providers, "load_dotenv", lambda: None)
+    with patch.object(llm_providers.os.path, "exists", lambda path: path == "/.dockerenv"):
+        assert llm_providers._ollama_base_url() == "http://host.docker.internal:11434"
+
+
+def test_ollama_base_url_explicit_env_overrides_docker_default(monkeypatch):
+    monkeypatch.setenv("OLLAMA_BASE_URL", "http://custom:11434")
+    monkeypatch.setattr(llm_providers, "load_dotenv", lambda: None)
+    with patch.object(llm_providers.os.path, "exists", lambda path: path == "/.dockerenv"):
+        assert llm_providers._ollama_base_url() == "http://custom:11434"
+
+
+def test_discover_models_merges_openai_and_ollama(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    ollama_tags = {
+        "models": [
+            {"name": "gemma:26b", "capabilities": ["completion"]},
+            {"name": "nomic-embed-text", "capabilities": ["embedding"]},
+        ]
+    }
+
+    with patch.object(llm_providers, "_fetch_ollama_tags", return_value=ollama_tags["models"]):
+        discovered = llm_providers.discover_models()
+
+    chat_ids = {m.id for m in discovered.chat_models}
+    embed_ids = {m.id for m in discovered.embedding_models}
+
+    assert "openai:chat:gpt-4.1" in chat_ids
+    assert "ollama:chat:gemma:26b" in chat_ids
+    assert "openai:embedding:text-embedding-3-large" in embed_ids
+    assert "ollama:embedding:nomic-embed-text" in embed_ids
+    assert discovered.default_model_id == "openai:chat:gpt-4.1"
+
+
+def test_discover_models_ollama_only(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("CHATMDV_DEFAULT_MODEL", "ollama:chat:llama3.2")
+
+    ollama_tags = [
+        {"name": "llama3.2", "capabilities": ["completion"]},
+        {"name": "nomic-embed-text", "capabilities": ["embedding"]},
+    ]
+
+    with patch.object(llm_providers, "_has_openai_api_key", return_value=False):
+        with patch.object(llm_providers, "_fetch_ollama_tags", return_value=ollama_tags):
+            discovered = llm_providers.discover_models()
+
+    assert len(discovered.chat_models) == 1
+    assert discovered.chat_models[0].model == "llama3.2"
+    assert discovered.default_model_id == "ollama:chat:llama3.2"
+
+
+def test_resolve_embedding_model_openai(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    discovered = llm_providers.discover_models()
+    chat = discovered.get_chat_model("openai:chat:gpt-4.1")
+    embedding = llm_providers.resolve_embedding_model(chat, discovered)
+    assert embedding.provider == "openai"
+    assert embedding.model == "text-embedding-3-large"
+
+
+def test_resolve_embedding_model_ollama(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("OLLAMA_EMBEDDING_MODEL", "nomic-embed-text")
+
+    ollama_tags = [
+        {"name": "gemma:26b", "capabilities": ["completion"]},
+        {"name": "nomic-embed-text", "capabilities": ["embedding"]},
+    ]
+
+    with patch.object(llm_providers, "_fetch_ollama_tags", return_value=ollama_tags):
+        discovered = llm_providers.discover_models()
+        chat = discovered.get_chat_model("ollama:chat:gemma:26b")
+        embedding = llm_providers.resolve_embedding_model(chat, discovered)
+
+    assert embedding.provider == "ollama"
+    assert embedding.model == "nomic-embed-text"
+
+
+def test_resolve_embedding_model_ollama_missing_raises(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("OLLAMA_EMBEDDING_MODEL", "missing-embed-model")
+
+    ollama_tags = [
+        {"name": "gemma:26b", "capabilities": ["completion"]},
+    ]
+
+    with patch.object(llm_providers, "_fetch_ollama_tags", return_value=ollama_tags):
+        discovered = llm_providers.discover_models()
+        chat = discovered.get_chat_model("ollama:chat:gemma:26b")
+        with pytest.raises(ValueError, match="No Ollama embedding model"):
+            llm_providers.resolve_embedding_model(chat, discovered)
+
+
+def test_rag_retriever_cache_keyed_by_embedding_model(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    from mdvtools.llm.langchain_mdv import _get_rag_retriever, _rag_retriever_cache
+
+    _rag_retriever_cache.clear()
+
+    openai_embed = llm_providers.ModelSpec(
+        id="openai:embedding:text-embedding-3-large",
+        label="OpenAI text-embedding-3-large",
+        provider="openai",
+        model="text-embedding-3-large",
+        kind="embedding",
+    )
+    other_embed = llm_providers.ModelSpec(
+        id="openai:embedding:text-embedding-3-small",
+        label="OpenAI text-embedding-3-small",
+        provider="openai",
+        model="text-embedding-3-small",
+        kind="embedding",
+    )
+
+    fake_retriever_a = object()
+    fake_retriever_b = object()
+
+    with patch("mdvtools.llm.langchain_mdv.crawl_local_repo", return_value=[]):
+        with patch("mdvtools.llm.langchain_mdv.create_embeddings", return_value=object()):
+            with patch("mdvtools.llm.langchain_mdv.FAISS") as mock_faiss:
+                mock_faiss.from_documents.return_value.as_retriever.return_value = fake_retriever_a
+                retriever_a = _get_rag_retriever(openai_embed)
+                mock_faiss.from_documents.return_value.as_retriever.return_value = fake_retriever_b
+                retriever_b = _get_rag_retriever(other_embed)
+
+    assert retriever_a is fake_retriever_a
+    assert retriever_b is fake_retriever_b
+    assert len(_rag_retriever_cache) == 2
+    assert openai_embed.id in _rag_retriever_cache
+    assert other_embed.id in _rag_retriever_cache
+
+    _rag_retriever_cache.clear()

--- a/python/mdvtools/tests/test_run_prompt_csv_outputs.py
+++ b/python/mdvtools/tests/test_run_prompt_csv_outputs.py
@@ -29,13 +29,14 @@ def test_run_prompt_csv_slim_results_and_details_jsonl(tmp_path, monkeypatch):
 
     fake_verification = "## What you can verify\n- chart ok\n"
 
-    def fake_run_chat_once(*, project_path, prompt, output_dir=None, view_name=None):
-        del project_path, prompt, output_dir, view_name
+    def fake_run_chat_once(*, project_path, prompt, output_dir=None, view_name=None, model_id=None):
+        del project_path, prompt, output_dir, view_name, model_id
         return {
             "success": True,
             "message": "Success",
             "captured_output": "Block 'b14' took 1.0 seconds\n",
             "duration_seconds": 3.5,
+            "block_timings": {"block_b14_execute_code_s": 1.0},
             "view_name": "test-view",
             "view_snapshot_present": True,
             "chart_count": 1,
@@ -83,8 +84,23 @@ def test_run_prompt_csv_slim_results_and_details_jsonl(tmp_path, monkeypatch):
 
     assert "exec_success" in fieldnames
     assert "details_jsonl_path" in fieldnames
+    assert "timing_jsonl_path" in fieldnames
+    assert "started_at_utc" in fieldnames
+    assert "finished_at_utc" in fieldnames
+    assert "block_b14_execute_code_s" in fieldnames
     assert rows[0]["exec_success"] == "True"
     assert rows[0]["view_name"] == "test-view"
+    assert float(rows[0]["duration_seconds"]) == 3.5
+
+    timing_files = list(out_dir.glob("timing_*.jsonl"))
+    assert len(timing_files) == 1
+    timing = json.loads(timing_files[0].read_text(encoding="utf-8").strip())
+    assert timing["row_index"] == 1
+    assert timing["duration_seconds"] == 3.5
+    assert timing["block_timings"]["block_b14_execute_code_s"] == 1.0
+    assert timing["started_at_utc"]
+    assert timing["finished_at_utc"]
+    assert timing["row_wall_seconds"] >= 0.0
 
     details_files = list(out_dir.glob("details_*.jsonl"))
     assert len(details_files) == 1
@@ -99,9 +115,58 @@ def test_run_prompt_csv_slim_results_and_details_jsonl(tmp_path, monkeypatch):
     assert len(summary_files) == 1
     summary = json.loads(summary_files[0].read_text(encoding="utf-8"))
     assert summary["run_id"]
+    assert summary["run_model_id"] is None
     assert summary["details_jsonl"] == str(details_files[0])
+    assert summary["timing_jsonl"] == str(timing_files[0])
     assert summary["totals"]["rows"] == 1
     assert "run_benchmark_summary_json_mirror" not in summary
+
+
+def test_run_prompt_csv_records_model_in_summary(tmp_path, monkeypatch):
+    input_csv = tmp_path / "prompts.csv"
+    out_dir = tmp_path / "report"
+    _write_input_csv(input_csv)
+
+    def fake_run_chat_once(*, project_path, prompt, output_dir=None, view_name=None, model_id=None):
+        del project_path, prompt, output_dir, view_name
+        assert model_id == "openai:chat:gpt-4.1"
+        return {
+            "success": True,
+            "message": "Success",
+            "captured_output": "",
+            "duration_seconds": 1.0,
+            "view_name": "v",
+            "view_snapshot_present": True,
+            "chart_count": 1,
+            "verification": "",
+            "needs_refresh": False,
+            "debug_output_dir": "",
+        }, 0
+
+    monkeypatch.setattr(
+        "mdvtools.llm.chat_cli.run_chat_once",
+        fake_run_chat_once,
+    )
+    monkeypatch.setattr(
+        "mdvtools.llm.llm_providers.resolve_chat_model_id",
+        lambda model: "openai:chat:gpt-4.1" if model == "gpt-4.1" else None,
+    )
+
+    argv = [
+        "run_prompt_csv",
+        "--csv",
+        str(input_csv),
+        "--output-dir",
+        str(out_dir),
+        "--in-process-rows",
+        "--model",
+        "gpt-4.1",
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    assert run_prompt_csv.main() == 0
+
+    summary = json.loads(next(out_dir.glob("benchmark_summary_*.json")).read_text(encoding="utf-8"))
+    assert summary["run_model_id"] == "openai:chat:gpt-4.1"
 
 
 def test_run_prompt_csv_failure_details_in_jsonl_not_csv(tmp_path, monkeypatch):
@@ -109,8 +174,8 @@ def test_run_prompt_csv_failure_details_in_jsonl_not_csv(tmp_path, monkeypatch):
     out_dir = tmp_path / "report"
     _write_input_csv(input_csv)
 
-    def fake_run_chat_once(*, project_path, prompt, output_dir=None, view_name=None):
-        del project_path, prompt, output_dir, view_name
+    def fake_run_chat_once(*, project_path, prompt, output_dir=None, view_name=None, model_id=None):
+        del project_path, prompt, output_dir, view_name, model_id
         return {
             "success": False,
             "message": "ERROR: Code execution failed: traceback here",
@@ -150,6 +215,13 @@ def test_run_prompt_csv_failure_details_in_jsonl_not_csv(tmp_path, monkeypatch):
     detail = json.loads(next(out_dir.glob("details_*.jsonl")).read_text(encoding="utf-8").strip())
     assert "traceback" in detail["failure_reason"]
     assert detail["captured_output_excerpt"]
+    assert detail["duration_seconds"] == 1.0
+    assert detail["started_at_utc"]
+    assert detail["finished_at_utc"]
+
+    timing = json.loads(next(out_dir.glob("timing_*.jsonl")).read_text(encoding="utf-8").strip())
+    assert timing["duration_seconds"] == 1.0
+    assert timing["exec_success"] is False
 
     failures_path = next(out_dir.glob("failures_*.jsonl"))
     failure = json.loads(failures_path.read_text(encoding="utf-8").strip())

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -2118,7 +2118,7 @@ wheels = [
 
 [[package]]
 name = "mdvtools"
-version = "1.2.3"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "anndata" },

--- a/src/charts/dialogs/ChatAPI.ts
+++ b/src/charts/dialogs/ChatAPI.ts
@@ -100,9 +100,24 @@ const completedChatResponseSchema = z.object({
     // timestamp: z.string(),
     error: z.boolean().optional(),
 });
+const chatModelSchema = z.object({
+    id: z.string(),
+    label: z.string(),
+    provider: z.enum(['openai', 'ollama']),
+    model: z.string(),
+    kind: z.enum(['chat', 'embedding']),
+    available: z.boolean().optional(),
+});
+
+export type ChatModelOption = z.infer<typeof chatModelSchema>;
+
+const CHAT_MODEL_STORAGE_KEY = 'chatmdv-selected-model';
+
 const chatInitResponseSchema = z.object({
     message: z.string(),
     suggested_questions: z.array(z.string()).optional(),
+    models: z.array(chatModelSchema).optional(),
+    default_model_id: z.string().optional().nullable(),
     error: z.boolean().optional(),
 });
 type ChatInitResponse = z.infer<typeof chatInitResponseSchema>;
@@ -197,7 +212,14 @@ const sendChatInitHttp = async (message: string, id: string, route: string, conv
     return parsed;
 };
 
-const sendMessageSocket = async (message: string, id: string, _routeUnused: string, conversationId: string, time?: number) => {
+const sendMessageSocket = async (
+    message: string,
+    id: string,
+    _routeUnused: string,
+    conversationId: string,
+    modelId?: string,
+    time?: number,
+) => {
     // consider refactoring to be a generator function, so that we can yield progress updates
     const socket = window.mdv.chartManager.ipc?.socket;
     if (!socket) return;
@@ -231,7 +253,12 @@ const sendMessageSocket = async (message: string, id: string, _routeUnused: stri
 
         socket.on('chat_response', onChatResponse);
         socket.on('chat_error', onError);
-        socket.emit('chat_request', { message, id, conversation_id: conversationId });
+        socket.emit('chat_request', {
+            message,
+            id,
+            conversation_id: conversationId,
+            ...(modelId ? { model_id: modelId } : {}),
+        });
     });
 
     return response;
@@ -325,6 +352,27 @@ const useChat = () => {
     const [conversationMap, setConversationMap] = useState<ConversationMap>({});
     const [chatLog, setChatLog] = useState<ChatLogItem[]>([]);
     const [suggestedQuestions, setSuggestedQuestions] = useState<string[]>([]);
+    const [availableModels, setAvailableModels] = useState<ChatModelOption[]>([]);
+    const [selectedModelId, setSelectedModelId] = useState<string>('');
+
+    const applyModelSelection = useCallback((models: ChatModelOption[], defaultModelId?: string | null) => {
+        const chatModels = models.filter((m) => m.kind === 'chat');
+        setAvailableModels(chatModels);
+        const stored = localStorage.getItem(CHAT_MODEL_STORAGE_KEY);
+        const storedValid = stored && chatModels.some((m) => m.id === stored);
+        const nextId = storedValid
+            ? stored
+            : (defaultModelId && chatModels.some((m) => m.id === defaultModelId)
+                ? defaultModelId
+                : chatModels[0]?.id ?? '');
+        setSelectedModelId(nextId);
+    }, []);
+
+    const onModelChange = useCallback((modelId: string) => {
+        setSelectedModelId(modelId);
+        localStorage.setItem(CHAT_MODEL_STORAGE_KEY, modelId);
+    }, []);
+
     const socket = useMemo(() => {
         if (!cm.ipc || !cm.ipc.socket) return null;
         return cm.ipc.socket;
@@ -429,6 +477,9 @@ const useChat = () => {
             // todo: Update when the endpoint is ready
             // const suggestedQuestions = await axios.get("");
             if (response?.suggested_questions) setSuggestedQuestions(response?.suggested_questions);
+            if (response?.models) {
+                applyModelSelection(response.models, response.default_model_id);
+            }
         } catch (error: any) {
             const errorMessage = formatChatError(error);
             console.error('Error sending welcome message: ', errorMessage);
@@ -447,7 +498,7 @@ const useChat = () => {
             setIsInit(true);
             setIsLoadingInit(false);
         }
-    }, [isSending, isInit, routeInit, conversationId, messages.length, isChatLogLoading]);
+    }, [isSending, isInit, routeInit, conversationId, messages.length, isChatLogLoading, applyModelSelection]);
 
     // Socket connection and Init chat
     useEffect(() => {
@@ -495,7 +546,13 @@ const useChat = () => {
                 conversationId,
             }])
             
-            const response = await sendMessageSocket(input, id, "", conversationId);
+            const response = await sendMessageSocket(
+                input,
+                id,
+                "",
+                conversationId,
+                selectedModelId || undefined,
+            );
 
             if (response) {
                 const allViews = viewManager.all_views;
@@ -531,7 +588,7 @@ const useChat = () => {
             setCurrentRequestId('');
             setRequestProgress(null);
         }
-    }, [conversationId, socket, viewManager]);
+    }, [conversationId, socket, viewManager, selectedModelId]);
 
 
     // Start New Conversation
@@ -554,6 +611,9 @@ const useChat = () => {
                 id: generateId(),
                 conversationId: newConversationId
             }]);
+            if (response?.models) {
+                applyModelSelection(response.models, response.default_model_id);
+            }
         } catch (error: any) {
             const errorMessage = formatChatError(error);
             setMessages([{
@@ -569,7 +629,7 @@ const useChat = () => {
             setCurrentRequestId("");
             setIsSending(false);
         }
-    }, [routeInit]);
+    }, [routeInit, applyModelSelection]);
 
     // Switch conversation
     const switchConversation = useCallback((id: string) => {
@@ -593,6 +653,9 @@ const useChat = () => {
         conversationMap,
         isLoadingInit,
         suggestedQuestions,
+        availableModels,
+        selectedModelId,
+        onModelChange,
     };
 };
 

--- a/src/charts/dialogs/ChatAPI.ts
+++ b/src/charts/dialogs/ChatAPI.ts
@@ -91,10 +91,12 @@ const completedChatResponseSchema = z.object({
      * This should be a string that identifies newly created views.
      */
     view: z.optional(z.string()).describe('The name of the newly created view, if a view was created'),
-    /** Provenance summary (also embedded as a TextBox in the created view). */
+    /** Provenance summary (technical; not duplicated in the view). */
     verification: z.string().optional().nullable(),
     /** Truncated stdout from executed script (tabular preview). */
     data_preview: z.string().optional().nullable(),
+    /** Analysis summary (same markdown as the view TextBox). */
+    guidance: z.string().optional().nullable(),
     /** Reload the page when opening the view so datasources.json changes are picked up. */
     needs_refresh: z.boolean().optional(),
     // timestamp: z.string(),
@@ -152,6 +154,7 @@ const chatLogItemSchema = z.object({
     error: z.boolean().optional(),
     verification: z.string().optional().nullable(),
     data_preview: z.string().optional().nullable(),
+    guidance: z.string().optional().nullable(),
 });
 // this is possible - may consider it at some point.
 // .transform((data) => ({
@@ -167,10 +170,12 @@ type ChatResponse = z.infer<typeof completedChatResponseSchema>;
 export type ChatMessage = {
     text: string;
     view?: string;
-    /** Provenance summary (same as the view TextBox when present). */
+    /** Provenance summary (technical). */
     verification?: string | null;
     /** Truncated script stdout shown in chat before the main reply. */
     data_preview?: string | null;
+    /** Analysis summary (same as the view TextBox when present). */
+    guidance?: string | null;
     /** When true, "Load view" should reload the app so new/updated datasources load in ChartManager. */
     needs_refresh?: boolean;
     sender: 'user' | 'bot' | 'system';
@@ -310,6 +315,7 @@ const createMessagePair = (log: ChatLogItem, conversationId: string) => {
         view: viewName,
         verification: log?.verification,
         data_preview: log?.data_preview,
+        guidance: log?.guidance,
         error: log?.error,
     };
     
@@ -569,6 +575,7 @@ const useChat = () => {
                     view: response?.view,
                     verification: response?.verification ?? undefined,
                     data_preview: response?.data_preview ?? undefined,
+                    guidance: response?.guidance ?? undefined,
                     needs_refresh: response?.needs_refresh ?? false,
                 }])
             }

--- a/src/charts/dialogs/ChatDialog.tsx
+++ b/src/charts/dialogs/ChatDialog.tsx
@@ -13,7 +13,7 @@ import {
     TextField,
     Typography,
 } from "@mui/material";
-import type { ChatMessage, ChatProgress, ConversationMap } from "./ChatAPI";
+import type { ChatMessage, ChatModelOption, ChatProgress, ConversationMap } from "./ChatAPI";
 import {
     Close as CloseIcon,
     Launch as LaunchIcon,
@@ -40,6 +40,9 @@ export type ChatDialogProps = {
     conversationMap: ConversationMap;
     conversationId: string;
     suggestedQuestions: string[];
+    availableModels: ChatModelOption[];
+    selectedModelId: string;
+    onModelChange: (modelId: string) => void;
     onPopout?: () => void;
     isPopout?: boolean;
     fullscreen?: boolean;
@@ -60,6 +63,9 @@ const ChatDialog = ({
     conversationMap,
     conversationId,
     suggestedQuestions,
+    availableModels,
+    selectedModelId,
+    onModelChange,
     onPopout,
     isPopout,
     fullscreen = false,
@@ -258,6 +264,9 @@ const ChatDialog = ({
                                     verboseProgress={verboseProgress}
                                     onClose={onClose}
                                     suggestedQuestions={suggestedQuestions}
+                                    availableModels={availableModels}
+                                    selectedModelId={selectedModelId}
+                                    onModelChange={onModelChange}
                                 />
                             </Suspense>
                         )}

--- a/src/charts/dialogs/ChatDialogComponent.tsx
+++ b/src/charts/dialogs/ChatDialogComponent.tsx
@@ -1,6 +1,6 @@
 import { BotMessageSquare, SquareTerminal } from 'lucide-react';
 import { MessageCircleQuestion, ThumbsUp, ThumbsDown, Star, NotebookPen, CircleAlert } from 'lucide-react';
-import { type ChatProgress, type ChatMessage, navigateToView } from './ChatAPI';
+import { type ChatProgress, type ChatMessage, type ChatModelOption, navigateToView } from './ChatAPI';
 import { forwardRef, memo, useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import JsonView from 'react18-json-view';
 import ReactMarkdown from 'react-markdown';
@@ -17,6 +17,10 @@ import {
     Divider,
     IconButton,
     InputAdornment,
+    FormControl,
+    InputLabel,
+    MenuItem,
+    Select,
     Skeleton,
     TextField,
     Typography,
@@ -450,10 +454,24 @@ export type ChatBotProps = {
     verboseProgress: string[];
     onClose: () => void;
     suggestedQuestions: string[];
+    availableModels: ChatModelOption[];
+    selectedModelId: string;
+    onModelChange: (modelId: string) => void;
 };
 
 
-const Chatbot = ({messages, isSending, sendAPI, requestProgress, verboseProgress, onClose, suggestedQuestions}: ChatBotProps) => {
+const Chatbot = ({
+    messages,
+    isSending,
+    sendAPI,
+    requestProgress,
+    verboseProgress,
+    onClose,
+    suggestedQuestions,
+    availableModels,
+    selectedModelId,
+    onModelChange,
+}: ChatBotProps) => {
     const [input, setInput] = useState<string>('');
     const messagesEndRef = useRef<HTMLDivElement>(null);
     const lastMessageRef = useRef<HTMLDivElement>(null);
@@ -542,7 +560,29 @@ const Chatbot = ({messages, isSending, sendAPI, requestProgress, verboseProgress
                 <RobotPandaSVG />
             </Box> */}
             <Divider />
-            <Box className="flex p-4 w-full">
+            <Box className="flex flex-col p-4 w-full gap-2">
+                {availableModels.length > 1 ? (
+                    <FormControl size="small" fullWidth disabled={isSending}>
+                        <InputLabel id="chatmdv-model-label">Model</InputLabel>
+                        <Select
+                            labelId="chatmdv-model-label"
+                            label="Model"
+                            value={selectedModelId}
+                            onChange={(e) => onModelChange(e.target.value)}
+                        >
+                            {availableModels.map((model) => (
+                                <MenuItem key={model.id} value={model.id}>
+                                    {model.label}
+                                </MenuItem>
+                            ))}
+                        </Select>
+                    </FormControl>
+                ) : availableModels.length === 1 ? (
+                    <Typography variant="caption" color="text.secondary">
+                        Model: {availableModels[0].label}
+                    </Typography>
+                ) : null}
+            <Box className="flex w-full">
                 <TextField
                     type="text"
                     // disabled={isSending} //we can still type while it's processing
@@ -570,6 +610,7 @@ const Chatbot = ({messages, isSending, sendAPI, requestProgress, verboseProgress
                 className="p-2 bg-blue-500 text-white rounded-lg" variant='contained'>
                     Send
                 </Button>
+            </Box>
             </Box>
         </Box>
     );

--- a/src/charts/dialogs/ChatDialogComponent.tsx
+++ b/src/charts/dialogs/ChatDialogComponent.tsx
@@ -214,7 +214,6 @@ const Message = memo(forwardRef<HTMLDivElement, MessageProps>(function Message(
                 )}
                 {sender === 'bot' && !error && guidance?.trim() && (
                     <ChatPreviewBlock
-                        variant="data"
                         title="Analysis summary"
                         content={guidance.trim()}
                         defaultExpandedWhenLong

--- a/src/charts/dialogs/ChatDialogComponent.tsx
+++ b/src/charts/dialogs/ChatDialogComponent.tsx
@@ -147,6 +147,7 @@ const Message = memo(forwardRef<HTMLDivElement, MessageProps>(function Message(
     view,
     verification,
     data_preview,
+    guidance,
     needs_refresh,
     onClose,
     error,
@@ -180,6 +181,7 @@ const Message = memo(forwardRef<HTMLDivElement, MessageProps>(function Message(
     const handleCopy = async () => {
         try {
             const parts: string[] = [];
+            if (guidance?.trim()) parts.push(guidance.trim());
             if (data_preview?.trim()) parts.push(data_preview.trim());
             if (verification?.trim()) parts.push(verification.trim());
             if (markdownContent) parts.push(markdownContent);
@@ -210,6 +212,14 @@ const Message = memo(forwardRef<HTMLDivElement, MessageProps>(function Message(
                         )}
                     </IconButton>
                 )}
+                {sender === 'bot' && !error && guidance?.trim() && (
+                    <ChatPreviewBlock
+                        variant="data"
+                        title="Analysis summary"
+                        content={guidance.trim()}
+                        defaultExpandedWhenLong
+                    />
+                )}
                 {sender === 'bot' && !error && data_preview?.trim() && (
                     <ChatPreviewBlock
                         variant="data"
@@ -219,14 +229,12 @@ const Message = memo(forwardRef<HTMLDivElement, MessageProps>(function Message(
                 )}
                 {sender === 'bot' && !error && verification?.trim() && (
                     <ChatPreviewBlock
-                        //title="What you can verify"
-                        //title='xxxxx'
-                        title=""
+                        title="What you can verify"
                         content={verification.trim()}
                         defaultExpandedWhenLong
                     />
                 )}
-                {sender === 'bot' && !error && (data_preview?.trim() || verification?.trim()) ? (
+                {sender === 'bot' && !error && (guidance?.trim() || data_preview?.trim() || verification?.trim()) ? (
                     <Accordion
                         defaultExpanded={false}
                         disableGutters
@@ -247,7 +255,7 @@ const Message = memo(forwardRef<HTMLDivElement, MessageProps>(function Message(
                 {view && sender === 'bot' && !error && (
                     <Box sx={{ mt: 2 }}>
                         <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 1 }}>
-                            Review the data preview and verification above, then open the view.
+                            Review the analysis summary and data preview above, then open the view.
                         </Typography>
                         <Button
                             variant="contained"
@@ -520,7 +528,7 @@ const Chatbot = ({
         const hasPreview =
             last?.sender === 'bot' &&
             !last?.error &&
-            (Boolean(last.verification?.trim()) || Boolean(last.data_preview?.trim()));
+            (Boolean(last.guidance?.trim()) || Boolean(last.verification?.trim()) || Boolean(last.data_preview?.trim()));
 
         if (!isSending && hasPreview && lastMessageRef.current) {
             lastMessageRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' });

--- a/src/react/components/ChatButtons.tsx
+++ b/src/react/components/ChatButtons.tsx
@@ -40,6 +40,9 @@ const ChatProvider: React.FC<ChatProviderProps> = ({
         conversationId,
         isLoadingInit,
         suggestedQuestions,
+        availableModels,
+        selectedModelId,
+        onModelChange,
     } = useChat();
 
     const chatDialogProps = {
@@ -55,6 +58,9 @@ const ChatProvider: React.FC<ChatProviderProps> = ({
         conversationId,
         isLoadingInit,
         suggestedQuestions,
+        availableModels,
+        selectedModelId,
+        onModelChange,
     };
 
     const dialog = (


### PR DESCRIPTION
Add functionality to support local LLM usage. 

1. Added facility to choose local or diiferent remote LLMs 
2. Added more intelligent ways of model choosing data sources.
3. Added ways of not using scanpy, especially when memory is limited 
4. Benchmarked with TAURUS and PBMC 3K with local LLM  (Qwen3-coder)
5. Added explanation in TextBox for each generated View. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Model selection across the chat UI and CLI, including local Ollama, with dynamic model metadata from the server.
  * “Analysis summary” (guidance) panel added to chat responses, persisted in saved views and chat logs.
  * CSV evaluation supports per-run model selection and now writes dedicated timing JSONL output with additional per-row timestamps and block timings.

* **Improvements**
  * Clearer preflight errors for missing datasource columns, including owning-datasource hints.
  * Better large-project routing guidance, Scanpy last-resort behavior, and gridstack layout consistency.
  * Auto-corrects common hallucinated chart import paths; enhanced RAG/guardrail behavior and compact prompt mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->