### PR TITLE
fix chart and dialog stack zindex logic (fix #518)

### DIFF
--- a/src/charts/ChartManager.js
+++ b/src/charts/ChartManager.js
@@ -2544,15 +2544,6 @@ export class ChartManager {
         popoutChart(chart);
     }
 
-    _sendAllChartsToBack(ds) {
-        for (const id in this.charts) {
-            const c = this.charts[id];
-            if (ds === c.dataSource) {
-                c.chart.div.style.zIndex = "";
-            }
-        }
-    }
-
     /**
      * @param {BaseChart} chart 
      * @param {import("@/charts/charts").DataSource} ds
@@ -2569,19 +2560,18 @@ export class ChartManager {
             return;
         }
         const div = chart.getDiv();
+        const stack = {
+            container: this.contentDiv,
+            group: ds?.name ?? "chart",
+            baseZ: 1,
+        };
         makeDraggable(div, {
             handle: ".ciview-chart-title",
             contain: "topleft",
-            ondragstart: (e) => {
-                this._sendAllChartsToBack(ds);
-                div.style.zIndex = 2;
-            },
+            stack: stack,
         });
         makeResizable(div, {
-            onResizeStart: () => {
-                this._sendAllChartsToBack(ds);
-                div.style.zIndex = 2;
-            },
+            stack: stack,
             onresizeend: (width, height) => chart.setSize(width, height),
         });
     }

--- a/src/utilities/Dialog.js
+++ b/src/utilities/Dialog.js
@@ -79,10 +79,12 @@ class BaseDialog {
             this.outer,
         );
 
+        const stack = { group: "dialog", baseZ: 1100 };
         //... needs fixing in popout / when doc changes
         //(if this was more react-y it should just work)
         makeResizable(this.outer, {
             doc: config.doc,
+            stack: stack,
             onresizeend: (x, y) => {
                 this.onResize(x, y);
             },
@@ -91,6 +93,7 @@ class BaseDialog {
             doc: config.doc,
             handle: ".ciview-dlg-header",
             snapback: true,
+            stack: stack,
         });
 
         if (config.columns) {
@@ -172,10 +175,12 @@ class BaseDialog {
         // need to makeResizable and makeDraggable work with this
         removeResizable(this.outer);
         removeDraggable(this.outer);
+        const dialogStack = { group: "dialog", baseZ: 1100 };
         if (parent) {
             parent.append(this.outer);
             makeResizable(this.outer, {
                 doc: parent.ownerDocument, //is ownerDocument a safe bet? What if we're fullscreen? then we can't resize anyway.
+                stack: dialogStack,
                 onresizeend: (x, y) => {
                     this.onResize(x, y);
                 },
@@ -184,11 +189,13 @@ class BaseDialog {
                 doc: parent.ownerDocument,
                 handle: ".ciview-dlg-header",
                 snapback: true,
+                stack: dialogStack,
             });
         } else {
             this.getDialogContainer().append(this.outer);
             makeResizable(this.outer, {
                 doc: this.config.doc,
+                stack: dialogStack,
                 onresizeend: (x, y) => {
                     this.onResize(x, y);
                 },
@@ -197,6 +204,7 @@ class BaseDialog {
                 doc: this.config.doc,
                 handle: ".ciview-dlg-header",
                 snapback: true,
+                stack: dialogStack,
             });
         }
     }

--- a/src/utilities/Elements.js
+++ b/src/utilities/Elements.js
@@ -207,6 +207,33 @@ function makeSortable(list, config = {}) {
     }
 }
 
+// increment-only z-index per (container, group); no instance registry
+const floatStacks = new WeakMap();
+
+function promoteFloatingElement(el, { container = el.parentElement, group = "default", baseZ = 1 } = {}) {
+    if (!container) {
+        return;
+    }
+    let groups = floatStacks.get(container);
+    if (!groups) {
+        groups = new Map();
+        floatStacks.set(container, groups);
+    }
+    let stack = groups.get(group);
+    if (!stack) {
+        stack = { next: 0, baseZ };
+        groups.set(group, stack);
+    }
+    stack.next += 1;
+    el.style.zIndex = String(stack.baseZ + stack.next);
+}
+
+function promoteIfStacked(el, stack) {
+    if (stack) {
+        promoteFloatingElement(el, stack === true ? {} : stack);
+    }
+}
+
 function makeResizable(el, config = {}) {
     //already resizable
     if (el.__resizeinfo__) {
@@ -265,6 +292,7 @@ function makeResizable(el, config = {}) {
     };
     function initDrag(e) {
         e.preventDefault();
+        promoteIfStacked(el, config.stack);
         if (config.onResizeStart) config.onResizeStart();
         const startX = e.clientX;
         const startY = e.clientY;
@@ -393,6 +421,7 @@ class MDVProgress {
  * @param {boolean} [config.snapback] - if set, if the drag is released with the element off 
  * the side of its container, it will snap back to the edge. This has known issues and is
  * currently only being used for Dialogs.
+ * @param {boolean|object} [config.stack] - promote on drag start; object may set container, group, baseZ
  * @returns {void}
  */
 function makeDraggable(el, config = {}) {
@@ -436,6 +465,7 @@ function makeDraggable(el, config = {}) {
         // get the mouse cursor position at startup:
         pos3 = e.clientX;
         pos4 = e.clientY;
+        promoteIfStacked(el, config.stack);
         if (config.ondragstart) {
             config.ondragstart(el);
         }


### PR DESCRIPTION
https://github.com/Taylor-CCB-Group/MDV/issues/518

Charts were pushed to the top when moved or resized, but the rest of the charts would shuffle because they had their index unset. Dialogs weren't able to push themselves up stack.

Instead, we add `promoteFloatingElement` / `promoteIfStacked` which increments z-index in relation to other `'dialog'`s or charts from the same DS.

We don't serialise this, though, so it seems like technically we don't really guarantee a view will appear the same as when it was saved. That isn't a regression though and probably not a massive issue (definitely not ideal though).