### PR TITLE
Feature/specify datasource

### DIFF
--- a/docker-secrets.yml
+++ b/docker-secrets.yml
@@ -45,6 +45,7 @@ services:
       - DB_PASSWORD=my_db_password
       - DB_NAME=my_db_name
       - DB_HOST=mdv_db  # Assuming the db service name is mdv_db
+      - OLLAMA_BASE_URL=http://host.docker.internal:11434
 
       - FLASK_SECRET_KEY=abc
       - MDV_API_ROOT=/ # If the app is mounted at the root path, otherwise set to /mdv or similar

--- a/python/mdvtools/llm/chat_cli.py
+++ b/python/mdvtools/llm/chat_cli.py
@@ -190,11 +190,18 @@ def _write_debug_artifacts(
     return str(out)
 
 
-def _parse_datasource_names(raw: Optional[str]) -> list[str] | None:
+def _parse_datasource_cli_args(
+    raw: Optional[str],
+) -> tuple[str, list[str] | None]:
+    """Return (datasource_mode, names) for CLI --datasources."""
     if not raw or not str(raw).strip():
-        return None
+        return "auto", None
+    if str(raw).strip().lower() == "auto":
+        return "auto", None
     names = [part.strip() for part in str(raw).split(",") if part.strip()]
-    return names or None
+    if not names:
+        return "auto", None
+    return "manual", names
 
 
 def run_chat_once(
@@ -204,6 +211,7 @@ def run_chat_once(
     output_dir: Optional[str] = None,
     view_name: Optional[str] = None,
     model_id: Optional[str] = None,
+    datasource_mode: str = "auto",
     datasource_names: list[str] | None = None,
 ) -> tuple[dict[str, Any], int]:
     abs_project = str(Path(project_path).expanduser().resolve())
@@ -245,7 +253,8 @@ def run_chat_once(
         }
         if resolved_model_id:
             chat_request["model_id"] = resolved_model_id
-        if datasource_names:
+        chat_request["datasource_mode"] = datasource_mode
+        if datasource_mode == "manual" and datasource_names:
             chat_request["datasource_names"] = datasource_names
         from io import StringIO
         from contextlib import redirect_stdout, redirect_stderr
@@ -391,6 +400,7 @@ def run_batch_prompts(
     base_url: str,
     output_dir: Optional[str] = None,
     model_id: Optional[str] = None,
+    datasource_mode: str = "auto",
     datasource_names: list[str] | None = None,
 ) -> tuple[list[dict[str, Any]], int]:
     prompts = _load_prompts(prompt_file)
@@ -411,6 +421,7 @@ def run_batch_prompts(
             output_dir=str(run_out) if run_out else None,
             view_name=None,
             model_id=model_id,
+            datasource_mode=datasource_mode,
             datasource_names=datasource_names,
         )
         finished = datetime.now(timezone.utc)
@@ -476,7 +487,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         except ValueError as exc:
             print(f"Argument error: {exc}", file=sys.stderr)
             return 2
-        datasource_names = _parse_datasource_names(args.datasources)
+        datasource_mode, datasource_names = _parse_datasource_cli_args(args.datasources)
         if args.prompt_file:
             rows, exit_code = run_batch_prompts(
                 project_path=args.project,
@@ -485,6 +496,7 @@ def main(argv: Optional[list[str]] = None) -> int:
                 base_url=args.base_url,
                 output_dir=args.output_dir,
                 model_id=args.model,
+                datasource_mode=datasource_mode,
                 datasource_names=datasource_names,
             )
             summary = {
@@ -506,6 +518,7 @@ def main(argv: Optional[list[str]] = None) -> int:
             output_dir=args.output_dir,
             view_name=args.view_name,
             model_id=args.model,
+            datasource_mode=datasource_mode,
             datasource_names=datasource_names,
         )
 

--- a/python/mdvtools/llm/chat_cli.py
+++ b/python/mdvtools/llm/chat_cli.py
@@ -63,6 +63,14 @@ def _build_parser() -> argparse.ArgumentParser:
             "or the first discovered model."
         ),
     )
+    parser.add_argument(
+        "--datasources",
+        default=None,
+        help=(
+            "Comma-separated MDV datasource names to scope analysis "
+            "(first name is the primary chart target)."
+        ),
+    )
     return parser
 
 
@@ -182,6 +190,13 @@ def _write_debug_artifacts(
     return str(out)
 
 
+def _parse_datasource_names(raw: Optional[str]) -> list[str] | None:
+    if not raw or not str(raw).strip():
+        return None
+    names = [part.strip() for part in str(raw).split(",") if part.strip()]
+    return names or None
+
+
 def run_chat_once(
     *,
     project_path: str,
@@ -189,6 +204,7 @@ def run_chat_once(
     output_dir: Optional[str] = None,
     view_name: Optional[str] = None,
     model_id: Optional[str] = None,
+    datasource_names: list[str] | None = None,
 ) -> tuple[dict[str, Any], int]:
     abs_project = str(Path(project_path).expanduser().resolve())
     views_file = str(Path(abs_project) / "views.json")
@@ -229,6 +245,8 @@ def run_chat_once(
         }
         if resolved_model_id:
             chat_request["model_id"] = resolved_model_id
+        if datasource_names:
+            chat_request["datasource_names"] = datasource_names
         from io import StringIO
         from contextlib import redirect_stdout, redirect_stderr
         out_stream = StringIO()
@@ -373,6 +391,7 @@ def run_batch_prompts(
     base_url: str,
     output_dir: Optional[str] = None,
     model_id: Optional[str] = None,
+    datasource_names: list[str] | None = None,
 ) -> tuple[list[dict[str, Any]], int]:
     prompts = _load_prompts(prompt_file)
     rows: list[dict[str, Any]] = []
@@ -392,6 +411,7 @@ def run_batch_prompts(
             output_dir=str(run_out) if run_out else None,
             view_name=None,
             model_id=model_id,
+            datasource_names=datasource_names,
         )
         finished = datetime.now(timezone.utc)
         if exit_code != 0:
@@ -456,6 +476,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         except ValueError as exc:
             print(f"Argument error: {exc}", file=sys.stderr)
             return 2
+        datasource_names = _parse_datasource_names(args.datasources)
         if args.prompt_file:
             rows, exit_code = run_batch_prompts(
                 project_path=args.project,
@@ -464,6 +485,7 @@ def main(argv: Optional[list[str]] = None) -> int:
                 base_url=args.base_url,
                 output_dir=args.output_dir,
                 model_id=args.model,
+                datasource_names=datasource_names,
             )
             summary = {
                 "batch_count": len(rows),
@@ -484,6 +506,7 @@ def main(argv: Optional[list[str]] = None) -> int:
             output_dir=args.output_dir,
             view_name=args.view_name,
             model_id=args.model,
+            datasource_names=datasource_names,
         )
 
         if args.json_output:

--- a/python/mdvtools/llm/chat_cli.py
+++ b/python/mdvtools/llm/chat_cli.py
@@ -9,7 +9,7 @@ import traceback
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 from urllib.parse import urlparse
 
 from mdvtools.llm.chat_protocol import AskQuestionResult, ChatRequest, ProjectChat
@@ -192,7 +192,7 @@ def _write_debug_artifacts(
 
 def _parse_datasource_cli_args(
     raw: Optional[str],
-) -> tuple[str, list[str] | None]:
+) -> tuple[Literal["auto", "manual"], list[str] | None]:
     """Return (datasource_mode, names) for CLI --datasources."""
     if not raw or not str(raw).strip():
         return "auto", None
@@ -211,7 +211,7 @@ def run_chat_once(
     output_dir: Optional[str] = None,
     view_name: Optional[str] = None,
     model_id: Optional[str] = None,
-    datasource_mode: str = "auto",
+    datasource_mode: Literal["auto", "manual"] = "auto",
     datasource_names: list[str] | None = None,
 ) -> tuple[dict[str, Any], int]:
     abs_project = str(Path(project_path).expanduser().resolve())
@@ -400,7 +400,7 @@ def run_batch_prompts(
     base_url: str,
     output_dir: Optional[str] = None,
     model_id: Optional[str] = None,
-    datasource_mode: str = "auto",
+    datasource_mode: Literal["auto", "manual"] = "auto",
     datasource_names: list[str] | None = None,
 ) -> tuple[list[dict[str, Any]], int]:
     prompts = _load_prompts(prompt_file)

--- a/python/mdvtools/llm/chat_protocol.py
+++ b/python/mdvtools/llm/chat_protocol.py
@@ -25,6 +25,7 @@ class ChatRequest(TypedDict):
     room: str
     handle_error: HandleError
     model_id: NotRequired[str]
+    datasource_names: NotRequired[list[str]]
 
 class ProjectChatProtocol(Protocol):
     def __init__(self, project: MDVProject): ...

--- a/python/mdvtools/llm/chat_protocol.py
+++ b/python/mdvtools/llm/chat_protocol.py
@@ -1,4 +1,4 @@
-from typing import NotRequired, Optional, Protocol, Any, TypedDict, Union
+from typing import Literal, NotRequired, Optional, Protocol, Any, TypedDict, Union
 from mdvtools.mdvproject import MDVProject
 
 
@@ -11,6 +11,7 @@ class AskQuestionResult(TypedDict):
     data_preview: Optional[str]
     guidance: Optional[str]
     needs_refresh: bool
+    resolved_datasource_names: NotRequired[list[str] | None]
 
 
 class HandleError(Protocol):
@@ -25,6 +26,7 @@ class ChatRequest(TypedDict):
     room: str
     handle_error: HandleError
     model_id: NotRequired[str]
+    datasource_mode: NotRequired[Literal["auto", "manual"]]
     datasource_names: NotRequired[list[str]]
 
 class ProjectChatProtocol(Protocol):
@@ -74,6 +76,7 @@ except Exception as e:
                 data_preview=None,
                 guidance=None,
                 needs_refresh=False,
+                resolved_datasource_names=None,
             )
 
 # Tell the type checker we’re exposing a ProjectChat conforming to the protocol

--- a/python/mdvtools/llm/chat_server_extension.py
+++ b/python/mdvtools/llm/chat_server_extension.py
@@ -15,6 +15,7 @@ from flask import Flask, request
 from flask_socketio import join_room, leave_room
 from mdvtools.logging_config import get_logger
 from mdvtools.llm.chatlog import log_chat_item
+from mdvtools.llm.datasource_roles import build_chat_datasource_catalog
 from mdvtools.llm.llm_providers import discover_models
 from mdvtools.server_extension import MDVProjectServerExtension
 from mdvtools.auth.authutils import is_authenticated
@@ -72,11 +73,14 @@ class MDVProjectChatServerExtension(MDVProjectServerExtension):
             suggested_questions = bot.get_suggested_questions()
             logger.info(f"Suggested questions: {suggested_questions}")
             discovered = discover_models()
+            ds_catalog = build_chat_datasource_catalog(project)
             return {
                 "message": detailed_message,
                 "suggested_questions": suggested_questions,
                 "models": [m.to_dict() for m in discovered.chat_models],
                 "default_model_id": discovered.default_model_id,
+                "datasources": ds_catalog["datasources"],
+                "default_datasource_names": ds_catalog["default_datasource_names"],
             }
 
         @socketio.on("chat_request", namespace=f"/project/{project.id}")
@@ -93,6 +97,7 @@ class MDVProjectChatServerExtension(MDVProjectServerExtension):
             id = data.get("id")
             conversation_id = data.get("conversation_id")
             model_id = data.get("model_id")
+            datasource_names = data.get("datasource_names")
             room = f"{sid}_{id}"
             join_room(room)
             def handle_error(error: Union[str, Exception], *, extra_metadata: Optional[dict] = None):
@@ -136,6 +141,10 @@ class MDVProjectChatServerExtension(MDVProjectServerExtension):
             }
             if model_id:
                 chat_request["model_id"] = model_id
+            if datasource_names and isinstance(datasource_names, list):
+                chat_request["datasource_names"] = [
+                    str(n) for n in datasource_names if n
+                ]
             try:
                 if bot is None:
                     # todo - allow this to be freed at some point if we're not using it anymore.

--- a/python/mdvtools/llm/chat_server_extension.py
+++ b/python/mdvtools/llm/chat_server_extension.py
@@ -97,6 +97,7 @@ class MDVProjectChatServerExtension(MDVProjectServerExtension):
             id = data.get("id")
             conversation_id = data.get("conversation_id")
             model_id = data.get("model_id")
+            datasource_mode = data.get("datasource_mode")
             datasource_names = data.get("datasource_names")
             room = f"{sid}_{id}"
             join_room(room)
@@ -141,7 +142,13 @@ class MDVProjectChatServerExtension(MDVProjectServerExtension):
             }
             if model_id:
                 chat_request["model_id"] = model_id
-            if datasource_names and isinstance(datasource_names, list):
+            if datasource_mode in ("auto", "manual"):
+                chat_request["datasource_mode"] = datasource_mode
+            if (
+                datasource_mode == "manual"
+                and datasource_names
+                and isinstance(datasource_names, list)
+            ):
                 chat_request["datasource_names"] = [
                     str(n) for n in datasource_names if n
                 ]
@@ -175,6 +182,9 @@ class MDVProjectChatServerExtension(MDVProjectServerExtension):
                         "data_preview": result.get("data_preview"),
                         "guidance": result.get("guidance"),
                         "needs_refresh": result.get("needs_refresh", False),
+                        "resolved_datasource_names": result.get(
+                            "resolved_datasource_names"
+                        ),
                     }
                     if result["view_name"] is not None:
                         response["view"] = result["view_name"]

--- a/python/mdvtools/llm/code_manipulation.py
+++ b/python/mdvtools/llm/code_manipulation.py
@@ -82,9 +82,16 @@ def _autofix_generated_code(code: str, log=print) -> str:
     return code
 
 
-def _prepend_chatmdv_roles_block(code: str, project: Any) -> str:
+def _prepend_chatmdv_roles_block(
+    code: str,
+    project: Any,
+    *,
+    selected_datasources: list[str] | None = None,
+) -> str:
     try:
-        roles_block = build_chatmdv_roles_constants_block(project)
+        roles_block = build_chatmdv_roles_constants_block(
+            project, selected_datasources=selected_datasources
+        )
     except Exception:
         return code
     if not roles_block.strip():
@@ -106,6 +113,8 @@ def prepare_code(
     log=print,
     modify_existing_project=False,
     view_name="default",
+    *,
+    selected_datasources: list[str] | None = None,
 ):
     """Given a response from the LLM, extract the code and post-process it, 
     attempting to ensure that 
@@ -162,7 +171,9 @@ if __name__ == "__main__":
     else:
         body = captured_lines
     final_code = f"{packages_functions}\n{body}"
-    final_code = _prepend_chatmdv_roles_block(final_code, project)
+    final_code = _prepend_chatmdv_roles_block(
+        final_code, project, selected_datasources=selected_datasources
+    )
     final_code = _autofix_generated_code(final_code, log=log)
     final_code = final_code.replace("project.serve()", "# project.serve()")
     if modify_existing_project:

--- a/python/mdvtools/llm/dataset_scale.py
+++ b/python/mdvtools/llm/dataset_scale.py
@@ -139,73 +139,101 @@ def agent_expression_probe_columns(
     return picked or ([name_column] if name_column else [])
 
 
+_AGENT_PROBE_CAP = 6
+
+
+def _load_probe_df_for_datasource(
+    project: Any,
+    datasource_name: str,
+    scale: ProjectScale,
+    roles: Any,
+) -> Any | None:
+    """Load one probe dataframe for the pandas agent (column subset on large projects)."""
+    expr_names = {e.datasource_name for e in (roles.expressions or [])}
+    primary_expr = roles.preferred_expression()
+    is_expression = datasource_name in expr_names
+
+    if scale.is_large:
+        if is_expression and primary_expr and datasource_name == primary_expr.datasource_name:
+            cols = agent_expression_probe_columns(
+                project, datasource_name, primary_expr.name_column
+            )
+        else:
+            cols = agent_probe_columns_from_metadata(project, datasource_name)
+        if not cols:
+            return None
+        return project.get_datasource_as_dataframe(datasource_name, columns=cols)
+
+    return project.get_datasource_as_dataframe(datasource_name)
+
+
 def load_agent_dataframes(
     project: Any,
     roles: Any,
     scale: ProjectScale,
     *,
     extra_datasource: str | None = None,
-) -> list[Any]:
+    selected_datasources: list[str] | None = None,
+) -> dict[str, Any]:
     """
-    Return [obs_df] or [obs_df, expr_df] for the pandas agent.
+    Return datasource-name-keyed probe DataFrames for the pandas agent.
 
     Large projects load column subsets only; small projects load full tables.
-    When there is no expression datasource and the project has multiple tabular tables,
-    ``extra_datasource`` (typically question-resolved) is loaded as df2 for agent probing.
+    When ``selected_datasources`` is set, load up to ``_AGENT_PROBE_CAP`` tables.
+    Legacy ``extra_datasource`` is used only when ``selected_datasources`` is absent.
     """
+    if selected_datasources:
+        out: dict[str, Any] = {}
+        for ds_name in selected_datasources[:_AGENT_PROBE_CAP]:
+            try:
+                df = _load_probe_df_for_datasource(project, ds_name, scale, roles)
+            except Exception:
+                continue
+            if df is not None:
+                out[ds_name] = df
+        if out:
+            return out
+
     obs_ds = roles.obs_datasource
-    if scale.is_large:
-        obs_cols = agent_probe_columns_from_metadata(project, obs_ds)
-        if not obs_cols:
+    df_obs = _load_probe_df_for_datasource(project, obs_ds, scale, roles)
+    if df_obs is None:
+        if scale.is_large:
             raise ValueError(
                 f"Large project: no probe columns for obs datasource {obs_ds!r}; "
                 "refusing full table load"
             )
-        df1 = project.get_datasource_as_dataframe(obs_ds, columns=obs_cols)
-    else:
-        df1 = project.get_datasource_as_dataframe(obs_ds)
+        df_obs = project.get_datasource_as_dataframe(obs_ds)
+
+    out = {obs_ds: df_obs}
 
     primary_expr = roles.preferred_expression()
-    if primary_expr is None:
-        names: list[str] = []
+    if primary_expr is not None:
+        expr_ds = primary_expr.datasource_name
+        df_expr = _load_probe_df_for_datasource(project, expr_ds, scale, roles)
+        if df_expr is not None:
+            out[expr_ds] = df_expr
+        return out
+
+    names: list[str] = []
+    try:
+        names = list(project.get_datasource_names())
+    except Exception:
+        pass
+    if (
+        extra_datasource
+        and extra_datasource != obs_ds
+        and len(names) > 2
+        and "cells" not in names
+    ):
         try:
-            names = list(project.get_datasource_names())
+            df_extra = _load_probe_df_for_datasource(
+                project, extra_datasource, scale, roles
+            )
+            if df_extra is not None:
+                out[extra_datasource] = df_extra
         except Exception:
             pass
-        if (
-            extra_datasource
-            and extra_datasource != obs_ds
-            and len(names) > 2
-            and "cells" not in names
-        ):
-            try:
-                if scale.is_large:
-                    extra_cols = agent_probe_columns_from_metadata(
-                        project, extra_datasource
-                    )
-                    if not extra_cols:
-                        return [df1]
-                    df_extra = project.get_datasource_as_dataframe(
-                        extra_datasource, columns=extra_cols
-                    )
-                else:
-                    df_extra = project.get_datasource_as_dataframe(extra_datasource)
-                return [df1, df_extra]
-            except Exception:
-                pass
-        return [df1]
-
-    expr_ds = primary_expr.datasource_name
-    if scale.is_large:
-        expr_cols = agent_expression_probe_columns(
-            project, expr_ds, primary_expr.name_column
-        )
-        if not expr_cols:
-            return [df1]
-        df2 = project.get_datasource_as_dataframe(expr_ds, columns=expr_cols)
-    else:
-        df2 = project.get_datasource_as_dataframe(expr_ds)
-    return [df1, df2]
+    return out
 
 
 def format_scale_context_block(scale: ProjectScale) -> str:

--- a/python/mdvtools/llm/dataset_scale.py
+++ b/python/mdvtools/llm/dataset_scale.py
@@ -184,15 +184,24 @@ def load_agent_dataframes(
     """
     if selected_datasources:
         out: dict[str, Any] = {}
+        first_error: Exception | None = None
         for ds_name in selected_datasources[:_AGENT_PROBE_CAP]:
             try:
                 df = _load_probe_df_for_datasource(project, ds_name, scale, roles)
-            except Exception:
+            except Exception as exc:
+                if first_error is None:
+                    first_error = exc
                 continue
             if df is not None:
                 out[ds_name] = df
         if out:
             return out
+        if first_error is not None:
+            raise first_error
+        raise ValueError(
+            "None of the requested selected datasources produced a probe dataframe: "
+            f"{selected_datasources[:_AGENT_PROBE_CAP]!r}"
+        )
 
     obs_ds = roles.obs_datasource
     df_obs = _load_probe_df_for_datasource(project, obs_ds, scale, roles)

--- a/python/mdvtools/llm/datasource_roles.py
+++ b/python/mdvtools/llm/datasource_roles.py
@@ -159,6 +159,127 @@ def _resolve_by_field_overlap(
     return max(scores, key=lambda ds: (scores[ds], ds))
 
 
+@dataclass(frozen=True)
+class ResolvedDatasources:
+    """Datasource routing for a single ChatMDV request."""
+
+    primary: str
+    selected: list[str]
+    source: str  # "user" | "question" | "default"
+
+
+def _datasource_role_for_name(
+    name: str,
+    roles: InferredDatasourceRoles,
+    expression_names: set[str],
+) -> str:
+    if name == roles.obs_datasource:
+        return "obs"
+    if name in expression_names:
+        return "expression"
+    return "table"
+
+
+def build_chat_datasource_catalog(project: Any) -> dict[str, Any]:
+    """
+    Structured datasource list for ChatMDV init (UI picker) and default selection.
+    """
+    roles = infer_datasource_roles(project)
+    names = _project_datasource_names(project)
+    expression_names = {e.datasource_name for e in roles.expressions}
+    datasources: list[dict[str, Any]] = []
+    for name in names:
+        row_count: int | None = None
+        try:
+            md = project.get_datasource_metadata(name)
+            if isinstance(md, dict) and md.get("size") is not None:
+                row_count = int(md["size"])
+        except Exception:
+            pass
+        datasources.append(
+            {
+                "name": name,
+                "role": _datasource_role_for_name(name, roles, expression_names),
+                "row_count": row_count,
+            }
+        )
+
+    if len(names) == 1:
+        default_names = [names[0]]
+    elif "cells" in names:
+        default_names = [roles.obs_datasource]
+        expr = roles.preferred_expression()
+        if expr is not None:
+            default_names.append(expr.datasource_name)
+    else:
+        default_names = [roles.obs_datasource]
+
+    return {
+        "datasources": datasources,
+        "default_datasource_names": default_names,
+    }
+
+
+def resolve_datasources_for_request(
+    project: Any,
+    *,
+    question: str,
+    user_datasource_names: list[str] | None = None,
+    field_index: dict[str, set[str]] | None = None,
+) -> ResolvedDatasources:
+    """
+    Resolve primary and selected datasources for a chat request.
+
+    User selection takes precedence; otherwise fall back to question-based routing,
+    then the first project datasource.
+    """
+    names = _project_datasource_names(project)
+    if not names:
+        raise ValueError("Project has no datasources")
+
+    if user_datasource_names:
+        valid = [n for n in user_datasource_names if n in names]
+        if not valid:
+            raise ValueError(
+                f"No valid datasources in {user_datasource_names!r}; "
+                f"available: {names}"
+            )
+        return ResolvedDatasources(primary=valid[0], selected=valid, source="user")
+
+    if field_index is None:
+        field_index = build_datasource_field_index(project)
+
+    resolved = resolve_datasource_from_question(
+        project, question, field_index=field_index
+    )
+    if resolved is not None:
+        return ResolvedDatasources(
+            primary=resolved, selected=[resolved], source="question"
+        )
+
+    default = str(names[0])
+    return ResolvedDatasources(primary=default, selected=[default], source="default")
+
+
+def format_selected_datasources_cross_table_policy(
+    selected_datasources: list[str],
+) -> str:
+    """Prompt text when the user selected multiple datasources for one analysis."""
+    if len(selected_datasources) < 2:
+        return ""
+    names = ", ".join(f"`{n}`" for n in selected_datasources)
+    primary = selected_datasources[0]
+    return (
+        "- **User-selected datasources:** "
+        f"{names}. Primary chart target: `{primary}` (first selected).\n"
+        "- Load each table with `project.get_datasource_as_dataframe(<datasource>, columns=[...])` "
+        "using only field ids from that datasource's metadata.\n"
+        "- For cross-table questions, merge in pandas on shared keys (`run_id`, `cell_id`, etc.) "
+        "discovered from Project Data Context — do not invent join columns.\n"
+        "- Chart `initialCharts` keys and `params` must use field ids from the datasource that owns each column.\n"
+    )
+
+
 def resolve_datasource_from_question(
     project: Any,
     question: str,
@@ -375,16 +496,27 @@ def collect_wrapper_subgroup_keys_for_project(project: Any) -> set[str]:
     return keys
 
 
-def build_chatmdv_roles_constants_block(project: Any) -> str:
+def build_chatmdv_roles_constants_block(
+    project: Any,
+    *,
+    selected_datasources: list[str] | None = None,
+) -> str:
     """
     Python source injected into ChatMDV-generated scripts so the LLM does not
     rediscover rows-as-columns metadata at runtime.
     """
     roles = infer_datasource_roles(project)
     expr = roles.preferred_expression()
+    primary = (
+        selected_datasources[0]
+        if selected_datasources
+        else roles.obs_datasource
+    )
     lines = [
         "# --- ChatMDV project roles (derived from project metadata; do not edit) ---",
         f"CHATMDV_OBS_DATASOURCE = {json.dumps(roles.obs_datasource)}",
+        f"CHATMDV_PRIMARY_DATASOURCE = {json.dumps(primary)}",
+        f"CHATMDV_SELECTED_DATASOURCES = {json.dumps(selected_datasources or [])}",
     ]
     if expr is None:
         lines.extend(

--- a/python/mdvtools/llm/datasource_roles.py
+++ b/python/mdvtools/llm/datasource_roles.py
@@ -165,7 +165,134 @@ class ResolvedDatasources:
 
     primary: str
     selected: list[str]
-    source: str  # "user" | "question" | "default"
+    source: str  # "user" | "auto" | "question" | "default"
+
+
+_EXPRESSION_QUESTION_KEYWORDS = frozenset(
+    {
+        "gene",
+        "genes",
+        "marker",
+        "markers",
+        "expression",
+        "express",
+        "protein",
+        "rna",
+        "enrichment",
+        "signature",
+        "deg",
+        "degs",
+        "differential",
+    }
+)
+
+
+def _order_datasources(names: list[str], selected: set[str]) -> list[str]:
+    """Stable catalog order for a subset of datasource names."""
+    return [n for n in names if n in selected]
+
+
+def _pick_primary_datasource(
+    project: Any,
+    selected: list[str],
+    *,
+    mentioned_fields: set[str],
+    field_index: dict[str, set[str]],
+) -> str:
+    if not selected:
+        raise ValueError("Cannot pick primary from empty selection")
+    if len(selected) == 1:
+        return selected[0]
+    scores = {
+        ds: len(mentioned_fields & field_index.get(ds, set()))
+        for ds in selected
+    }
+    best_score = max(scores.values())
+    top = [ds for ds in selected if scores[ds] == best_score]
+    if len(top) == 1:
+        return top[0]
+    try:
+        obs = infer_datasource_roles(project).obs_datasource
+        if obs in top:
+            return obs
+    except Exception:
+        pass
+    return top[0]
+
+
+def _question_suggests_expression(question: str) -> bool:
+    tokens = _question_word_tokens(question)
+    return bool(tokens & _EXPRESSION_QUESTION_KEYWORDS)
+
+
+def resolve_datasources_from_question_auto(
+    project: Any,
+    question: str,
+    *,
+    field_index: dict[str, set[str]] | None = None,
+) -> ResolvedDatasources:
+    """
+    Infer one or more datasources from the question text and project field metadata.
+    """
+    names = _project_datasource_names(project)
+    if not names:
+        raise ValueError("Project has no datasources")
+
+    if field_index is None:
+        field_index = build_datasource_field_index(project)
+
+    name_matches = _datasource_names_mentioned_in_question(names, question)
+    if name_matches:
+        ordered = sorted(name_matches, key=len, reverse=True)
+        primary = ordered[0]
+        stable = _order_datasources(names, set(ordered))
+        return ResolvedDatasources(primary=primary, selected=stable, source="auto")
+
+    mentioned = _question_field_tokens(question, field_index)
+    if mentioned:
+        owners_by_field = find_datasources_for_fields(field_index, sorted(mentioned))
+        owner_set = {ds for owners in owners_by_field.values() for ds in owners}
+        if owner_set:
+            stable = _order_datasources(names, owner_set)
+            primary = _pick_primary_datasource(
+                project,
+                stable,
+                mentioned_fields=mentioned,
+                field_index=field_index,
+            )
+            # Primary first in selected list for RAG/chart default.
+            if primary in stable:
+                stable = [primary] + [ds for ds in stable if ds != primary]
+            return ResolvedDatasources(
+                primary=primary, selected=stable, source="auto"
+            )
+
+    if "cells" in names and _question_suggests_expression(question):
+        roles = infer_datasource_roles(project)
+        expr = roles.preferred_expression()
+        if expr is not None:
+            selected = _order_datasources(
+                names, {roles.obs_datasource, expr.datasource_name}
+            )
+            return ResolvedDatasources(
+                primary=roles.obs_datasource,
+                selected=selected,
+                source="auto",
+            )
+
+    catalog = build_chat_datasource_catalog(project)
+    default_names = [
+        n for n in catalog.get("default_datasource_names", []) if n in names
+    ]
+    if default_names:
+        return ResolvedDatasources(
+            primary=default_names[0],
+            selected=default_names,
+            source="auto",
+        )
+
+    default = str(names[0])
+    return ResolvedDatasources(primary=default, selected=[default], source="default")
 
 
 def _datasource_role_for_name(
@@ -249,29 +376,29 @@ def resolve_datasources_for_request(
     if field_index is None:
         field_index = build_datasource_field_index(project)
 
-    resolved = resolve_datasource_from_question(
+    return resolve_datasources_from_question_auto(
         project, question, field_index=field_index
     )
-    if resolved is not None:
-        return ResolvedDatasources(
-            primary=resolved, selected=[resolved], source="question"
-        )
-
-    default = str(names[0])
-    return ResolvedDatasources(primary=default, selected=[default], source="default")
 
 
 def format_selected_datasources_cross_table_policy(
     selected_datasources: list[str],
+    *,
+    auto_resolved: bool = False,
 ) -> str:
-    """Prompt text when the user selected multiple datasources for one analysis."""
+    """Prompt text when multiple datasources are in scope for one analysis."""
     if len(selected_datasources) < 2:
         return ""
     names = ", ".join(f"`{n}`" for n in selected_datasources)
     primary = selected_datasources[0]
+    scope_label = (
+        "Auto-resolved datasources"
+        if auto_resolved
+        else "Selected datasources"
+    )
     return (
-        "- **User-selected datasources:** "
-        f"{names}. Primary chart target: `{primary}` (first selected).\n"
+        f"- **{scope_label}:** "
+        f"{names}. Primary chart target: `{primary}` (first in scope).\n"
         "- Load each table with `project.get_datasource_as_dataframe(<datasource>, columns=[...])` "
         "using only field ids from that datasource's metadata.\n"
         "- For cross-table questions, merge in pandas on shared keys (`run_id`, `cell_id`, etc.) "

--- a/python/mdvtools/llm/datasource_roles.py
+++ b/python/mdvtools/llm/datasource_roles.py
@@ -225,6 +225,15 @@ def _question_suggests_expression(question: str) -> bool:
     return bool(tokens & _EXPRESSION_QUESTION_KEYWORDS)
 
 
+def _resolved_datasources(
+    primary: str, selected: list[str], *, source: str
+) -> ResolvedDatasources:
+    """Keep primary aligned with the first selected datasource."""
+    if primary in selected:
+        selected = [primary] + [ds for ds in selected if ds != primary]
+    return ResolvedDatasources(primary=primary, selected=selected, source=source)
+
+
 def resolve_datasources_from_question_auto(
     project: Any,
     question: str,
@@ -246,7 +255,7 @@ def resolve_datasources_from_question_auto(
         ordered = sorted(name_matches, key=len, reverse=True)
         primary = ordered[0]
         stable = _order_datasources(names, set(ordered))
-        return ResolvedDatasources(primary=primary, selected=stable, source="auto")
+        return _resolved_datasources(primary, stable, source="auto")
 
     mentioned = _question_field_tokens(question, field_index)
     if mentioned:
@@ -260,12 +269,7 @@ def resolve_datasources_from_question_auto(
                 mentioned_fields=mentioned,
                 field_index=field_index,
             )
-            # Primary first in selected list for RAG/chart default.
-            if primary in stable:
-                stable = [primary] + [ds for ds in stable if ds != primary]
-            return ResolvedDatasources(
-                primary=primary, selected=stable, source="auto"
-            )
+            return _resolved_datasources(primary, stable, source="auto")
 
     if "cells" in names and _question_suggests_expression(question):
         roles = infer_datasource_roles(project)
@@ -274,10 +278,8 @@ def resolve_datasources_from_question_auto(
             selected = _order_datasources(
                 names, {roles.obs_datasource, expr.datasource_name}
             )
-            return ResolvedDatasources(
-                primary=roles.obs_datasource,
-                selected=selected,
-                source="auto",
+            return _resolved_datasources(
+                roles.obs_datasource, selected, source="auto"
             )
 
     catalog = build_chat_datasource_catalog(project)

--- a/python/mdvtools/llm/guidance.py
+++ b/python/mdvtools/llm/guidance.py
@@ -1,22 +1,47 @@
 """
 Post-execution analysis summary for ChatMDV.
 
-Builds user-facing guidance (why / what to look for / next steps), persists it as a
+Builds user-facing guidance (why / biological insights / next steps), persists it as a
 view TextBox, and echoes the same markdown to the chat client.
 """
 from __future__ import annotations
 
 import json
+import re
 from typing import Any, Optional
 
 from mdvtools.charts.text_box_plot import TextBox
 from mdvtools.llm.verification import (
-    format_charts_from_saved_view,
+    CHART_PARAM_ROLE_MAP,
+    SavedViewChart,
+    _WRAPPER_RE,
+    collect_saved_view_charts,
+    format_chart_param_display,
     parse_datasource_name,
 )
 
 ANALYSIS_SUMMARY_TITLE = "Analysis summary"
 CHATMDV_SUMMARY_TEXTBOX_ID = "chatmdv_analysis_summary"
+
+_CHART_TYPE_LABELS: dict[str, str] = {
+    "wgl_scatter_plot": "Scatter Plot (2D)",
+    "density_scatter_plot": "Density Scatter Plot",
+    "box_plot": "Box Plot",
+    "violin_plot": "Violin Plot",
+    "selection_dialog": "Selection Dialog Plot",
+    "table_chart": "Table Plot",
+    "single_heat_map": "Heatmap",
+    "dot_plot": "Dot Plot",
+    "histogram_chart": "Histogram",
+    "multi_line_chart": "Multiline Chart",
+    "pie_chart": "Pie Chart",
+    "ring_chart": "Ring Chart",
+    "stacked_row_chart": "Stacked Row Chart",
+    "row_chart": "Row Chart",
+    "sankey_chart": "Sankey Plot",
+    "wordcloud_chart": "Wordcloud",
+    "abundance_box_plot": "Abundance Box Plot",
+}
 
 
 def _is_summary_textbox(chart: dict[str, Any]) -> bool:
@@ -44,29 +69,388 @@ def _view_has_non_summary_charts(view: dict[str, Any], datasource_name: str) -> 
     return any(isinstance(c, dict) and not _is_summary_textbox(c) for c in charts)
 
 
+def _short_field_label(project: Any, datasource_name: str, token: str) -> str:
+    """Compact label for narrative text (gene name, display name, or field id)."""
+    m = _WRAPPER_RE.match(token.strip())
+    if m:
+        return m.group(2).strip()
+    try:
+        col = project.get_column_metadata(datasource_name, token)
+        display = col.get("name") or token
+        return str(display)
+    except Exception:
+        return token
+
+
+def _chart_type_label(chart_type: str) -> str:
+    return _CHART_TYPE_LABELS.get(
+        chart_type, chart_type.replace("_", " ").title()
+    )
+
+
+def _role_params(
+    project: Any, chart: SavedViewChart
+) -> list[tuple[str, str, str]]:
+    """Return (role, raw_token, display) for each chart param."""
+    roles = CHART_PARAM_ROLE_MAP.get(chart.chart_type)
+    out: list[tuple[str, str, str]] = []
+    for idx, token in enumerate(chart.param_tokens):
+        role = roles[idx] if roles and idx < len(roles) else f"Param {idx}"
+        display = format_chart_param_display(project, chart.datasource_name, token)
+        out.append((role, token, display))
+    return out
+
+
+def _detect_subset_context(question: str, code: str) -> str | None:
+    """Best-effort description of a row subset (e.g. a cluster) from question/code."""
+    for text in (question, code):
+        m = re.search(
+            r"(?:within|inside|in)\s+(?:cluster|group)\s+['\"]?(\w+)['\"]?",
+            text,
+            re.IGNORECASE,
+        )
+        if m:
+            return f"cluster {m.group(1)}"
+        m = re.search(r"cluster\s+['\"]?(\w+)['\"]?", text, re.IGNORECASE)
+        if m:
+            return f"cluster {m.group(1)}"
+    if ".loc[" in code or ".query(" in code.lower() or "adata[" in code:
+        return "the filtered cell subset"
+    return None
+
+
+def _gene_tokens_from_charts(
+    project: Any, charts: list[SavedViewChart]
+) -> list[str]:
+    genes: list[str] = []
+    seen: set[str] = set()
+    for chart in charts:
+        for token in (*chart.param_tokens, chart.color_by or ""):
+            m = _WRAPPER_RE.match(token.strip()) if token else None
+            if m:
+                gene = m.group(2).strip()
+                if gene not in seen:
+                    seen.add(gene)
+                    genes.append(gene)
+            elif token:
+                label = _short_field_label(project, chart.datasource_name, token)
+                if re.search(r"gene|expr", token, re.IGNORECASE) and label not in seen:
+                    seen.add(label)
+                    genes.append(label)
+    return genes
+
+
+def _embedding_axes(charts: list[SavedViewChart]) -> list[str]:
+    axes: list[str] = []
+    seen: set[str] = set()
+    for chart in charts:
+        for token in chart.param_tokens[:2]:
+            low = token.lower()
+            if "umap" in low or "pca" in low or "tsne" in low:
+                if token not in seen:
+                    seen.add(token)
+                    axes.append(token)
+    return axes
+
+
+def _detect_intents(
+    question: str, code: str, charts: list[SavedViewChart]
+) -> set[str]:
+    q = question.lower()
+    intents: set[str] = set()
+    if any(k in q for k in ("subcluster", "sub-cluster", "within cluster", "inside cluster")):
+        intents.add("subcluster")
+    if any(k in q for k in ("expression", "express", "gene", "marker", "deg", "de ")):
+        intents.add("expression")
+    if any(k in q for k in ("marker", "rank_genes", "differential", "deg", "de gene")):
+        intents.add("markers")
+    if any(k in q for k in ("proportion", "abundance", "composition", "frequency", "percent")):
+        intents.add("proportion")
+    if any(k in q for k in ("qc", "quality", "uniformity", "cv", "channel")):
+        intents.add("qc")
+    if any(k in q for k in ("correlat", "relationship", "association", "compare", "versus", " vs ")):
+        intents.add("relationship")
+    if any(k in q for k in ("trajectory", "pseudotime", "lineage", "development")):
+        intents.add("trajectory")
+    if any(c.chart_type == "selection_dialog" for c in charts):
+        intents.add("interactive")
+    if _embedding_axes(charts):
+        intents.add("embedding")
+    gene_list = []
+    for c in charts:
+        for t in c.param_tokens:
+            m = _WRAPPER_RE.match(t.strip())
+            if m:
+                gene_list.append(m.group(2))
+    if gene_list:
+        intents.add("expression")
+    if not intents:
+        intents.add("explore")
+    return intents
+
+
+def _describe_chart_rationale(
+    project: Any,
+    chart: SavedViewChart,
+    subset: str | None,
+) -> str:
+    label = _chart_type_label(chart.chart_type)
+    roles = _role_params(project, chart)
+    subset_phrase = f" for cells in {subset}" if subset else ""
+
+    if chart.chart_type == "wgl_scatter_plot":
+        x = roles[0][2] if roles else "X"
+        y = roles[1][2] if len(roles) > 1 else "Y"
+        color = (
+            format_chart_param_display(project, chart.datasource_name, chart.color_by)
+            if chart.color_by
+            else None
+        )
+        lines = [
+            f"Plots {x} vs {y}{subset_phrase}"
+            + (f", colored by {color}." if color else ".")
+        ]
+        if color and "Expression feature" in color:
+            lines.append(
+                "This allows visual identification of subclusters or gradients "
+                "that may correspond to different expression levels."
+            )
+        elif color:
+            lines.append(
+                "This reveals how cells group in embedding or feature space and "
+                "whether categories or expression levels form distinct regions."
+            )
+        else:
+            lines.append(
+                "This shows spatial structure in the chosen dimensions for the selected cells."
+            )
+        return "\n".join(lines)
+
+    if chart.chart_type == "density_scatter_plot":
+        x = roles[0][2] if roles else "X"
+        y = roles[1][2] if len(roles) > 1 else "Y"
+        cat = roles[2][2] if len(roles) > 2 else None
+        base = f"Adds density information to a scatter of {x} vs {y}{subset_phrase}"
+        if cat:
+            base += f", grouped or colored by {cat}"
+        base += ", highlighting regions of high cell density."
+        return (
+            base
+            + " Dense regions may indicate stable subpopulations; sparse tails may be transitional or rare states."
+        )
+
+    if chart.chart_type == "selection_dialog":
+        filters = ", ".join(display for _, _, display in roles) or "(see chart)"
+        return (
+            f"Allows interactive subsetting and filtering by {filters}, supporting "
+            "further subclustering, focused views, or downstream analysis on selected cells."
+        )
+
+    if chart.chart_type == "table_chart":
+        cols = ", ".join(display for _, _, display in roles) or "relevant columns"
+        return (
+            f"Provides a tabular view of {cols}{subset_phrase}, enabling detailed "
+            "inspection, sorting, and row-level review of the underlying data."
+        )
+
+    if chart.chart_type in ("box_plot", "violin_plot"):
+        cat = roles[0][2] if roles else "category"
+        val = roles[1][2] if len(roles) > 1 else "value"
+        kind = "distribution spread" if chart.chart_type == "violin_plot" else "median and spread"
+        return (
+            f"Compares {val} across {cat}{subset_phrase}, showing {kind} per group "
+            "to identify shifts, outliers, or group-specific differences."
+        )
+
+    if chart.chart_type == "single_heat_map":
+        return (
+            "Summarizes expression or scores across categories and features in a matrix view, "
+            "making patterns of high and low values easy to compare at a glance."
+        )
+
+    if chart.chart_type == "dot_plot":
+        return (
+            "Shows per-category expression or scores for multiple features simultaneously, "
+            "useful for comparing marker patterns across groups."
+        )
+
+    if chart.chart_type in ("pie_chart", "ring_chart", "stacked_row_chart"):
+        return (
+            "Shows relative proportions or composition across categories, "
+            "helping assess whether group sizes or abundances differ meaningfully."
+        )
+
+    # Generic fallback
+    param_summary = ", ".join(display for _, _, display in roles)
+    if param_summary:
+        return (
+            f"Visualizes {param_summary}{subset_phrase} using a {label.lower()} "
+            "to support inspection of the patterns relevant to your question."
+        )
+    return f"Provides a {label.lower()} view{subset_phrase} to help answer your question."
+
+
+def _synthesis_sentence(
+    question: str,
+    charts: list[SavedViewChart],
+    genes: list[str],
+    subset: str | None,
+) -> str:
+    parts: list[str] = []
+    if subset and genes:
+        parts.append(
+            f"This combination directly addresses your question by visualizing heterogeneity "
+            f"within {subset} as a function of {', '.join(genes)} expression"
+        )
+    elif genes:
+        parts.append(
+            f"Together, these charts link {', '.join(genes)} expression to cell grouping "
+            "and support both overview and detailed inspection"
+        )
+    elif subset:
+        parts.append(
+            f"These views focus on {subset} and combine overview plots with tools for "
+            "interactive exploration where appropriate"
+        )
+    else:
+        parts.append(
+            "Together, these charts answer your question with complementary views—overview "
+            "plots plus tabular or interactive inspection where saved"
+        )
+    if any(c.chart_type == "selection_dialog" for c in charts):
+        parts.append("and enables hypothesis-driven downstream analysis on selected cells")
+    else:
+        parts.append("and helps validate patterns seen in the plots")
+    return parts[0] + ", " + parts[1] + "."
+
+
+def _biological_insights(
+    intents: set[str],
+    genes: list[str],
+    subset: str | None,
+    data_preview: str | None,
+) -> list[str]:
+    bullets: list[str] = []
+    gene_phrase = ", ".join(genes) if genes else "the chosen feature"
+
+    if "subcluster" in intents or ("expression" in intents and subset):
+        bullets.append(
+            "**Subpopulation discovery:** If expression is heterogeneous"
+            + (f" within {subset}" if subset else "")
+            + ", scatter and density plots may reveal spatially distinct subclusters, "
+            "suggesting functional or developmental diversity."
+        )
+    if "expression" in intents or genes:
+        bullets.append(
+            f"**Gene expression patterns:** The visualization may show gradients or discrete "
+            f"groups of {gene_phrase}-high and {gene_phrase}-low cells, which could correspond "
+            "to different cell states or subtypes."
+        )
+    if "markers" in intents:
+        bullets.append(
+            "**Marker and DE context:** Patterns in expression or heatmap/dot views can highlight "
+            "candidate markers and whether differences are cluster-wide or subset-specific."
+        )
+    if "proportion" in intents:
+        bullets.append(
+            "**Composition shifts:** Proportion charts can reveal whether certain groups are "
+            "over- or under-represented, which may reflect biology or technical bias."
+        )
+    if "qc" in intents:
+        bullets.append(
+            "**Data quality:** Distribution and comparison plots help spot outlier channels, "
+            "runs, or assays that may need filtering before biological interpretation."
+        )
+    if "relationship" in intents:
+        bullets.append(
+            "**Association structure:** Scatter or density views can reveal correlations, "
+            "anti-correlations, or non-linear relationships between measured variables."
+        )
+    if "trajectory" in intents or ("expression" in intents and genes):
+        bullets.append(
+            "**Cluster purity and annotation:** If expression aligns with known markers or "
+            "functional states, this can inform annotation or refinement of cluster labels."
+        )
+    if (data_preview or "").strip():
+        bullets.append(
+            "**Computed summaries:** Review the data preview in chat for printed aggregates, "
+            "counts, or table excerpts that complement what you see in the charts."
+        )
+    if not bullets:
+        bullets.append(
+            "**Pattern discovery:** Look for separated groups, gradients, outliers, or "
+            "category-specific shifts that motivate a more targeted follow-up analysis."
+        )
+    return bullets
+
+
 def _suggest_next_steps(
     project: Any,
     question: str,
     datasource_name: str | None,
+    intents: set[str],
+    charts: list[SavedViewChart],
+    genes: list[str],
+    subset: str | None,
 ) -> list[str]:
+    steps: list[str] = []
+    gene_phrase = ", ".join(genes) if genes else "the feature of interest"
+    has_selection = any(c.chart_type == "selection_dialog" for c in charts)
+
+    if has_selection or "subcluster" in intents:
+        steps.append(
+            "**Automated subclustering:** Use the selection dialog to select expression-high "
+            "or expression-low subpopulations"
+            + (f" within {subset}" if subset else "")
+            + ", then run further clustering or differential expression on the subset."
+        )
+    if genes or "expression" in intents or "markers" in intents:
+        steps.append(
+            f"**Marker gene analysis:** Identify other genes that co-vary with {gene_phrase}"
+            + (f" within {subset}" if subset else "")
+            + " to discover new markers or pathways."
+        )
+    if "trajectory" in intents or ("expression" in intents and genes):
+        steps.append(
+            f"**Trajectory / lineage inference:** If {gene_phrase} expression forms a gradient, "
+            "investigate whether this reflects a developmental trajectory or continuous state change."
+        )
+    if genes and ("subcluster" in intents or has_selection):
+        steps.append(
+            f"**Functional enrichment:** Run GO or pathway enrichment on {gene_phrase}-high vs "
+            f"{gene_phrase}-low subclusters to infer biological functions."
+        )
+    if "proportion" in intents:
+        steps.append(
+            "**Stratified comparisons:** Break down proportions by sample, batch, or condition "
+            "to see whether composition differences are consistent across cohorts."
+        )
+    if "qc" in intents:
+        steps.append(
+            "**QC follow-up:** Filter or flag problematic channels/runs, then re-plot key metrics "
+            "to confirm improvements before downstream analysis."
+        )
+
+    q_lower = question.lower()
     names: list[str] = []
     for ds in project.datasources or []:
         if isinstance(ds, dict) and ds.get("name"):
             names.append(str(ds["name"]))
-    q_lower = question.lower()
-    steps: list[str] = []
     for name in names:
-        if name == datasource_name:
+        if name == datasource_name or name.lower() in q_lower:
             continue
-        if name.lower() in q_lower:
-            continue
-        steps.append(f"Compare with related table `{name}` (e.g. other QC metrics or run metadata).")
-        if len(steps) >= 2:
-            break
-    steps.append(
-        "Ask a follow-up to filter by session, channel, or assay—or to plot a related numeric column."
-    )
-    return steps[:3]
+        steps.append(
+            f"**Cross-datasource check:** Compare with related table `{name}` "
+            "(e.g. run metadata, alternate QC tables, or companion assays)."
+        )
+        break
+
+    if len(steps) < 3:
+        steps.append(
+            "**Follow-up question:** Ask ChatMDV to filter by a specific group, add another "
+            "gene or numeric column, or export a table of cells matching a visual pattern."
+        )
+    return steps[:5]
 
 
 def build_response_guidance(
@@ -83,53 +467,78 @@ def build_response_guidance(
     ds_from_code = parse_datasource_name(final_code)
     lines: list[str] = []
 
-    lines.append("## Why this visualization")
     view = None
+    charts: list[SavedViewChart] = []
     if view_name:
         try:
             view = project.get_view(view_name)
+            if isinstance(view, dict):
+                charts = collect_saved_view_charts(project, view)
         except Exception:
             view = None
-    charts_md = ""
-    if isinstance(view, dict) and view.get("initialCharts"):
-        try:
-            charts_md, _ = format_charts_from_saved_view(project, view)
-        except Exception:
-            charts_md = ""
-    if charts_md.strip():
-        for part in charts_md.strip().splitlines():
-            if part.startswith("### Charts"):
-                lines.append(
-                    "The saved view uses the chart(s) below to answer your question "
-                    f"using datasource `{ds_from_code or 'see code'}`."
-                )
-            elif part.strip():
-                lines.append(part)
+            charts = []
+
+    subset = _detect_subset_context(question, final_code)
+    genes = _gene_tokens_from_charts(project, charts)
+    intents = _detect_intents(question, final_code, charts)
+
+    lines.append("## 1. Why this chart is the best way to answer the question")
+    lines.append("")
+    lines.append("The user asked:")
+    lines.append(f'> "{question.strip()}"')
+    lines.append("")
+
+    if charts:
+        for chart in charts:
+            label = _chart_type_label(chart.chart_type)
+            title = chart.title
+            lines.append(f"**{label}**" + (f" ({title})" if title and title != label else "") + ":")
+            lines.append(_describe_chart_rationale(project, chart, subset))
+            lines.append("")
+        lines.append(_synthesis_sentence(question, charts, genes, subset))
     else:
         lines.append(
-            f"This analysis addresses: **{question.strip()}**"
+            f"This analysis addresses your question using datasource "
+            f"`{ds_from_code or 'see generated code'}`."
         )
         if agent_plan.strip():
-            lines.append(f"- Planned fields/charts: {agent_plan.strip()[:400]}")
+            lines.append("")
+            lines.append("Planned fields and charts:")
+            lines.append(f"- {agent_plan.strip()[:600]}")
 
     lines.append("")
-    lines.append("## What to look for")
+    lines.append("## 2. Biological insights that can be gained")
+    lines.append("")
+    for bullet in _biological_insights(intents, genes, subset, data_preview):
+        lines.append(f"- {bullet}")
+
     preview = (data_preview or "").strip()
     if preview:
-        lines.append("- Review the **data preview** in chat for computed aggregates or row samples.")
+        lines.append("")
         snippet = preview[:1200]
         if len(preview) > 1200:
             snippet += "\n\n_(preview truncated)_"
-        lines.append("")
         lines.append(snippet)
-    else:
-        lines.append("- Compare groups or categories on the chart axes.")
-        lines.append("- Note outliers, skew, or channels that differ strongly from others.")
 
     lines.append("")
-    lines.append("## Suggested next steps")
-    for step in _suggest_next_steps(project, question, ds_from_code):
+    lines.append("## 3. Subsequent analysis tasks")
+    lines.append("")
+    for step in _suggest_next_steps(
+        project, question, ds_from_code, intents, charts, genes, subset
+    ):
         lines.append(f"- {step}")
+
+    lines.append("")
+    lines.append("### In summary")
+    if charts:
+        lines.append(
+            "This visualization suite enables visual exploration of the patterns in your question "
+            "and provides tools for interactive, hypothesis-driven downstream analysis."
+        )
+    else:
+        lines.append(
+            "Review the computed outputs and ask a follow-up to add charts or refine the analysis."
+        )
 
     return "\n".join(lines).strip()
 

--- a/python/mdvtools/llm/langchain_mdv.py
+++ b/python/mdvtools/llm/langchain_mdv.py
@@ -60,7 +60,7 @@ from .datasource_roles import (
     collect_wrapper_subgroup_keys_for_project,
     format_field_index_hint,
     infer_datasource_roles,
-    resolve_datasource_from_question,
+    resolve_datasources_for_request,
 )
 from .dataset_scale import (
     assess_project_scale,
@@ -507,7 +507,7 @@ class ProjectChat(ProjectChatProtocol):
             self.roles = roles
             path_to_data = _resolve_path_to_data(self.project.dir)
             self.scale = assess_project_scale(self.project, path_to_data)
-            self.df_list = load_agent_dataframes(self.project, roles, self.scale)
+            self.df_map = load_agent_dataframes(self.project, roles, self.scale)
 
             try:
                 with time_block("b_suggest: Generating suggested questions"):
@@ -553,7 +553,12 @@ class ProjectChat(ProjectChatProtocol):
             del self.conversation_memories[conversation_id]
         chat_debug_logger.info(f"Cleared conversation history for conversation {conversation_id}")
 
-    def _build_role_hint(self, *, question_datasource: str | None = None) -> str:
+    def _build_role_hint(
+        self,
+        *,
+        primary_datasource: str | None = None,
+        selected_datasources: list[str] | None = None,
+    ) -> str:
         try:
             roles = getattr(self, "roles", None)
             scale = getattr(self, "scale", None)
@@ -568,29 +573,50 @@ class ProjectChat(ProjectChatProtocol):
                     "- Before suggesting columns, decide: obs metadata only, expression wrappers, or Scanpy markers.\n"
                     "- Question-type routing: proportion / frequency / before-after → StackedRowChart; "
                     "gene signature / enrichment / ISG genes → DotPlot or Heatmap + wrappers + SelectionDialogPlot.\n"
-                    "- On large projects df1 is a column subset — list every field id codegen will need in `fields`.\n"
+                    "- On large projects probe dataframes are column subsets — list every field id codegen will need in `fields`.\n"
                 )
             if roles is not None:
-                exprs = roles.expressions or []
-                if exprs:
-                    expr_lines = (
-                        f"- df2 maps to expression datasource '{exprs[0].datasource_name}' "
-                        f"(feature names in column '{exprs[0].name_column}', default subgroup '{exprs[0].subgroup_key}')"
+                selected = selected_datasources or []
+                primary = primary_datasource or roles.obs_datasource
+                if selected:
+                    inspect_cmds = ", ".join(f"`{n}.columns`" for n in selected)
+                    df_lines = "\n".join(
+                        f"- `{ds_name}`: preloaded pandas probe dataframe keyed as `{ds_name}`"
+                        for ds_name in selected
+                    )
+                    selection_lines = (
+                        f"- User-selected datasources for this request: {selected!r}\n"
+                        f"- Primary chart target (first selected): `{primary}`\n"
+                        f"{df_lines}\n"
+                        f"- Run {inspect_cmds} for every selected datasource before planning fields.\n"
                     )
                 else:
-                    if question_datasource and question_datasource != roles.obs_datasource:
+                    exprs = roles.expressions or []
+                    if exprs:
                         expr_lines = (
-                            f"- df2 maps to question-resolved datasource '{question_datasource}' "
-                            "(use this table when the user names it or its columns)"
+                            f"- Expression datasource '{exprs[0].datasource_name}' "
+                            f"(feature names in column '{exprs[0].name_column}', "
+                            f"default subgroup '{exprs[0].subgroup_key}')"
+                        )
+                    elif primary_datasource and primary_datasource != roles.obs_datasource:
+                        expr_lines = (
+                            f"- Additional table '{primary_datasource}' "
+                            "(use when the user names it or its columns)"
                         )
                     else:
-                        expr_lines = "- No rows-as-columns expression datasource detected for this project."
+                        expr_lines = (
+                            "- No rows-as-columns expression datasource detected for this project."
+                        )
+                    selection_lines = (
+                        f"- Observation datasource '{roles.obs_datasource}' is preloaded when available.\n"
+                        f"{expr_lines}\n"
+                    )
                 return (
                     "\n\nDatasource roles:\n"
-                    f"- df1 maps to obs datasource '{roles.obs_datasource}'\n"
-                    f"{expr_lines}\n"
-                    "- For any chart `params` on the **feature table datasource** (df2), use **Field ID** strings from "
-                    "`df2.columns` / project metadata for **that** datasource (e.g. `gene_ids` when listed for `genes`); "
+                    f"- Project observation datasource: '{roles.obs_datasource}'\n"
+                    f"{selection_lines}"
+                    "- For chart `params` on a **feature table datasource**, use **Field ID** strings from "
+                    "that datasource's metadata (e.g. `gene_ids` when listed for `genes`); "
                     "do not use those ids as `params` on charts bound to **cells** unless `cells` lists the same Field ID.\n"
                     "- Do not pair Scanpy `rank_genes_groups` tables with DotPlot/Heatmap on cells using wrapper `params` "
                     "as a substitute for that table (see ChatMDV \"Marker ranking vs DotPlot\" in RAG); optional "
@@ -615,14 +641,22 @@ class ProjectChat(ProjectChatProtocol):
         verbose: bool,
         *,
         use_react: bool = False,
-        question_datasource: str | None = None,
+        primary_datasource: str | None = None,
+        selected_datasources: list[str] | None = None,
     ) -> AgentExecutor:
-        role_hint = self._build_role_hint(question_datasource=question_datasource)
+        role_hint = self._build_role_hint(
+            primary_datasource=primary_datasource,
+            selected_datasources=selected_datasources,
+        )
+        df_keys = ", ".join(f"`{k}`" for k in dfs.keys())
+        inspect_hint = (
+            f"Before answering any user question, run `.columns` on each preloaded dataframe: {df_keys}."
+        )
         prompt_data_template = f"""You have access to the following Pandas DataFrames: 
-        {', '.join(dfs.keys())}. These are preloaded, so do not redefine them.
+        {', '.join(dfs.keys())}. These are preloaded and keyed by MDV datasource name — do not redefine them.
         {role_hint}
-        Before answering any user question, you must first run `df1.columns` and `df2.columns` to inspect available fields.
-        On large projects, df1/df2 may be column subsets for schema probing — use Project Data Context field ids for planning.
+        {inspect_hint}
+        On large projects these may be column subsets for schema probing — use Project Data Context field ids for planning.
         Prefer MDV chart field ids and expression wrappers; suggest Scanpy only for marker-ranking or DE questions when MDV metadata lacks required columns.
         Route by question type: proportion/frequency/before-after → StackedRowChart; signature/enrichment/ISG expression → DotPlot or Heatmap with wrappers.
         Use these to correct the column names mentioned by the user.
@@ -666,7 +700,8 @@ class ProjectChat(ProjectChatProtocol):
         provider: ProviderKind,
         verbose=False,
         on_agent_fallback=None,
-        question_datasource: str | None = None,
+        primary_datasource: str | None = None,
+        selected_datasources: list[str] | None = None,
     ):
         """
         Creates a LangChain agent that can interact with Pandas DataFrames using a Python REPL tool.
@@ -700,7 +735,8 @@ class ProjectChat(ProjectChatProtocol):
             provider,
             verbose,
             use_react=False,
-            question_datasource=question_datasource,
+            primary_datasource=primary_datasource,
+            selected_datasources=selected_datasources,
         )
 
         def agent_with_contextualization(question):
@@ -724,7 +760,8 @@ class ProjectChat(ProjectChatProtocol):
                     provider,
                     verbose,
                     use_react=True,
-                    question_datasource=question_datasource,
+                    primary_datasource=primary_datasource,
+                    selected_datasources=selected_datasources,
                 )
                 return fallback_executor.invoke({"input": standalone_question})
 
@@ -763,6 +800,7 @@ class ProjectChat(ProjectChatProtocol):
         question = chat_request["message"]
         handle_error = chat_request["handle_error"]
         model_id = chat_request.get("model_id")
+        user_datasource_names = chat_request.get("datasource_names")
 
         discovered = discover_models()
         chat_model = discovered.get_chat_model(model_id)
@@ -806,23 +844,39 @@ class ProjectChat(ProjectChatProtocol):
         # there is a risk that these are out of date by the time we get here...
         # but it's a bit of an expensive operation, so avoiding it for now (in most cases we shouldn't need to refer to them)
         field_index = build_datasource_field_index(self.project)
-        question_datasource = resolve_datasource_from_question(
-            self.project, question, field_index=field_index
+        try:
+            resolved_ds = resolve_datasources_for_request(
+                self.project,
+                question=question,
+                user_datasource_names=user_datasource_names,
+                field_index=field_index,
+            )
+        except ValueError as exc:
+            handle_error(str(exc))
+            return AskQuestionResult(
+                code=None,
+                view_name=None,
+                error=True,
+                message=str(exc),
+                verification=None,
+                data_preview=None,
+                guidance=None,
+                needs_refresh=False,
+            )
+        selected_datasources = resolved_ds.selected
+        rag_datasource = resolved_ds.primary
+        chat_debug_logger.info(
+            "Resolved datasources: primary=%s selected=%s source=%s",
+            resolved_ds.primary,
+            resolved_ds.selected,
+            resolved_ds.source,
         )
-        df_list = load_agent_dataframes(
+        df_map = load_agent_dataframes(
             self.project,
             self.roles,
             self.scale,
-            extra_datasource=question_datasource,
+            selected_datasources=selected_datasources,
         )
-        default_datasource = str(self.project.datasources[0]["name"])
-        rag_datasource = question_datasource or default_datasource
-        if question_datasource:
-            chat_debug_logger.info(
-                "Resolved question datasource: %s (default would be %s)",
-                question_datasource,
-                default_datasource,
-            )
         
         progress = 0
 
@@ -845,14 +899,15 @@ class ProjectChat(ProjectChatProtocol):
         # Create agent with local LLM and memory
         with time_block("b8: Pandas agent creating"):
             agent = self.create_custom_pandas_agent(
-                dataframe_llm, 
-                {"df1": df_list[0], "df2": df_list[1] if len(df_list) > 1 else df_list[0]}, 
-                prompt_data, 
+                dataframe_llm,
+                df_map,
+                prompt_data,
                 memory,
                 chat_model.provider,
                 verbose=True,
                 on_agent_fallback=_notify_agent_fallback,
-                question_datasource=question_datasource,
+                primary_datasource=rag_datasource,
+                selected_datasources=selected_datasources,
             )
 
         total_steps = 6
@@ -937,8 +992,6 @@ class ProjectChat(ProjectChatProtocol):
                 path_to_data = _resolve_path_to_data(self.project.dir)
                 self.scale = assess_project_scale(self.project, path_to_data)
 
-                datasource_names = [ds['name'] for ds in self.project.datasources[:2]]  # Get names of up to 2 datasources
-
                 prompt_RAG = get_createproject_prompt_RAG(
                     self.project,
                     path_to_data,
@@ -947,6 +1000,7 @@ class ProjectChat(ProjectChatProtocol):
                     response["input"],
                     compact=chat_model.provider == "ollama",
                     scale=self.scale,
+                    datasource_names=selected_datasources,
                 )
                 chat_debug_logger.info(f"=== RAG Base Prompt (before context injection) ===\n{prompt_RAG}\n=== End Base Prompt ===")
 
@@ -997,6 +1051,7 @@ class ProjectChat(ProjectChatProtocol):
                     chat_debug_logger.info,
                     modify_existing_project=True,
                     view_name=question,
+                    selected_datasources=selected_datasources,
                 )
 
                 if _is_text_table_intent(question) and not _is_text_table_only_code(final_code):
@@ -1018,6 +1073,7 @@ class ProjectChat(ProjectChatProtocol):
                         chat_debug_logger.info,
                         modify_existing_project=True,
                         view_name=question,
+                        selected_datasources=selected_datasources,
                     )
                     if not _is_text_table_only_code(final_code_retry):
                         output_qa = output_qa_retry
@@ -1055,6 +1111,7 @@ class ProjectChat(ProjectChatProtocol):
                         chat_debug_logger.info,
                         modify_existing_project=True,
                         view_name=question,
+                        selected_datasources=selected_datasources,
                     )
 
                 allowed_wrapper_subgroup_keys = collect_wrapper_subgroup_keys_for_project(

--- a/python/mdvtools/llm/langchain_mdv.py
+++ b/python/mdvtools/llm/langchain_mdv.py
@@ -800,7 +800,12 @@ class ProjectChat(ProjectChatProtocol):
         question = chat_request["message"]
         handle_error = chat_request["handle_error"]
         model_id = chat_request.get("model_id")
-        user_datasource_names = chat_request.get("datasource_names")
+        datasource_mode = chat_request.get("datasource_mode", "auto")
+        user_datasource_names = (
+            chat_request.get("datasource_names")
+            if datasource_mode == "manual"
+            else None
+        )
 
         discovered = discover_models()
         chat_model = discovered.get_chat_model(model_id)
@@ -862,6 +867,7 @@ class ProjectChat(ProjectChatProtocol):
                 data_preview=None,
                 guidance=None,
                 needs_refresh=False,
+                resolved_datasource_names=None,
             )
         selected_datasources = resolved_ds.selected
         rag_datasource = resolved_ds.primary
@@ -1001,6 +1007,7 @@ class ProjectChat(ProjectChatProtocol):
                     compact=chat_model.provider == "ollama",
                     scale=self.scale,
                     datasource_names=selected_datasources,
+                    auto_resolved=resolved_ds.source == "auto",
                 )
                 chat_debug_logger.info(f"=== RAG Base Prompt (before context injection) ===\n{prompt_RAG}\n=== End Base Prompt ===")
 
@@ -1387,6 +1394,7 @@ class ProjectChat(ProjectChatProtocol):
                     "data_preview": data_preview_text,
                     "guidance": guidance_text or None,
                     "needs_refresh": client_needs_refresh_after_chat(final_code),
+                    "resolved_datasource_names": selected_datasources,
                 }
         except Exception as e:
             # Log general error
@@ -1410,4 +1418,5 @@ class ProjectChat(ProjectChatProtocol):
                 "data_preview": None,
                 "guidance": None,
                 "needs_refresh": False,
+                "resolved_datasource_names": None,
             }

--- a/python/mdvtools/llm/templates.py
+++ b/python/mdvtools/llm/templates.py
@@ -224,6 +224,7 @@ def get_createproject_prompt_RAG(
     scale: ProjectScale | None = None,
     *,
     datasource_names: list[str] | None = None,
+    auto_resolved: bool = False,
 ) -> str:
     """
     Constructs a RAG prompt to guide LLM code generation for creating MDV plots.
@@ -242,7 +243,9 @@ def get_createproject_prompt_RAG(
     multi_table_policy = ""
     if is_multi_table_tabular_project(project, roles) or len(resolved_names) > 1:
         multi_table_policy = format_multi_table_tabular_policy()
-    cross_table_policy = format_selected_datasources_cross_table_policy(resolved_names)
+    cross_table_policy = format_selected_datasources_cross_table_policy(
+        resolved_names, auto_resolved=auto_resolved
+    )
     context_md = _build_rag_context_markdown(project, resolved_names)
     datasource_name_guidance = (
         f"- datasource_name = '{primary_datasource}'  "

--- a/python/mdvtools/llm/templates.py
+++ b/python/mdvtools/llm/templates.py
@@ -6,6 +6,7 @@ from mdvtools.markdown_utils import create_project_markdown, create_column_markd
 from mdvtools.llm.dataset_scale import ProjectScale, assess_project_scale
 from mdvtools.llm.datasource_roles import (
     infer_datasource_roles,
+    categorical_field_ids_from_metadata,
     format_feature_table_field_policy,
     format_marker_gene_scanpy_fallback_policy,
     format_marker_ranking_viz_policy,
@@ -15,31 +16,30 @@ from mdvtools.llm.datasource_roles import (
     format_no_hallucination_chart_policy,
     format_obs_table_chart_param_policy,
     format_scanpy_hybrid_routing_policy,
+    format_selected_datasources_cross_table_policy,
     format_targeted_chart_policies,
     format_visualization_consistency_policy,
     is_multi_table_tabular_project,
 )
 prompt_data = """
 Your task is to:  
-1. Identify the type of data the user needs (e.g., categorical, numerical, etc.) by inspecting the DataFrames provided.
-2. Use only the two DataFrames provided:
-   - df1: observation/metadata table (e.g. cells)
-   - df2: linked feature table for wrapper-based expression (e.g. rna/genes/protein). The gene/feature label column may be `name`, `gene_ids`, or another id — inspect `df2.columns`; do not assume `name` unless present.
+1. Identify the type of data the user needs (e.g., categorical, numerical, etc.) by inspecting the preloaded DataFrames.
+2. Use only the DataFrames provided — each is keyed by its MDV datasource name (e.g. `cells`, `rna`, `qc_runs`). Inspect every selected table with `<datasource_key>.columns` before planning fields.
 3. Column selection logic:
-   - For non-expression queries: select columns from df1 only. Inspect df1, using df1.columns
+   - For non-expression queries: select columns from the observation/metadata datasource when present; otherwise from the datasource that owns the requested fields.
    - For expression-related queries (e.g., expression of a gene/protein, comparison of features, highest expressing features):
-       a. Resolve the feature-label column from `df2.columns` (see Datasource roles / name_column when available). Use ONLY values from that column for feature identifiers — do NOT use unrelated metadata columns unless explicitly instructed.
+       a. Resolve the feature-label column from the expression datasource dataframe columns (see Datasource roles / name_column when available). Use ONLY values from that column for feature identifiers — do NOT use unrelated metadata columns unless explicitly instructed.
        b. If a specific feature is mentioned by the user, check if it exists in that label column.
-           - If it does not exist, assume the user provided a synonym and the label column may use different ids (e.g. Ensembl). Attempt mapping or lookup within `df2` only.
+           - If it does not exist, assume the user provided a synonym and the label column may use different ids (e.g. Ensembl). Attempt mapping or lookup within the expression table only.
            - If a match is found, return that label value.
-           - If no match is found, ignore the requested gene and select from available labels in `df2`.
-       c. If no feature is mentioned, select one or more feature labels from `df2`.
-       d. Only use the resolved label column from df2 for feature strings — do not invent column names.
+           - If no match is found, ignore the requested gene and select from available labels in the expression table.
+       c. If no feature is mentioned, select one or more feature labels from the expression table.
+       d. Only use the resolved label column from the expression datasource for feature strings — do not invent column names.
 4. Always return the list of required columns as a quoted comma-separated string, like:
    - "col1", "col2"
-   - Or for expression-related: "col", "feature_name"   (make sure "col" is from df1) 
+   - Or for expression-related: "col", "feature_name"   (make sure "col" is from the obs/metadata table) 
 5. For expression-related queries:
-   - Return both df1 columns and the selected feature name (from the resolved df2 label column).
+   - Return both obs/metadata columns and the selected feature name (from the resolved expression label column).
    - Only return the name as a string (e.g., "gene_name")—do not wrap it.
 6. NEVER create new DataFrames or modify existing ones.
 7. Ensure that the selected columns match the visualization requirements:  
@@ -107,6 +107,7 @@ from mdvtools.charts.sankey_plot import SankeyPlot
 from mdvtools.llm.datasource_roles import (
     infer_datasource_roles,
     categorical_field_ids_from_metadata,
+    format_selected_datasources_cross_table_policy,
 )
 from mdvtools.llm.column_field_resolve import build_expression_wrapper_token
 
@@ -138,27 +139,60 @@ def _datasource_context_section(
         return f"## {heading}: **{ds_name}**\n\n"
 
 
-def _build_rag_context_markdown(project: CreateProjectPromptProject, datasource_name: str) -> str:
+def _build_rag_context_markdown(
+    project: CreateProjectPromptProject,
+    datasource_names: list[str],
+) -> str:
     """Project Data Context block for RAG prompts."""
+    if not datasource_names:
+        try:
+            datasource_names = [str(project.datasources[0]["name"])]  # type: ignore[index]
+        except Exception:
+            return ""
+
+    primary = datasource_names[0]
     try:
         names = list(project.get_datasource_names())
     except Exception:
         names = []
 
     has_cells = "cells" in names
+    sections: list[str] = []
+
+    if len(datasource_names) > 1:
+        sections.append(
+            _datasource_context_section(
+                project,
+                primary,
+                "Primary datasource for this question",
+            )
+        )
+        for ds_name in datasource_names[1:]:
+            sections.append(
+                _datasource_context_section(
+                    project,
+                    ds_name,
+                    f"Additional selected datasource: {ds_name}",
+                )
+            )
+        if len(names) > len(datasource_names) and not has_cells:
+            all_tables = create_project_markdown(project, wrap_in_details=False)
+            sections.append("## All project datasources\n\n" + all_tables)
+        return "\n\n".join(sections)
+
+    datasource_name = primary
     if len(names) > 1 and not has_cells:
-        primary = _datasource_context_section(
+        primary_section = _datasource_context_section(
             project,
             datasource_name,
             "Primary datasource for this question",
         )
         all_tables = create_project_markdown(project, wrap_in_details=False)
-        return primary + "\n\n## All project datasources\n\n" + all_tables
+        return primary_section + "\n\n## All project datasources\n\n" + all_tables
 
     if has_cells and len(names) > 1:
         roles = infer_datasource_roles(project)
         obs = roles.obs_datasource
-        sections: list[str] = []
         if datasource_name != obs:
             sections.append(
                 _datasource_context_section(
@@ -188,6 +222,8 @@ def get_createproject_prompt_RAG(
     question: str,
     compact: bool = False,
     scale: ProjectScale | None = None,
+    *,
+    datasource_names: list[str] | None = None,
 ) -> str:
     """
     Constructs a RAG prompt to guide LLM code generation for creating MDV plots.
@@ -196,22 +232,30 @@ def get_createproject_prompt_RAG(
     """
     if scale is None:
         scale = assess_project_scale(project, path_to_data)
+    resolved_names = datasource_names if datasource_names else [datasource_name]
+    primary_datasource = resolved_names[0]
     mdv_first_policy = format_mdv_first_data_access_policy(
         scale, path_to_data, compact=compact
     )
     chart_policies = format_targeted_chart_policies(compact=compact)
     roles = infer_datasource_roles(project)
     multi_table_policy = ""
-    if is_multi_table_tabular_project(project, roles):
+    if is_multi_table_tabular_project(project, roles) or len(resolved_names) > 1:
         multi_table_policy = format_multi_table_tabular_policy()
-    context_md = _build_rag_context_markdown(project, datasource_name)
+    cross_table_policy = format_selected_datasources_cross_table_policy(resolved_names)
+    context_md = _build_rag_context_markdown(project, resolved_names)
     datasource_name_guidance = (
-        f"- datasource_name = '{datasource_name}'  "
+        f"- datasource_name = '{primary_datasource}'  "
         "(use this datasource for charts and dataframe loads when it matches the user question; "
         "do not substitute CHATMDV_OBS_DATASOURCE when the user names a different table)\n"
     )
+    if len(resolved_names) > 1:
+        datasource_name_guidance += (
+            f"- user_selected_datasources = {resolved_names!r}  "
+            "(scope analysis and joins to these tables; primary chart target is the first)\n"
+        )
     datasource_name_guidance_indented = (
-        f"            - datasource_name = '{datasource_name}'  "
+        f"            - datasource_name = '{primary_datasource}'  "
         "(use this datasource for charts and dataframe loads when it matches the user question; "
         "do not substitute CHATMDV_OBS_DATASOURCE when the user names a different table)\n"
     )
@@ -243,6 +287,7 @@ def get_createproject_prompt_RAG(
 
 """
             + multi_table_policy
+            + cross_table_policy
             + mdv_first_policy
             + """
 
@@ -337,7 +382,7 @@ def get_createproject_prompt_RAG(
         - When modifying an existing project (the default in this chat context), do NOT recreate or delete the project.
 
     2. Data Access (MDV-first; Scanpy last resort):
-"""+mdv_first_policy+multi_table_policy+"""
+"""+mdv_first_policy+multi_table_policy+cross_table_policy+"""
         - Observation/metadata datasource: `"""+roles.obs_datasource+"""`
         - Wrapper-capable expression datasources (feature tables):
 """+expr_lines+"""

--- a/python/mdvtools/llm/templates.py
+++ b/python/mdvtools/llm/templates.py
@@ -262,6 +262,11 @@ def get_createproject_prompt_RAG(
         "(use this datasource for charts and dataframe loads when it matches the user question; "
         "do not substitute CHATMDV_OBS_DATASOURCE when the user names a different table)\n"
     )
+    if len(resolved_names) > 1:
+        datasource_name_guidance_indented += (
+            f"            - user_selected_datasources = {resolved_names!r}  "
+            "(scope analysis and joins to these tables; primary chart target is the first)\n"
+        )
     if compact:
         expr_lines = ""
         if roles.expressions:

--- a/python/mdvtools/llm/verification.py
+++ b/python/mdvtools/llm/verification.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import ast
 import re
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Optional
 
 if TYPE_CHECKING:
@@ -84,6 +85,70 @@ def _to_param_list(p: Any) -> list[Any]:
     return [p]
 
 
+# Stable role labels for saved-view chart params (by persisted `chart['type']`).
+CHART_PARAM_ROLE_MAP: dict[str, list[str]] = {
+    "wgl_scatter_plot": ["X", "Y"],
+    "density_scatter_plot": ["X", "Y", "Category"],
+    "box_plot": ["Category", "Value"],
+    "violin_plot": ["Category", "Value"],
+}
+
+
+@dataclass(frozen=True)
+class SavedViewChart:
+    """One non-text-box chart from a saved view, with resolved param tokens."""
+
+    datasource_name: str
+    title: str
+    chart_type: str
+    param_tokens: tuple[str, ...]
+    color_by: str | None
+
+
+def format_chart_param_display(project: Any, datasource_name: str, token: Any) -> str:
+    """Public alias for user-facing param token formatting."""
+    return _format_param_value(project, datasource_name, token)
+
+
+def collect_saved_view_charts(project: Any, view: dict[str, Any]) -> list[SavedViewChart]:
+    """Return structured chart metadata from a saved view (skips text-box charts)."""
+    initial = view.get("initialCharts")
+    if not isinstance(initial, dict) or not initial:
+        return []
+
+    out: list[SavedViewChart] = []
+    for ds_name, charts in initial.items():
+        if not isinstance(charts, list):
+            continue
+        for chart in charts:
+            if not isinstance(chart, dict):
+                continue
+            ctype = chart.get("type")
+            if not isinstance(ctype, str) or ctype == "text_box_chart":
+                continue
+            title = (chart.get("title") or "").strip() or ctype
+            param_list = _to_param_list(chart.get("param"))
+            tokens = tuple(
+                str(p).strip() for p in param_list if p is not None and str(p).strip()
+            )
+            color_by = chart.get("color_by")
+            color_str = (
+                str(color_by).strip()
+                if isinstance(color_by, str) and color_by.strip()
+                else None
+            )
+            out.append(
+                SavedViewChart(
+                    datasource_name=str(ds_name),
+                    title=title,
+                    chart_type=ctype,
+                    param_tokens=tokens,
+                    color_by=color_str,
+                )
+            )
+    return out
+
+
 def _format_param_value(project: Any, datasource_name: str, token: Any) -> str:
     """
     Format a saved-view param token for display.
@@ -125,13 +190,7 @@ def format_charts_from_saved_view(
     if not isinstance(initial, dict) or not initial:
         return "", False
 
-    # Stable simplified role labels based on persisted `chart['type']`.
-    role_map: dict[str, list[str]] = {
-        "wgl_scatter_plot": ["X", "Y"],
-        "density_scatter_plot": ["X", "Y", "Category"],
-        "box_plot": ["Category", "Value"],
-        "violin_plot": ["Category", "Value"],
-    }
+    role_map = CHART_PARAM_ROLE_MAP
 
     has_selection_dialog = False
     out: list[str] = ["### Charts (from saved view)"]

--- a/python/mdvtools/tests/test_chat_cli_batch.py
+++ b/python/mdvtools/tests/test_chat_cli_batch.py
@@ -34,8 +34,17 @@ def test_batch_prompts_continue_on_error_and_write_csv(tmp_path, monkeypatch):
 
     calls = {"n": 0}
 
-    def fake_run_chat_once(*, project_path, prompt, output_dir=None, view_name=None, model_id=None):
-        del project_path, view_name, model_id
+    def fake_run_chat_once(
+        *,
+        project_path,
+        prompt,
+        output_dir=None,
+        view_name=None,
+        model_id=None,
+        datasource_mode="auto",
+        datasource_names=None,
+    ):
+        del project_path, view_name, model_id, datasource_mode, datasource_names
         calls["n"] += 1
         if output_dir is None:
             raise ValueError("output_dir is required")

--- a/python/mdvtools/tests/test_dataset_scale.py
+++ b/python/mdvtools/tests/test_dataset_scale.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import pytest
 
 from mdvtools.llm.dataset_scale import (
@@ -60,7 +58,7 @@ def test_load_agent_dataframes_large_obs_uses_column_subset():
 
     result = load_agent_dataframes(project, roles, _LARGE_SCALE)
 
-    assert result == ["df:cells"]
+    assert result == {"cells": "df:cells"}
     assert project.loads == [("cells", ["leiden"])]
 
 
@@ -77,7 +75,7 @@ def test_load_agent_dataframes_large_extra_skips_when_no_probe_columns():
         project, roles, _LARGE_SCALE, extra_datasource="table_b"
     )
 
-    assert result == ["df:cells"]
+    assert result == {"cells": "df:cells"}
     assert project.loads == [("cells", ["leiden"])]
 
 
@@ -102,5 +100,26 @@ def test_load_agent_dataframes_large_expr_skips_when_no_probe_columns():
 
     result = load_agent_dataframes(project, roles, _LARGE_SCALE)
 
-    assert result == ["df:cells"]
+    assert result == {"cells": "df:cells"}
     assert project.loads == [("cells", ["leiden"])]
+
+
+def test_load_agent_dataframes_selected_datasources_multi_table():
+    project = _ScaleProject(
+        metadata_by_name={
+            "table_a": {"columns": _OBS_COLUMNS},
+            "table_b": {"columns": [{"field": "assay", "datatype": "text"}]},
+        }
+    )
+    roles = InferredDatasourceRoles(obs_datasource="table_a", expressions=[])
+
+    result = load_agent_dataframes(
+        project,
+        roles,
+        _LARGE_SCALE,
+        selected_datasources=["table_a", "table_b"],
+    )
+
+    assert result == {"table_a": "df:table_a", "table_b": "df:table_b"}
+    assert ("table_a", ["leiden"]) in project.loads
+    assert ("table_b", ["assay"]) in project.loads

--- a/python/mdvtools/tests/test_dataset_scale.py
+++ b/python/mdvtools/tests/test_dataset_scale.py
@@ -24,6 +24,12 @@ class _ScaleProject:
         return ["table_a", "table_b", "table_c"]
 
 
+class _FailingSelectedDatasourceProject(_ScaleProject):
+    def get_datasource_as_dataframe(self, name: str, columns: list[str] | None = None):
+        self.loads.append((name, columns))
+        raise RuntimeError(f"load failed for {name}")
+
+
 _LARGE_SCALE = ProjectScale(
     obs_rows=200_000,
     obs_columns=10,
@@ -123,3 +129,43 @@ def test_load_agent_dataframes_selected_datasources_multi_table():
     assert result == {"table_a": "df:table_a", "table_b": "df:table_b"}
     assert ("table_a", ["leiden"]) in project.loads
     assert ("table_b", ["assay"]) in project.loads
+
+
+def test_load_agent_dataframes_selected_datasources_raises_first_load_error():
+    project = _FailingSelectedDatasourceProject(
+        metadata_by_name={
+            "table_a": {"columns": _OBS_COLUMNS},
+            "table_b": {"columns": [{"field": "assay", "datatype": "text"}]},
+        }
+    )
+    roles = InferredDatasourceRoles(obs_datasource="cells", expressions=[])
+
+    with pytest.raises(RuntimeError, match="load failed for table_a"):
+        load_agent_dataframes(
+            project,
+            roles,
+            _LARGE_SCALE,
+            selected_datasources=["table_a", "table_b"],
+        )
+
+    assert project.loads == [("table_a", ["leiden"]), ("table_b", ["assay"])]
+
+
+def test_load_agent_dataframes_selected_datasources_raises_when_all_probes_empty():
+    project = _ScaleProject(
+        metadata_by_name={
+            "table_a": {"columns": []},
+            "table_b": {"columns": []},
+        }
+    )
+    roles = InferredDatasourceRoles(obs_datasource="cells", expressions=[])
+
+    with pytest.raises(ValueError, match="None of the requested selected datasources"):
+        load_agent_dataframes(
+            project,
+            roles,
+            _LARGE_SCALE,
+            selected_datasources=["table_a", "table_b"],
+        )
+
+    assert project.loads == []

--- a/python/mdvtools/tests/test_datasource_roles.py
+++ b/python/mdvtools/tests/test_datasource_roles.py
@@ -1,7 +1,10 @@
 import inspect
 
+import pytest
+
 from mdvtools.llm.datasource_roles import (
     CHAT_RANK_GENES_DATASOURCE_NAME,
+    build_chat_datasource_catalog,
     build_chatmdv_roles_constants_block,
     build_datasource_field_index,
     categorical_field_ids_from_metadata,
@@ -24,6 +27,7 @@ from mdvtools.llm.datasource_roles import (
     infer_datasource_roles,
     is_multi_table_tabular_project,
     resolve_datasource_from_question,
+    resolve_datasources_for_request,
 )
 from mdvtools.llm.dataset_scale import ProjectScale, assess_project_scale
 
@@ -446,4 +450,81 @@ def test_rag_prompt_includes_all_tables_and_resolved_datasource():
     assert "Primary datasource for this question: **qc_field_uniformity**" in prompt
     assert "qc_runs" in prompt
     assert "datasource_name = 'qc_field_uniformity'" in prompt
+
+
+def test_build_chat_datasource_catalog_micron():
+    project = MicronLikeProject()
+    catalog = build_chat_datasource_catalog(project)
+    names = {d["name"] for d in catalog["datasources"]}
+    assert names == {"qc_channels", "qc_field_uniformity", "qc_runs", "qc_sessions"}
+    roles = {d["name"]: d["role"] for d in catalog["datasources"]}
+    assert roles["qc_runs"] == "obs"
+    assert catalog["default_datasource_names"] == ["qc_runs"]
+
+
+def test_build_chat_datasource_catalog_single_cell_defaults():
+    project = FakeProject()
+    catalog = build_chat_datasource_catalog(project)
+    assert catalog["default_datasource_names"] == ["cells", "rna"]
+
+
+def test_resolve_datasources_for_request_user_selection():
+    project = MicronLikeProject()
+    resolved = resolve_datasources_for_request(
+        project,
+        question="ignored",
+        user_datasource_names=["qc_runs", "qc_field_uniformity"],
+    )
+    assert resolved.source == "user"
+    assert resolved.primary == "qc_runs"
+    assert resolved.selected == ["qc_runs", "qc_field_uniformity"]
+
+
+def test_resolve_datasources_for_request_invalid_user_names():
+    project = MicronLikeProject()
+    with pytest.raises(ValueError, match="No valid datasources"):
+        resolve_datasources_for_request(
+            project,
+            question="x",
+            user_datasource_names=["not_a_table"],
+        )
+
+
+def test_resolve_datasources_for_request_question_fallback():
+    project = MicronLikeProject()
+    resolved = resolve_datasources_for_request(
+        project,
+        question="Show cv_pct by channel",
+        user_datasource_names=None,
+    )
+    assert resolved.source == "question"
+    assert resolved.primary == "qc_field_uniformity"
+
+
+def test_build_chatmdv_roles_constants_block_selected_datasources():
+    block = build_chatmdv_roles_constants_block(
+        FakeProject(),
+        selected_datasources=["cells", "rna"],
+    )
+    assert 'CHATMDV_PRIMARY_DATASOURCE = "cells"' in block
+    assert 'CHATMDV_SELECTED_DATASOURCES = ["cells", "rna"]' in block
+
+
+def test_rag_prompt_includes_multiple_selected_datasources():
+    from mdvtools.llm.templates import get_createproject_prompt_RAG
+
+    project = MicronLikeProject()
+    prompt = get_createproject_prompt_RAG(
+        project,
+        "",
+        "qc_runs",
+        'fields "assay"\ncharts "Row Chart"',
+        "Compare assay types with cv_pct",
+        compact=True,
+        datasource_names=["qc_runs", "qc_field_uniformity"],
+    )
+    assert "Primary datasource for this question: **qc_runs**" in prompt
+    assert "Additional selected datasource: qc_field_uniformity" in prompt
+    assert "user_selected_datasources" in prompt
+    assert "User-selected datasources" in prompt
 

--- a/python/mdvtools/tests/test_datasource_roles.py
+++ b/python/mdvtools/tests/test_datasource_roles.py
@@ -28,6 +28,7 @@ from mdvtools.llm.datasource_roles import (
     is_multi_table_tabular_project,
     resolve_datasource_from_question,
     resolve_datasources_for_request,
+    resolve_datasources_from_question_auto,
 )
 from mdvtools.llm.dataset_scale import ProjectScale, assess_project_scale
 
@@ -497,8 +498,51 @@ def test_resolve_datasources_for_request_question_fallback():
         question="Show cv_pct by channel",
         user_datasource_names=None,
     )
-    assert resolved.source == "question"
+    assert resolved.source == "auto"
     assert resolved.primary == "qc_field_uniformity"
+    assert resolved.selected == ["qc_field_uniformity"]
+
+
+def test_resolve_datasources_auto_cross_table_fields():
+    project = MicronLikeProject()
+    resolved = resolve_datasources_from_question_auto(
+        project,
+        "Show cv_pct and assay breakdown",
+    )
+    assert resolved.source == "auto"
+    assert set(resolved.selected) == {"qc_field_uniformity", "qc_runs"}
+    assert resolved.primary in resolved.selected
+
+
+def test_resolve_datasources_auto_expression_heuristic():
+    class CellsRnaProject(FakeProject):
+        datasources = [{"name": "cells"}, {"name": "rna"}, {"name": "protein"}]
+
+    project = CellsRnaProject()
+    resolved = resolve_datasources_from_question_auto(
+        project,
+        "What are the top marker genes by cluster?",
+    )
+    assert resolved.source == "auto"
+    assert resolved.selected == ["cells", "rna"]
+    assert resolved.primary == "cells"
+
+
+def test_rag_prompt_auto_resolved_cross_table_policy():
+    from mdvtools.llm.templates import get_createproject_prompt_RAG
+
+    project = MicronLikeProject()
+    prompt = get_createproject_prompt_RAG(
+        project,
+        "",
+        "qc_runs",
+        'fields "assay"\ncharts "Row Chart"',
+        "Compare assay types with cv_pct",
+        compact=True,
+        datasource_names=["qc_runs", "qc_field_uniformity"],
+        auto_resolved=True,
+    )
+    assert "Auto-resolved datasources" in prompt
 
 
 def test_build_chatmdv_roles_constants_block_selected_datasources():
@@ -526,5 +570,5 @@ def test_rag_prompt_includes_multiple_selected_datasources():
     assert "Primary datasource for this question: **qc_runs**" in prompt
     assert "Additional selected datasource: qc_field_uniformity" in prompt
     assert "user_selected_datasources" in prompt
-    assert "User-selected datasources" in prompt
+    assert "Selected datasources" in prompt
 

--- a/python/mdvtools/tests/test_datasource_roles.py
+++ b/python/mdvtools/tests/test_datasource_roles.py
@@ -514,6 +514,23 @@ def test_resolve_datasources_auto_cross_table_fields():
     assert resolved.primary in resolved.selected
 
 
+def test_resolve_datasources_auto_name_match_keeps_primary_first():
+    class NestedNameProject(MicronLikeProject):
+        datasources = [
+            {"name": "runs", "columns": [{"field": "run_id"}]},
+            {"name": "qc_runs", "columns": [{"field": "assay"}, {"field": "run_id"}]},
+        ]
+
+    project = NestedNameProject()
+    resolved = resolve_datasources_from_question_auto(
+        project,
+        "What assay types are present in qc_runs and runs?",
+    )
+    assert resolved.source == "auto"
+    assert resolved.primary == "qc_runs"
+    assert resolved.selected == ["qc_runs", "runs"]
+
+
 def test_resolve_datasources_auto_expression_heuristic():
     class CellsRnaProject(FakeProject):
         datasources = [{"name": "cells"}, {"name": "rna"}, {"name": "protein"}]
@@ -526,6 +543,23 @@ def test_resolve_datasources_auto_expression_heuristic():
     assert resolved.source == "auto"
     assert resolved.selected == ["cells", "rna"]
     assert resolved.primary == "cells"
+
+
+def test_resolve_datasources_auto_expression_heuristic_keeps_primary_first():
+    class RnaCellsProject(FakeProject):
+        datasources = [{"name": "rna"}, {"name": "cells"}, {"name": "protein"}]
+
+        def get_datasource_names(self):
+            return ["rna", "cells", "protein"]
+
+    project = RnaCellsProject()
+    resolved = resolve_datasources_from_question_auto(
+        project,
+        "Show marker expression by cluster",
+    )
+    assert resolved.source == "auto"
+    assert resolved.primary == "cells"
+    assert resolved.selected == ["cells", "rna"]
 
 
 def test_rag_prompt_auto_resolved_cross_table_policy():

--- a/python/mdvtools/tests/test_datasource_roles.py
+++ b/python/mdvtools/tests/test_datasource_roles.py
@@ -592,15 +592,16 @@ def test_rag_prompt_includes_multiple_selected_datasources():
     from mdvtools.llm.templates import get_createproject_prompt_RAG
 
     project = MicronLikeProject()
-    kwargs = dict(
-        path_to_data="",
-        datasource_name="qc_runs",
-        final_answer='fields "assay"\ncharts "Row Chart"',
-        question="Compare assay types with cv_pct",
-        datasource_names=["qc_runs", "qc_field_uniformity"],
-    )
     for compact in (True, False):
-        prompt = get_createproject_prompt_RAG(project, compact=compact, **kwargs)
+        prompt = get_createproject_prompt_RAG(
+            project,
+            "",
+            "qc_runs",
+            'fields "assay"\ncharts "Row Chart"',
+            "Compare assay types with cv_pct",
+            compact=compact,
+            datasource_names=["qc_runs", "qc_field_uniformity"],
+        )
         assert "Primary datasource for this question: **qc_runs**" in prompt
         assert "Additional selected datasource: qc_field_uniformity" in prompt
         assert "user_selected_datasources" in prompt

--- a/python/mdvtools/tests/test_datasource_roles.py
+++ b/python/mdvtools/tests/test_datasource_roles.py
@@ -592,17 +592,17 @@ def test_rag_prompt_includes_multiple_selected_datasources():
     from mdvtools.llm.templates import get_createproject_prompt_RAG
 
     project = MicronLikeProject()
-    prompt = get_createproject_prompt_RAG(
-        project,
-        "",
-        "qc_runs",
-        'fields "assay"\ncharts "Row Chart"',
-        "Compare assay types with cv_pct",
-        compact=True,
+    kwargs = dict(
+        path_to_data="",
+        datasource_name="qc_runs",
+        final_answer='fields "assay"\ncharts "Row Chart"',
+        question="Compare assay types with cv_pct",
         datasource_names=["qc_runs", "qc_field_uniformity"],
     )
-    assert "Primary datasource for this question: **qc_runs**" in prompt
-    assert "Additional selected datasource: qc_field_uniformity" in prompt
-    assert "user_selected_datasources" in prompt
-    assert "Selected datasources" in prompt
+    for compact in (True, False):
+        prompt = get_createproject_prompt_RAG(project, compact=compact, **kwargs)
+        assert "Primary datasource for this question: **qc_runs**" in prompt
+        assert "Additional selected datasource: qc_field_uniformity" in prompt
+        assert "user_selected_datasources" in prompt
+        assert "Selected datasources" in prompt
 

--- a/python/mdvtools/tests/test_guidance.py
+++ b/python/mdvtools/tests/test_guidance.py
@@ -21,6 +21,9 @@ class FakeProject:
         self._columns = {
             "channel_name": {"field": "channel_name", "name": "channel_name"},
             "cv_pct": {"field": "cv_pct", "name": "cv_pct"},
+            "X_pca_1": {"field": "X_pca_1", "name": "X_pca_1"},
+            "X_pca_2": {"field": "X_pca_2", "name": "X_pca_2"},
+            "leiden": {"field": "leiden", "name": "leiden"},
         }
 
     def get_view(self, view_name: str):
@@ -58,10 +61,64 @@ def test_build_response_guidance_includes_sections():
         'fields "channel_name", "cv_pct"\ncharts "Box plot"',
         "| channel | cv_pct |\n|---|---|\n| C405 | 12 |",
     )
-    assert "## Why this visualization" in md
-    assert "## What to look for" in md
-    assert "## Suggested next steps" in md
-    assert "qc_runs" in md or "follow-up" in md.lower()
+    assert "## 1. Why this chart is the best way to answer the question" in md
+    assert "## 2. Biological insights that can be gained" in md
+    assert "## 3. Subsequent analysis tasks" in md
+    assert "### In summary" in md
+    assert "The user asked:" in md
+    assert "**Box Plot**" in md
+    assert "qc_runs" in md or "Follow-up" in md
+
+
+def test_build_response_guidance_subclustering_style_explanation():
+    proj = FakeProject()
+    proj.datasources = [{"name": "cells"}]
+    proj._columns["ARVCF"] = {"field": "ARVCF", "name": "ARVCF"}
+    gene_wrapper = "rna_expr|ARVCF(rna_expr)|42"
+    proj._views["v1"] = {
+        "initialCharts": {
+            "cells": [
+                {
+                    "title": "PCA colored by ARVCF",
+                    "type": "wgl_scatter_plot",
+                    "param": ["X_pca_1", "X_pca_2"],
+                    "color_by": gene_wrapper,
+                },
+                {
+                    "title": "Density",
+                    "type": "density_scatter_plot",
+                    "param": ["X_pca_1", "X_pca_2", "leiden"],
+                },
+                {
+                    "title": "Cells table",
+                    "type": "table_chart",
+                    "param": ["leiden", "X_pca_1", "X_pca_2", gene_wrapper],
+                },
+                {
+                    "title": "Filter cells",
+                    "type": "selection_dialog",
+                    "param": ["leiden", "X_pca_1", "X_pca_2", gene_wrapper],
+                },
+            ]
+        }
+    }
+    question = (
+        "Could you perform subclustering within cluster 1 based on the "
+        "expression levels of the gene ARVCF?"
+    )
+    code = (
+        "datasource_name = 'cells'\n"
+        "subset = adata.obs['leiden'] == '1'\n"
+    )
+    md = build_response_guidance(proj, question, code, "v1", "", None)
+    assert "ARVCF" in md
+    assert "**Scatter Plot (2D)**" in md
+    assert "**Density Scatter Plot**" in md
+    assert "**Table Plot**" in md
+    assert "**Selection Dialog Plot**" in md
+    assert "Subpopulation discovery" in md
+    assert "Marker gene analysis" in md or "Automated subclustering" in md
+    assert "cluster 1" in md.lower()
 
 
 def test_append_guidance_textbox_prepends_and_replaces_summary():
@@ -83,7 +140,7 @@ def test_append_guidance_textbox_prepends_and_replaces_summary():
             ]
         }
     }
-    guidance = "## Why this visualization\n\nTest summary.\n"
+    guidance = "## 1. Why this chart is the best way to answer the question\n\nTest summary.\n"
     ok = append_guidance_textbox_to_view(
         proj, "v1", "qc_field_uniformity", guidance
     )

--- a/python/mdvtools/tests/test_langchain_mdv_helpers.py
+++ b/python/mdvtools/tests/test_langchain_mdv_helpers.py
@@ -1,11 +1,51 @@
 from typing import cast
 
+import re
+
+from mdvtools.llm.datasource_roles import InferredDatasourceRoles, RowsAsColumnsExpression
 from mdvtools.llm.langchain_mdv import (
     ProjectChat,
     _is_text_table_intent,
     _is_text_table_only_code,
 )
+from mdvtools.llm.templates import prompt_data
 from mdvtools.mdvproject import MDVProject
+
+_LANGCHAIN_AGENT_VARS = frozenset(
+    {"input", "chat_history", "agent_scratchpad", "tools", "tool_names"}
+)
+
+
+def _single_brace_placeholders(text: str) -> set[str]:
+    return set(re.findall(r"(?<!\{)\{([a-zA-Z_][a-zA-Z0-9_]*)\}(?!\})", text))
+
+
+def test_prompt_data_has_no_stray_langchain_variables():
+    assert _single_brace_placeholders(prompt_data).isdisjoint(_LANGCHAIN_AGENT_VARS)
+
+
+def test_build_role_hint_selected_datasources_has_no_stray_langchain_variables():
+    class _StubChat:
+        roles = InferredDatasourceRoles(
+            obs_datasource="cells",
+            expressions=[
+                RowsAsColumnsExpression(
+                    datasource_name="rna",
+                    name_column="name",
+                    subgroup_key="rna_expr",
+                    subgroup_label="rna_expr",
+                )
+            ],
+        )
+        scale = None
+
+    hint = ProjectChat._build_role_hint(
+        _StubChat(),
+        primary_datasource="cells",
+        selected_datasources=["cells", "rna"],
+    )
+    stray = _single_brace_placeholders(hint)
+    assert stray.isdisjoint(_LANGCHAIN_AGENT_VARS), f"unexpected placeholders: {stray}"
 
 
 def test_is_text_table_only_code_print_only():

--- a/python/mdvtools/tests/test_langchain_mdv_helpers.py
+++ b/python/mdvtools/tests/test_langchain_mdv_helpers.py
@@ -40,7 +40,7 @@ def test_build_role_hint_selected_datasources_has_no_stray_langchain_variables()
         scale = None
 
     hint = ProjectChat._build_role_hint(
-        _StubChat(),
+        cast(ProjectChat, _StubChat()),
         primary_datasource="cells",
         selected_datasources=["cells", "rna"],
     )

--- a/python/mdvtools/tests/test_verification_charts.py
+++ b/python/mdvtools/tests/test_verification_charts.py
@@ -6,6 +6,7 @@ import pytest
 
 from mdvtools.llm.verification import (
     build_verification_summary,
+    collect_saved_view_charts,
     format_charts_from_saved_view,
 )
 
@@ -29,6 +30,28 @@ class FakeProject:
     def get_datasource_metadata(self, name: str):
         assert name == "cells"
         return {"name": name, "size": self._size}
+
+
+def test_collect_saved_view_charts_skips_text_box():
+    view = {
+        "initialCharts": {
+            "cells": [
+                {"title": "TB", "type": "text_box_chart", "text": "x"},
+                {
+                    "title": "S1",
+                    "type": "wgl_scatter_plot",
+                    "param": ["x_field", "y_field"],
+                    "color_by": "color_field",
+                },
+            ]
+        }
+    }
+    proj = FakeProject(view=view, column_names={})
+    charts = collect_saved_view_charts(proj, view)
+    assert len(charts) == 1
+    assert charts[0].chart_type == "wgl_scatter_plot"
+    assert charts[0].param_tokens == ("x_field", "y_field")
+    assert charts[0].color_by == "color_field"
 
 
 def test_format_charts_scatter_includes_roles_and_color_by():

--- a/src/charts/dialogs/ChatAPI.ts
+++ b/src/charts/dialogs/ChatAPI.ts
@@ -99,6 +99,7 @@ const completedChatResponseSchema = z.object({
     guidance: z.string().optional().nullable(),
     /** Reload the page when opening the view so datasources.json changes are picked up. */
     needs_refresh: z.boolean().optional(),
+    resolved_datasource_names: z.array(z.string()).optional().nullable(),
     // timestamp: z.string(),
     error: z.boolean().optional(),
 });
@@ -115,6 +116,9 @@ export type ChatModelOption = z.infer<typeof chatModelSchema>;
 
 const CHAT_MODEL_STORAGE_KEY = 'chatmdv-selected-model';
 const CHAT_DATASOURCE_STORAGE_KEY = 'chatmdv-selected-datasources';
+const CHAT_DATASOURCE_MODE_STORAGE_KEY = 'chatmdv-datasource-mode';
+
+export type DatasourceMode = 'auto' | 'manual';
 
 const chatDatasourceSchema = z.object({
     name: z.string(),
@@ -189,8 +193,11 @@ export type ChatMessage = {
     guidance?: string | null;
     /** When true, "Load view" should reload the app so new/updated datasources load in ChartManager. */
     needs_refresh?: boolean;
-    /** Datasources scoped for this user message (when manually selected). */
+    /** Datasources scoped for this user message (manual mode). */
     datasource_names?: string[];
+    datasource_mode?: DatasourceMode;
+    /** Datasources inferred by the backend (auto mode). */
+    resolved_datasource_names?: string[];
     sender: 'user' | 'bot' | 'system';
     id: string;
     conversationId: string;
@@ -237,6 +244,7 @@ const sendMessageSocket = async (
     conversationId: string,
     modelId?: string,
     time?: number,
+    datasourceMode: DatasourceMode = 'auto',
     datasourceNames?: string[],
 ) => {
     // consider refactoring to be a generator function, so that we can yield progress updates
@@ -277,7 +285,8 @@ const sendMessageSocket = async (
             id,
             conversation_id: conversationId,
             ...(modelId ? { model_id: modelId } : {}),
-            ...(datasourceNames && datasourceNames.length > 0
+            datasource_mode: datasourceMode,
+            ...(datasourceMode === 'manual' && datasourceNames && datasourceNames.length > 0
                 ? { datasource_names: datasourceNames }
                 : {}),
         });
@@ -379,8 +388,28 @@ const useChat = () => {
     const [selectedModelId, setSelectedModelId] = useState<string>('');
     const [availableDatasources, setAvailableDatasources] = useState<ChatDatasourceOption[]>([]);
     const [selectedDatasourceNames, setSelectedDatasourceNames] = useState<string[]>([]);
+    const [datasourceMode, setDatasourceMode] = useState<DatasourceMode>('auto');
 
     const datasourceStorageKey = `${CHAT_DATASOURCE_STORAGE_KEY}:${projectName}`;
+    const datasourceModeStorageKey = `${CHAT_DATASOURCE_MODE_STORAGE_KEY}:${projectName}`;
+
+    const applyDatasourceMode = useCallback(() => {
+        try {
+            const stored = sessionStorage.getItem(datasourceModeStorageKey);
+            if (stored === 'manual' || stored === 'auto') {
+                setDatasourceMode(stored);
+            } else {
+                setDatasourceMode('auto');
+            }
+        } catch {
+            setDatasourceMode('auto');
+        }
+    }, [datasourceModeStorageKey]);
+
+    const onDatasourceModeChange = useCallback((mode: DatasourceMode) => {
+        setDatasourceMode(mode);
+        sessionStorage.setItem(datasourceModeStorageKey, mode);
+    }, [datasourceModeStorageKey]);
 
     const applyDatasourceSelection = useCallback((
         datasources: ChatDatasourceOption[],
@@ -543,6 +572,7 @@ const useChat = () => {
             if (response?.datasources) {
                 applyDatasourceSelection(response.datasources, response.default_datasource_names);
             }
+            applyDatasourceMode();
         } catch (error: any) {
             const errorMessage = formatChatError(error);
             console.error('Error sending welcome message: ', errorMessage);
@@ -561,7 +591,7 @@ const useChat = () => {
             setIsInit(true);
             setIsLoadingInit(false);
         }
-    }, [isSending, isInit, routeInit, conversationId, messages.length, isChatLogLoading, applyModelSelection, applyDatasourceSelection]);
+    }, [isSending, isInit, routeInit, conversationId, messages.length, isChatLogLoading, applyModelSelection, applyDatasourceSelection, applyDatasourceMode]);
 
     // Socket connection and Init chat
     useEffect(() => {
@@ -607,7 +637,8 @@ const useChat = () => {
                 sender: 'user',
                 id: generateId(),
                 conversationId,
-                datasource_names: selectedDatasourceNames.length > 0 ? [...selectedDatasourceNames] : undefined,
+                datasource_mode: datasourceMode,
+                datasource_names: datasourceMode === 'manual' ? [...selectedDatasourceNames] : undefined,
             }])
             
             const response = await sendMessageSocket(
@@ -617,6 +648,7 @@ const useChat = () => {
                 conversationId,
                 selectedModelId || undefined,
                 undefined,
+                datasourceMode,
                 selectedDatasourceNames,
             );
 
@@ -637,6 +669,7 @@ const useChat = () => {
                     data_preview: response?.data_preview ?? undefined,
                     guidance: response?.guidance ?? undefined,
                     needs_refresh: response?.needs_refresh ?? false,
+                    resolved_datasource_names: response?.resolved_datasource_names ?? undefined,
                 }])
             }
         } catch (error: any) {
@@ -655,7 +688,7 @@ const useChat = () => {
             setCurrentRequestId('');
             setRequestProgress(null);
         }
-    }, [conversationId, socket, viewManager, selectedModelId, selectedDatasourceNames]);
+    }, [conversationId, socket, viewManager, selectedModelId, selectedDatasourceNames, datasourceMode]);
 
 
     // Start New Conversation
@@ -684,6 +717,7 @@ const useChat = () => {
             if (response?.datasources) {
                 applyDatasourceSelection(response.datasources, response.default_datasource_names);
             }
+            applyDatasourceMode();
         } catch (error: any) {
             const errorMessage = formatChatError(error);
             setMessages([{
@@ -699,7 +733,7 @@ const useChat = () => {
             setCurrentRequestId("");
             setIsSending(false);
         }
-    }, [routeInit, applyModelSelection, applyDatasourceSelection]);
+    }, [routeInit, applyModelSelection, applyDatasourceSelection, applyDatasourceMode]);
 
     // Switch conversation
     const switchConversation = useCallback((id: string) => {
@@ -729,6 +763,8 @@ const useChat = () => {
         availableDatasources,
         selectedDatasourceNames,
         onDatasourcesChange,
+        datasourceMode,
+        onDatasourceModeChange,
     };
 };
 

--- a/src/charts/dialogs/ChatAPI.ts
+++ b/src/charts/dialogs/ChatAPI.ts
@@ -114,12 +114,23 @@ const chatModelSchema = z.object({
 export type ChatModelOption = z.infer<typeof chatModelSchema>;
 
 const CHAT_MODEL_STORAGE_KEY = 'chatmdv-selected-model';
+const CHAT_DATASOURCE_STORAGE_KEY = 'chatmdv-selected-datasources';
+
+const chatDatasourceSchema = z.object({
+    name: z.string(),
+    role: z.enum(['obs', 'expression', 'table']),
+    row_count: z.number().nullable().optional(),
+});
+
+export type ChatDatasourceOption = z.infer<typeof chatDatasourceSchema>;
 
 const chatInitResponseSchema = z.object({
     message: z.string(),
     suggested_questions: z.array(z.string()).optional(),
     models: z.array(chatModelSchema).optional(),
     default_model_id: z.string().optional().nullable(),
+    datasources: z.array(chatDatasourceSchema).optional(),
+    default_datasource_names: z.array(z.string()).optional(),
     error: z.boolean().optional(),
 });
 type ChatInitResponse = z.infer<typeof chatInitResponseSchema>;
@@ -178,6 +189,8 @@ export type ChatMessage = {
     guidance?: string | null;
     /** When true, "Load view" should reload the app so new/updated datasources load in ChartManager. */
     needs_refresh?: boolean;
+    /** Datasources scoped for this user message (when manually selected). */
+    datasource_names?: string[];
     sender: 'user' | 'bot' | 'system';
     id: string;
     conversationId: string;
@@ -224,6 +237,7 @@ const sendMessageSocket = async (
     conversationId: string,
     modelId?: string,
     time?: number,
+    datasourceNames?: string[],
 ) => {
     // consider refactoring to be a generator function, so that we can yield progress updates
     const socket = window.mdv.chartManager.ipc?.socket;
@@ -263,6 +277,9 @@ const sendMessageSocket = async (
             id,
             conversation_id: conversationId,
             ...(modelId ? { model_id: modelId } : {}),
+            ...(datasourceNames && datasourceNames.length > 0
+                ? { datasource_names: datasourceNames }
+                : {}),
         });
     });
 
@@ -360,6 +377,43 @@ const useChat = () => {
     const [suggestedQuestions, setSuggestedQuestions] = useState<string[]>([]);
     const [availableModels, setAvailableModels] = useState<ChatModelOption[]>([]);
     const [selectedModelId, setSelectedModelId] = useState<string>('');
+    const [availableDatasources, setAvailableDatasources] = useState<ChatDatasourceOption[]>([]);
+    const [selectedDatasourceNames, setSelectedDatasourceNames] = useState<string[]>([]);
+
+    const datasourceStorageKey = `${CHAT_DATASOURCE_STORAGE_KEY}:${projectName}`;
+
+    const applyDatasourceSelection = useCallback((
+        datasources: ChatDatasourceOption[],
+        defaultNames?: string[],
+    ) => {
+        setAvailableDatasources(datasources);
+        if (datasources.length <= 1) {
+            setSelectedDatasourceNames(datasources.map((d) => d.name));
+            return;
+        }
+        const validNames = new Set(datasources.map((d) => d.name));
+        let stored: string[] = [];
+        try {
+            const raw = sessionStorage.getItem(datasourceStorageKey);
+            if (raw) {
+                const parsed = JSON.parse(raw);
+                if (Array.isArray(parsed)) {
+                    stored = parsed.filter((n): n is string => typeof n === 'string' && validNames.has(n));
+                }
+            }
+        } catch {
+            stored = [];
+        }
+        const defaults = (defaultNames ?? []).filter((n) => validNames.has(n));
+        const next = stored.length > 0 ? stored : (defaults.length > 0 ? defaults : [datasources[0].name]);
+        setSelectedDatasourceNames(next);
+    }, [datasourceStorageKey]);
+
+    const onDatasourcesChange = useCallback((names: string[]) => {
+        if (names.length === 0) return;
+        setSelectedDatasourceNames(names);
+        sessionStorage.setItem(datasourceStorageKey, JSON.stringify(names));
+    }, [datasourceStorageKey]);
 
     const applyModelSelection = useCallback((models: ChatModelOption[], defaultModelId?: string | null) => {
         const chatModels = models.filter((m) => m.kind === 'chat');
@@ -486,6 +540,9 @@ const useChat = () => {
             if (response?.models) {
                 applyModelSelection(response.models, response.default_model_id);
             }
+            if (response?.datasources) {
+                applyDatasourceSelection(response.datasources, response.default_datasource_names);
+            }
         } catch (error: any) {
             const errorMessage = formatChatError(error);
             console.error('Error sending welcome message: ', errorMessage);
@@ -504,7 +561,7 @@ const useChat = () => {
             setIsInit(true);
             setIsLoadingInit(false);
         }
-    }, [isSending, isInit, routeInit, conversationId, messages.length, isChatLogLoading, applyModelSelection]);
+    }, [isSending, isInit, routeInit, conversationId, messages.length, isChatLogLoading, applyModelSelection, applyDatasourceSelection]);
 
     // Socket connection and Init chat
     useEffect(() => {
@@ -550,6 +607,7 @@ const useChat = () => {
                 sender: 'user',
                 id: generateId(),
                 conversationId,
+                datasource_names: selectedDatasourceNames.length > 0 ? [...selectedDatasourceNames] : undefined,
             }])
             
             const response = await sendMessageSocket(
@@ -558,6 +616,8 @@ const useChat = () => {
                 "",
                 conversationId,
                 selectedModelId || undefined,
+                undefined,
+                selectedDatasourceNames,
             );
 
             if (response) {
@@ -595,7 +655,7 @@ const useChat = () => {
             setCurrentRequestId('');
             setRequestProgress(null);
         }
-    }, [conversationId, socket, viewManager, selectedModelId]);
+    }, [conversationId, socket, viewManager, selectedModelId, selectedDatasourceNames]);
 
 
     // Start New Conversation
@@ -621,6 +681,9 @@ const useChat = () => {
             if (response?.models) {
                 applyModelSelection(response.models, response.default_model_id);
             }
+            if (response?.datasources) {
+                applyDatasourceSelection(response.datasources, response.default_datasource_names);
+            }
         } catch (error: any) {
             const errorMessage = formatChatError(error);
             setMessages([{
@@ -636,7 +699,7 @@ const useChat = () => {
             setCurrentRequestId("");
             setIsSending(false);
         }
-    }, [routeInit, applyModelSelection]);
+    }, [routeInit, applyModelSelection, applyDatasourceSelection]);
 
     // Switch conversation
     const switchConversation = useCallback((id: string) => {
@@ -663,6 +726,9 @@ const useChat = () => {
         availableModels,
         selectedModelId,
         onModelChange,
+        availableDatasources,
+        selectedDatasourceNames,
+        onDatasourcesChange,
     };
 };
 

--- a/src/charts/dialogs/ChatDialog.tsx
+++ b/src/charts/dialogs/ChatDialog.tsx
@@ -13,7 +13,7 @@ import {
     TextField,
     Typography,
 } from "@mui/material";
-import type { ChatMessage, ChatModelOption, ChatProgress, ConversationMap } from "./ChatAPI";
+import type { ChatMessage, ChatModelOption, ChatDatasourceOption, ChatProgress, ConversationMap } from "./ChatAPI";
 import {
     Close as CloseIcon,
     Launch as LaunchIcon,
@@ -43,6 +43,9 @@ export type ChatDialogProps = {
     availableModels: ChatModelOption[];
     selectedModelId: string;
     onModelChange: (modelId: string) => void;
+    availableDatasources: ChatDatasourceOption[];
+    selectedDatasourceNames: string[];
+    onDatasourcesChange: (names: string[]) => void;
     onPopout?: () => void;
     isPopout?: boolean;
     fullscreen?: boolean;
@@ -66,6 +69,9 @@ const ChatDialog = ({
     availableModels,
     selectedModelId,
     onModelChange,
+    availableDatasources,
+    selectedDatasourceNames,
+    onDatasourcesChange,
     onPopout,
     isPopout,
     fullscreen = false,
@@ -267,6 +273,9 @@ const ChatDialog = ({
                                     availableModels={availableModels}
                                     selectedModelId={selectedModelId}
                                     onModelChange={onModelChange}
+                                    availableDatasources={availableDatasources}
+                                    selectedDatasourceNames={selectedDatasourceNames}
+                                    onDatasourcesChange={onDatasourcesChange}
                                 />
                             </Suspense>
                         )}

--- a/src/charts/dialogs/ChatDialog.tsx
+++ b/src/charts/dialogs/ChatDialog.tsx
@@ -13,7 +13,7 @@ import {
     TextField,
     Typography,
 } from "@mui/material";
-import type { ChatMessage, ChatModelOption, ChatDatasourceOption, ChatProgress, ConversationMap } from "./ChatAPI";
+import type { ChatMessage, ChatModelOption, ChatDatasourceOption, DatasourceMode, ChatProgress, ConversationMap } from "./ChatAPI";
 import {
     Close as CloseIcon,
     Launch as LaunchIcon,
@@ -46,6 +46,8 @@ export type ChatDialogProps = {
     availableDatasources: ChatDatasourceOption[];
     selectedDatasourceNames: string[];
     onDatasourcesChange: (names: string[]) => void;
+    datasourceMode: DatasourceMode;
+    onDatasourceModeChange: (mode: DatasourceMode) => void;
     onPopout?: () => void;
     isPopout?: boolean;
     fullscreen?: boolean;
@@ -72,6 +74,8 @@ const ChatDialog = ({
     availableDatasources,
     selectedDatasourceNames,
     onDatasourcesChange,
+    datasourceMode,
+    onDatasourceModeChange,
     onPopout,
     isPopout,
     fullscreen = false,
@@ -276,6 +280,8 @@ const ChatDialog = ({
                                     availableDatasources={availableDatasources}
                                     selectedDatasourceNames={selectedDatasourceNames}
                                     onDatasourcesChange={onDatasourcesChange}
+                                    datasourceMode={datasourceMode}
+                                    onDatasourceModeChange={onDatasourceModeChange}
                                 />
                             </Suspense>
                         )}

--- a/src/charts/dialogs/ChatDialogComponent.tsx
+++ b/src/charts/dialogs/ChatDialogComponent.tsx
@@ -1,6 +1,6 @@
 import { BotMessageSquare, SquareTerminal } from 'lucide-react';
 import { MessageCircleQuestion, ThumbsUp, ThumbsDown, Star, NotebookPen, CircleAlert } from 'lucide-react';
-import { type ChatProgress, type ChatMessage, type ChatModelOption, navigateToView } from './ChatAPI';
+import { type ChatProgress, type ChatMessage, type ChatModelOption, type ChatDatasourceOption, navigateToView } from './ChatAPI';
 import { forwardRef, memo, useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import JsonView from 'react18-json-view';
 import ReactMarkdown from 'react-markdown';
@@ -18,10 +18,13 @@ import {
     IconButton,
     InputAdornment,
     FormControl,
+    Checkbox,
     InputLabel,
     MenuItem,
     Select,
     Skeleton,
+    FormControlLabel,
+    FormGroup,
     TextField,
     Typography,
 } from '@mui/material';
@@ -149,6 +152,7 @@ const Message = memo(forwardRef<HTMLDivElement, MessageProps>(function Message(
     data_preview,
     guidance,
     needs_refresh,
+    datasource_names,
     onClose,
     error,
     updateInput,
@@ -211,6 +215,11 @@ const Message = memo(forwardRef<HTMLDivElement, MessageProps>(function Message(
                             <ContentCopy fontSize='small' />
                         )}
                     </IconButton>
+                )}
+                {isUser && datasource_names && datasource_names.length > 0 && (
+                    <Typography variant="caption" color="text.secondary" className="block mb-2">
+                        Datasources: {datasource_names.join(', ')}
+                    </Typography>
                 )}
                 {sender === 'bot' && !error && guidance?.trim() && (
                     <ChatPreviewBlock
@@ -453,6 +462,12 @@ const Progress = (props: ChatProgress & {verboseProgress: string[]}) => {
     );
 }
 
+function datasourceRoleLabel(role: ChatDatasourceOption['role']): string {
+    if (role === 'obs') return 'obs';
+    if (role === 'expression') return 'expr';
+    return 'table';
+}
+
 export type ChatBotProps = {
     messages: ChatMessage[];
     isSending: boolean;
@@ -464,6 +479,9 @@ export type ChatBotProps = {
     availableModels: ChatModelOption[];
     selectedModelId: string;
     onModelChange: (modelId: string) => void;
+    availableDatasources: ChatDatasourceOption[];
+    selectedDatasourceNames: string[];
+    onDatasourcesChange: (names: string[]) => void;
 };
 
 
@@ -478,6 +496,9 @@ const Chatbot = ({
     availableModels,
     selectedModelId,
     onModelChange,
+    availableDatasources,
+    selectedDatasourceNames,
+    onDatasourcesChange,
 }: ChatBotProps) => {
     const [input, setInput] = useState<string>('');
     const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -587,6 +608,49 @@ const Chatbot = ({
                 ) : availableModels.length === 1 ? (
                     <Typography variant="caption" color="text.secondary">
                         Model: {availableModels[0].label}
+                    </Typography>
+                ) : null}
+                {availableDatasources.length > 1 ? (
+                    <Box>
+                        <Typography variant="caption" color="text.secondary" className="block mb-1">
+                            Datasources (first selected is the primary chart target)
+                        </Typography>
+                        <FormGroup row sx={{ flexWrap: 'wrap', gap: 0.5 }}>
+                            {availableDatasources.map((ds) => {
+                                const checked = selectedDatasourceNames.includes(ds.name);
+                                return (
+                                    <FormControlLabel
+                                        key={ds.name}
+                                        disabled={isSending || (checked && selectedDatasourceNames.length <= 1)}
+                                        control={
+                                            <Checkbox
+                                                size="small"
+                                                checked={checked}
+                                                onChange={() => {
+                                                    const nameSet = new Set(
+                                                        checked
+                                                            ? selectedDatasourceNames.filter((n) => n !== ds.name)
+                                                            : [...selectedDatasourceNames, ds.name],
+                                                    );
+                                                    const next = availableDatasources
+                                                        .map((d) => d.name)
+                                                        .filter((n) => nameSet.has(n));
+                                                    if (next.length > 0) {
+                                                        onDatasourcesChange(next);
+                                                    }
+                                                }}
+                                            />
+                                        }
+                                        label={`${ds.name} (${datasourceRoleLabel(ds.role)})`}
+                                        sx={{ mr: 1 }}
+                                    />
+                                );
+                            })}
+                        </FormGroup>
+                    </Box>
+                ) : availableDatasources.length === 1 ? (
+                    <Typography variant="caption" color="text.secondary">
+                        Datasource: {availableDatasources[0].name}
                     </Typography>
                 ) : null}
             <Box className="flex w-full">

--- a/src/charts/dialogs/ChatDialogComponent.tsx
+++ b/src/charts/dialogs/ChatDialogComponent.tsx
@@ -1,6 +1,6 @@
 import { BotMessageSquare, SquareTerminal } from 'lucide-react';
 import { MessageCircleQuestion, ThumbsUp, ThumbsDown, Star, NotebookPen, CircleAlert } from 'lucide-react';
-import { type ChatProgress, type ChatMessage, type ChatModelOption, type ChatDatasourceOption, navigateToView } from './ChatAPI';
+import { type ChatProgress, type ChatMessage, type ChatModelOption, type ChatDatasourceOption, type DatasourceMode, navigateToView } from './ChatAPI';
 import { forwardRef, memo, useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import JsonView from 'react18-json-view';
 import ReactMarkdown from 'react-markdown';
@@ -19,14 +19,16 @@ import {
     InputAdornment,
     FormControl,
     Checkbox,
+    FormControlLabel,
+    FormGroup,
     InputLabel,
     MenuItem,
     Select,
     Skeleton,
-    FormControlLabel,
-    FormGroup,
     TextField,
     Typography,
+    ToggleButton,
+    ToggleButtonGroup,
 } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import _ from 'lodash';
@@ -153,6 +155,8 @@ const Message = memo(forwardRef<HTMLDivElement, MessageProps>(function Message(
     guidance,
     needs_refresh,
     datasource_names,
+    datasource_mode,
+    resolved_datasource_names,
     onClose,
     error,
     updateInput,
@@ -216,9 +220,19 @@ const Message = memo(forwardRef<HTMLDivElement, MessageProps>(function Message(
                         )}
                     </IconButton>
                 )}
-                {isUser && datasource_names && datasource_names.length > 0 && (
+                {isUser && datasource_mode === 'manual' && datasource_names && datasource_names.length > 0 && (
                     <Typography variant="caption" color="text.secondary" className="block mb-2">
                         Datasources: {datasource_names.join(', ')}
+                    </Typography>
+                )}
+                {isUser && datasource_mode === 'auto' && (
+                    <Typography variant="caption" color="text.secondary" className="block mb-2">
+                        Datasources: Auto
+                    </Typography>
+                )}
+                {sender === 'bot' && !error && resolved_datasource_names && resolved_datasource_names.length > 0 && (
+                    <Typography variant="caption" color="text.secondary" className="block mb-2">
+                        Resolved datasources: {resolved_datasource_names.join(', ')}
                     </Typography>
                 )}
                 {sender === 'bot' && !error && guidance?.trim() && (
@@ -482,6 +496,8 @@ export type ChatBotProps = {
     availableDatasources: ChatDatasourceOption[];
     selectedDatasourceNames: string[];
     onDatasourcesChange: (names: string[]) => void;
+    datasourceMode: DatasourceMode;
+    onDatasourceModeChange: (mode: DatasourceMode) => void;
 };
 
 
@@ -499,6 +515,8 @@ const Chatbot = ({
     availableDatasources,
     selectedDatasourceNames,
     onDatasourcesChange,
+    datasourceMode,
+    onDatasourceModeChange,
 }: ChatBotProps) => {
     const [input, setInput] = useState<string>('');
     const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -613,40 +631,69 @@ const Chatbot = ({
                 {availableDatasources.length > 1 ? (
                     <Box>
                         <Typography variant="caption" color="text.secondary" className="block mb-1">
-                            Datasources (first selected is the primary chart target)
+                            Datasource mode
                         </Typography>
-                        <FormGroup row sx={{ flexWrap: 'wrap', gap: 0.5 }}>
-                            {availableDatasources.map((ds) => {
-                                const checked = selectedDatasourceNames.includes(ds.name);
-                                return (
-                                    <FormControlLabel
-                                        key={ds.name}
-                                        disabled={isSending || (checked && selectedDatasourceNames.length <= 1)}
-                                        control={
-                                            <Checkbox
-                                                size="small"
-                                                checked={checked}
-                                                onChange={() => {
-                                                    const nameSet = new Set(
-                                                        checked
-                                                            ? selectedDatasourceNames.filter((n) => n !== ds.name)
-                                                            : [...selectedDatasourceNames, ds.name],
-                                                    );
-                                                    const next = availableDatasources
-                                                        .map((d) => d.name)
-                                                        .filter((n) => nameSet.has(n));
-                                                    if (next.length > 0) {
-                                                        onDatasourcesChange(next);
-                                                    }
-                                                }}
+                        <ToggleButtonGroup
+                            size="small"
+                            exclusive
+                            value={datasourceMode}
+                            onChange={(_e, value: DatasourceMode | null) => {
+                                if (value) onDatasourceModeChange(value);
+                            }}
+                            aria-label="datasource mode"
+                            disabled={isSending}
+                            sx={{ mb: 1 }}
+                        >
+                            <ToggleButton value="auto" sx={{ textTransform: 'none' }}>
+                                Auto
+                            </ToggleButton>
+                            <ToggleButton value="manual" sx={{ textTransform: 'none' }}>
+                                Manual
+                            </ToggleButton>
+                        </ToggleButtonGroup>
+                        {datasourceMode === 'auto' ? (
+                            <Typography variant="caption" color="text.secondary" className="block">
+                                Datasources inferred from your question (table names and column fields).
+                            </Typography>
+                        ) : (
+                            <>
+                                <Typography variant="caption" color="text.secondary" className="block mb-1">
+                                    Datasources (first selected is the primary chart target)
+                                </Typography>
+                                <FormGroup row sx={{ flexWrap: 'wrap', gap: 0.5 }}>
+                                    {availableDatasources.map((ds) => {
+                                        const checked = selectedDatasourceNames.includes(ds.name);
+                                        return (
+                                            <FormControlLabel
+                                                key={ds.name}
+                                                disabled={isSending || (checked && selectedDatasourceNames.length <= 1)}
+                                                control={
+                                                    <Checkbox
+                                                        size="small"
+                                                        checked={checked}
+                                                        onChange={() => {
+                                                            const nameSet = new Set(
+                                                                checked
+                                                                    ? selectedDatasourceNames.filter((n) => n !== ds.name)
+                                                                    : [...selectedDatasourceNames, ds.name],
+                                                            );
+                                                            const next = availableDatasources
+                                                                .map((d) => d.name)
+                                                                .filter((n) => nameSet.has(n));
+                                                            if (next.length > 0) {
+                                                                onDatasourcesChange(next);
+                                                            }
+                                                        }}
+                                                    />
+                                                }
+                                                label={`${ds.name} (${datasourceRoleLabel(ds.role)})`}
+                                                sx={{ mr: 1 }}
                                             />
-                                        }
-                                        label={`${ds.name} (${datasourceRoleLabel(ds.role)})`}
-                                        sx={{ mr: 1 }}
-                                    />
-                                );
-                            })}
-                        </FormGroup>
+                                        );
+                                    })}
+                                </FormGroup>
+                            </>
+                        )}
                     </Box>
                 ) : availableDatasources.length === 1 ? (
                     <Typography variant="caption" color="text.secondary">

--- a/src/react/components/ChatButtons.tsx
+++ b/src/react/components/ChatButtons.tsx
@@ -46,6 +46,8 @@ const ChatProvider: React.FC<ChatProviderProps> = ({
         availableDatasources,
         selectedDatasourceNames,
         onDatasourcesChange,
+        datasourceMode,
+        onDatasourceModeChange,
     } = useChat();
 
     const chatDialogProps = {
@@ -67,6 +69,8 @@ const ChatProvider: React.FC<ChatProviderProps> = ({
         availableDatasources,
         selectedDatasourceNames,
         onDatasourcesChange,
+        datasourceMode,
+        onDatasourceModeChange,
     };
 
     const dialog = (

--- a/src/react/components/ChatButtons.tsx
+++ b/src/react/components/ChatButtons.tsx
@@ -43,6 +43,9 @@ const ChatProvider: React.FC<ChatProviderProps> = ({
         availableModels,
         selectedModelId,
         onModelChange,
+        availableDatasources,
+        selectedDatasourceNames,
+        onDatasourcesChange,
     } = useChat();
 
     const chatDialogProps = {
@@ -61,6 +64,9 @@ const ChatProvider: React.FC<ChatProviderProps> = ({
         availableModels,
         selectedModelId,
         onModelChange,
+        availableDatasources,
+        selectedDatasourceNames,
+        onDatasourcesChange,
     };
 
     const dialog = (


### PR DESCRIPTION
This feature allows the user to not have to always rely on ChatMDV choosing the optimum datasource(s) as this can get complicated on projects with lots of tables. 

The user will see 'Auto' as default when they do a query but you can also toggle this off and choose individual/multiple tables for ChatMDV to focus on when querying the datasources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-datasource selection to chat with **auto** and **manual** modes (including multi-selection) and UI display of chosen/resolved datasources.
  * Extended the chat API/CLI to support datasource-scoped analysis and added resolved datasource names to chat responses.
  * Upgraded guidance generation with richer, chart-aware explanations and more targeted next-step tasks.
* **Bug Fixes**
  * Updated local AI connection configuration to use the standard host URL for Ollama.
* **Tests**
  * Expanded unit/integration coverage for datasource resolution, UI payload shaping, guidance sections, and saved-view chart parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->