### PR TITLE
fix issue #504 with long initial view loading by bypassing expectsInitialViewLoaded

### DIFF
--- a/src/modules/project_bootstrap.tsx
+++ b/src/modules/project_bootstrap.tsx
@@ -61,11 +61,13 @@ let stateHandlerContainer: HTMLElement | null = null;
 let stateHandlerRoot: Root | null = null;
 
 function expectsInitialViewLoadedEvent(config: any) {
-    const allViews = config?.all_views;
-    if (Array.isArray(allViews)) {
-        return allViews.length > 0;
-    }
-    return Boolean(config?.only_view);
+    console.log('expectsInitialViewLoaded is always false now, avoid issue with stuck loading screen...');
+    return false;
+    // const allViews = config?.all_views;
+    // if (Array.isArray(allViews)) {
+    //     return allViews.length > 0;
+    // }
+    // return Boolean(config?.only_view);
 }
 
 function LoadState({
@@ -245,6 +247,7 @@ function BootstrapApp({ onComplete }: { onComplete: () => void }) {
                         listener,
                     );
                     if (!expectsInitialViewLoadedEvent(runtime.config)) {
+                        //^^
                         setInitialViewLoaded(true);
                     }
                     setInitialised(true);

--- a/src/modules/project_bootstrap.tsx
+++ b/src/modules/project_bootstrap.tsx
@@ -60,16 +60,6 @@ type BootstrapStatus =
 let stateHandlerContainer: HTMLElement | null = null;
 let stateHandlerRoot: Root | null = null;
 
-function expectsInitialViewLoadedEvent(config: any) {
-    console.log('expectsInitialViewLoaded is always false now, avoid issue with stuck loading screen...');
-    return false;
-    // const allViews = config?.all_views;
-    // if (Array.isArray(allViews)) {
-    //     return allViews.length > 0;
-    // }
-    // return Boolean(config?.only_view);
-}
-
 function LoadState({
     status,
     detail,
@@ -150,8 +140,9 @@ function LoadState({
 function BootstrapApp({ onComplete }: { onComplete: () => void }) {
     const context = useMemo(() => getProjectBootstrapContext(), []);
     const [status, setStatus] = useState<BootstrapStatus>({ kind: "loading" });
+    // nb no longer separately tracking isInitialViewLoaded, 
+    // we can re-introduce that if e.g. we have more lazy charts (probably not)
     const [initialised, setInitialised] = useState(false);
-    const [initialViewLoaded, setInitialViewLoaded] = useState(false);
     const [isClosing, setIsClosing] = useState(false);
     const completeCalledRef = useRef(false);
     const detail = useMemo(() => {
@@ -234,7 +225,6 @@ function BootstrapApp({ onComplete }: { onComplete: () => void }) {
                         }
                         if (type === "view_loaded") {
                             changeURLParam("view", cm.viewManager.current_view);
-                            setInitialViewLoaded(true);
                         }
                     };
 
@@ -246,10 +236,6 @@ function BootstrapApp({ onComplete }: { onComplete: () => void }) {
                         runtime.config,
                         listener,
                     );
-                    if (!expectsInitialViewLoadedEvent(runtime.config)) {
-                        //^^
-                        setInitialViewLoaded(true);
-                    }
                     setInitialised(true);
                 },
             )
@@ -265,10 +251,10 @@ function BootstrapApp({ onComplete }: { onComplete: () => void }) {
     }, [status, initialised]);
 
     useEffect(() => {
-        if (status.kind !== "error" && initialised && initialViewLoaded) {
+        if (status.kind !== "error" && initialised) {
             setIsClosing(true);
         }
-    }, [status, initialised, initialViewLoaded]);
+    }, [status, initialised]);
 
     useEffect(() => {
         if (!isClosing) return;


### PR DESCRIPTION
https://github.com/Taylor-CCB-Group/MDV/issues/504

The project-bootstrap had assumed that if there are some views, then there should be a loading overlay that persists until the loading had settled, but in cases where this is slow it unnecessarily blocks user interaction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the app’s startup flow so the initial view is marked as loaded more reliably after initialization.
  * Reduced cases where the interface could remain in a loading state longer than expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->