### PR TITLE
perf: fetch Auth0 admin members once in sync_users_to_db

### DIFF
--- a/python/mdvtools/auth/auth0_provider.py
+++ b/python/mdvtools/auth/auth0_provider.py
@@ -19,17 +19,12 @@ from jose.exceptions import ExpiredSignatureError, JWTError, JWTClaimsError
 from auth0.management import Auth0
 from auth0.authentication import GetToken
 from auth0.exceptions import RateLimitError
-import random
 
 # Add JWKS cache with thread-safe access
 _jwks_cache = {}
 _jwks_cache_expiry = None
 _jwks_cache_lock = threading.Lock()  # Lock to protect cache access
 JWKS_CACHE_DURATION = 3600  # Cache for 1 hour
-
-# Rate limiting and retry parameters
-BASE_DELAY = 1  # Base delay in seconds
-MAX_DELAY = 8  # Maximum delay in seconds
 
 class Auth0Provider(AuthProvider):
     def __init__(self, app, oauth: OAuth, client_id: str, client_secret: str, domain: str):
@@ -419,8 +414,7 @@ class Auth0Provider(AuthProvider):
             max_pagination_rate_limit_retries: int = 5,
             pagination_retry_delay: float = 2.0,
             per_page: int = 50,
-            max_role_fetch_retries: int = 3,
-            user_processing_delay: float = 1.0
+            admin_auth_ids: Optional[set] = None
         ):
             self.auth0 = auth0
             self.all_projects = all_projects
@@ -433,9 +427,9 @@ class Auth0Provider(AuthProvider):
             self.max_pagination_rate_limit_retries = max_pagination_rate_limit_retries
             self.pagination_retry_delay = pagination_retry_delay
             self.per_page = per_page
-            self.max_role_fetch_retries = max_role_fetch_retries
-            self.user_processing_delay = user_processing_delay
-        
+            # auth0 user_ids holding the 'admin' role, fetched once per sync
+            self.admin_auth_ids = admin_auth_ids if admin_auth_ids is not None else set()
+
         def to_dict(self) -> Dict[str, int]:
             """Convert context stats to dictionary."""
             return {
@@ -450,66 +444,79 @@ class Auth0Provider(AuthProvider):
             self.pagination_rate_limit_count = 0
             self.pagination_retry_delay = 2.0
     
-    def _fetch_user_roles_with_retry(
-        self, 
-        auth0_id: str,
+    def _fetch_admin_auth_ids(
+        self,
+        auth0: Auth0,
         context: 'SyncContext'
-    ) -> Optional[Dict[str, Any]]:
+    ) -> set:
         """
-        Fetch user roles from Auth0 with retry logic for rate limiting.
-        
+        Fetch the Auth0 user_ids of every member of the 'admin' role, once.
+
+        Replaces the previous per-user ``users.list_roles()`` call (an N+1 that
+        made one Management-API request per user) with ~2 requests total: one to
+        resolve the 'admin' role id, then paged requests for its members.
+
         Args:
-            auth0_id: Auth0 user ID
-            context: SyncContext object containing auth0 client, page, and stats
-            
+            auth0: Auth0 Management API client
+            context: SyncContext (used for rate-limit retry configuration)
+
         Returns:
-            dict: User roles dictionary, or None if fetch failed after retries
+            set: auth0 user_ids holding the 'admin' role (empty if none / on error).
         """
-        roles = None
-        retry_count = 0
-        success = False
-        max_retries = context.max_role_fetch_retries
-        
-        while retry_count < max_retries and not success:
+        # 1. Resolve the 'admin' role id.
+        try:
+            roles_resp = auth0.roles.list(name_filter='admin')
+            roles_list = roles_resp.get('roles', []) if isinstance(roles_resp, dict) else []
+            admin_role = next((r for r in roles_list if r.get('name') == 'admin'), None)
+        except Exception as e:
+            logging.error(f"Failed to resolve Auth0 'admin' role: {e}")
+            return set()
+
+        if not admin_role:
+            logging.warning("No 'admin' role found in Auth0; no users will be marked admin.")
+            return set()
+
+        # 2. Page through the role's members, collecting user_ids.
+        admin_ids: set = set()
+        page = 0
+        retry_delay = 2.0
+        rate_limit_retries = 0
+        while True:
             try:
-                roles = context.auth0.users.list_roles(auth0_id)
-                success = True
-            except RateLimitError as e:
-                retry_count += 1
-                if retry_count >= max_retries:
-                    # Max retries exceeded
-                    error_info = {
-                        'user_id': auth0_id,
-                        'page': context.page,
-                        'processed': context.processed_users,
-                        'status': getattr(e, 'status_code', None),
-                        'code': getattr(e, 'error_code', None),
-                        'message': getattr(e, 'message', str(e)),
-                        'reset_at': getattr(e, 'reset_at', None),
-                        'remaining': getattr(e, 'remaining', None),
-                        'limit': getattr(e, 'limit', None),
-                    }
-                    error_info = {k: v for k, v in error_info.items() if v is not None}
-                    
+                members = auth0.roles.list_users(admin_role['id'], page=page, per_page=100)
+                rate_limit_retries = 0
+            except RateLimitError:
+                rate_limit_retries += 1
+                if rate_limit_retries > context.max_pagination_rate_limit_retries:
                     logging.error(
-                        f"Rate limit during role fetch for user {auth0_id} after {max_retries} retries: "
-                        f"{error_info}. Skipping user."
+                        f"Too many rate-limit retries listing admin members (page {page}); "
+                        f"proceeding with {len(admin_ids)} collected so far."
                     )
-                    return None
-                else:
-                    # Calculate exponential backoff delay with jitter
-                    delay = min(BASE_DELAY * (2 ** retry_count) + random.uniform(0, 1), MAX_DELAY)
-                    logging.warning(
-                        f"Rate limit during role fetch for user {auth0_id}. "
-                        f"Retrying in {delay:.2f} seconds... (Attempt {retry_count}/{max_retries})"
-                    )
-                    time.sleep(delay)
+                    break
+                logging.warning(
+                    f"Rate limit listing admin members (page {page}). "
+                    f"Retrying in {retry_delay:.1f}s... (attempt {rate_limit_retries})"
+                )
+                time.sleep(retry_delay)
+                retry_delay = min(retry_delay * 2, 60.0)
+                continue
             except Exception as e:
-                # Non-rate-limit error
-                logging.error(f"Error fetching roles for user {auth0_id}: {str(e)}")
-                return None
-        
-        return roles if success else None
+                logging.error(f"Failed to list admin role members (page {page}): {e}")
+                break
+
+            users = members.get('users', []) if isinstance(members, dict) else []
+            for u in users:
+                uid = u.get('user_id')
+                if uid:
+                    admin_ids.add(uid)
+
+            if len(users) < 100:
+                break
+            page += 1
+            time.sleep(1)  # gentle pacing between member pages
+
+        logging.info(f"Fetched {len(admin_ids)} admin member(s) from Auth0.")
+        return admin_ids
     
     def _process_single_user(
         self, 
@@ -545,18 +552,9 @@ class Auth0Provider(AuthProvider):
             auth_id=auth0_id
         )
                 
-        # Add delay between role requests to avoid rate limiting
-        time.sleep(context.user_processing_delay)
-        
-        # Fetch user's roles with retry mechanism
-        roles = self._fetch_user_roles_with_retry(auth0_id, context)
-        if roles is None:
-            # Failed to fetch roles, skip this user
-            return False
-        
-        roles_list = roles.get('roles', [])
-        is_admin = any(role['name'] == 'admin' for role in roles_list)
-        
+        # Admin status comes from the pre-fetched admin role members (no per-user API call)
+        is_admin = auth0_id in context.admin_auth_ids
+
         # Update admin status
         was_admin = db_user.is_admin
         db_user.is_admin = is_admin
@@ -639,7 +637,7 @@ class Auth0Provider(AuthProvider):
         logging.warning(
             f"Rate limit hit ({new_count}/{context.max_pagination_rate_limit_retries}). "
             f"Possible issues: frequent calls, concurrent execution, batch size ({context.per_page}), "
-            f"or insufficient delays (1s pages, {context.user_processing_delay}s roles). Retrying in {context.pagination_retry_delay}s..."
+            f"or insufficient delays (1s between pages). Retrying in {context.pagination_retry_delay}s..."
         )
     
     def _log_sync_statistics(self, initial_user_count: int, initial_admin_count: int) -> None:
@@ -661,22 +659,19 @@ class Auth0Provider(AuthProvider):
             f"{final_admin_count} admin users ({final_admin_count - initial_admin_count:+d})"
         )
         
-    def sync_users_to_db(self, user_processing_delay: float = 1.0) -> None:
+    def sync_users_to_db(self) -> None:
         """
         Syncs users from Auth0 to the application's database using UserService and UserProjectService.
         Implements rate limiting and retry logic for Auth0 API calls.
-        
+
         WARNING: This function makes many Auth0 Management API calls and should be called manually only.
         This function should only be called from manage_project_permissions.py script.
-        
-        Args:
-            user_processing_delay: Delay in seconds between processing each user (default: 1.0)
-        
+
         Design concerns:
         - Auth0 Management API has strict rate limits (typically 2 req/sec for free tier)
-        - This function makes 1 + N*2 API calls where N = number of users (list users + list_roles per user)
-        - If called frequently, will hit rate limits quickly
-        - Consider: caching, background jobs, or incremental sync instead of full sync on-demand
+        - This function makes ~ceil(N/per_page) + ~ceil(A/per_page) API calls, where N = total
+          users and A = admin-role members (admins are fetched once, not once per user)
+        - If called frequently it still adds load; prefer event-driven sync (see issue #515)
         """
         from mdvtools.dbutils.dbmodels import Project
         
@@ -707,10 +702,13 @@ class Auth0Provider(AuthProvider):
             sync_context = self.SyncContext(
                 auth0=auth0,
                 all_projects=all_projects,
-                page=0,
-                user_processing_delay=user_processing_delay
+                page=0
             )
-            
+
+            # Fetch all 'admin' role members once, up front. Replaces the old
+            # per-user list_roles() call (N+1) with ~2 calls total.
+            sync_context.admin_auth_ids = self._fetch_admin_auth_ids(auth0, sync_context)
+
             # Fetch users from Auth0 connection with pagination
             while True:
                 try:

--- a/python/mdvtools/auth/tests/test_auth.py
+++ b/python/mdvtools/auth/tests/test_auth.py
@@ -180,14 +180,9 @@ class TestAuth0ProviderSync:
             {'users': []}  # Empty list to signal end
         ]
         
-        # Mock role fetches - first user is admin, rest are not
-        def mock_list_roles(user_id):
-            if user_id == 'auth0|user0':
-                return {'roles': [{'name': 'admin'}]}
-            else:
-                return {'roles': []}
-        
-        mock_auth0_client.users.list_roles.side_effect = mock_list_roles
+        # Mock admin-role fetch - user0 is the only admin (fetched once, up front)
+        mock_auth0_client.roles.list.return_value = {'roles': [{'id': 'rol_admin', 'name': 'admin'}]}
+        mock_auth0_client.roles.list_users.return_value = {'users': [{'user_id': 'auth0|user0'}]}
         
         # Mock OAuth initialization to avoid real HTTP requests
         with patch('mdvtools.auth.auth0_provider.requests.get') as mock_get:
@@ -213,25 +208,26 @@ class TestAuth0ProviderSync:
         # Verify: 75 users processed
         assert mock_auth0_client.users.list.call_count >= 2
         assert mock_user_service.add_or_update_user.call_count == 75
-        # Admin user should get project assignments
-        # `>= 0` is vacuous and doesn't test anything
-        # assert mock_user_project_service.add_or_update_user_project.call_count >= 0
+        # Admin members were fetched once, up front — not once per user (no N+1)
+        assert mock_auth0_client.roles.list.called
+        mock_auth0_client.users.list_roles.assert_not_called()
     
-    def test_sync_users_to_db_rate_limit_role_fetch(
+    def test_sync_users_to_db_rate_limit_admin_fetch(
         self, auth0_app, mock_auth0_client, mock_user_service,
         mock_user_project_service, mock_db, mock_user_model,
         mock_project_model, mock_get_token, mock_auth0_class
     ):
-        """Test rate limit on role fetch with successful retry."""
+        """Test rate limit on the admin-members fetch with successful retry."""
         # Setup: single user
         mock_auth0_client.users.list.side_effect = [
             {'users': [{'user_id': 'auth0|user1', 'email': 'user1@test.com'}]},
             {'users': []}
         ]
-        
-        # Mock role fetch: rate limit on first call, succeed on retry
+
+        # Admin role resolves fine; listing its members rate-limits once then succeeds
+        mock_auth0_client.roles.list.return_value = {'roles': [{'id': 'rol_admin', 'name': 'admin'}]}
         call_count = [0]
-        def mock_list_roles(user_id):
+        def mock_list_users(role_id, page, per_page):
             call_count[0] += 1
             if call_count[0] == 1:
                 raise RateLimitError(
@@ -239,9 +235,9 @@ class TestAuth0ProviderSync:
                     message="Rate limit exceeded",
                     reset_at=1234567890
                 )
-            return {'roles': []}
-        
-        mock_auth0_client.users.list_roles.side_effect = mock_list_roles
+            return {'users': []}
+
+        mock_auth0_client.roles.list_users.side_effect = mock_list_users
         
         # Mock OAuth initialization
         with patch('mdvtools.auth.auth0_provider.requests.get') as mock_get:
@@ -263,8 +259,8 @@ class TestAuth0ProviderSync:
                     with patch('mdvtools.auth.auth0_provider.time.sleep'):  # Speed up test
                         provider.sync_users_to_db()
         
-        # Verify: user was processed after retry
-        assert mock_auth0_client.users.list_roles.call_count == 2  # Initial + retry
+        # Verify: admin-member fetch was retried after the rate limit
+        assert mock_auth0_client.roles.list_users.call_count == 2  # Initial + retry
         assert mock_user_service.add_or_update_user.called
     
     def test_sync_users_to_db_rate_limit_pagination(
@@ -353,9 +349,6 @@ class TestAuth0ProviderSync:
             {'users': [{'user_id': 'auth0|user1', 'email': 'user1@test.com'}]},
             {'users': []}
         ]
-        
-        # Mock roles
-        mock_auth0_client.users.list_roles.return_value = {'roles': []}
         
         # Mock database commit to raise error
         mock_db.session.commit.side_effect = Exception("Database error")


### PR DESCRIPTION
`sync_users_to_db` determined admin status by calling `users.list_roles()` once per user — an N+1 against the Auth0 Management API (~1 call per user, plus a 1-second sleep each). On a tenant with ~300 users that's ~300 calls and several minutes of sleeping, with real rate-limit risk.

This fetches the `admin` role's members **once**, up front, and checks membership with a local set lookup. For ~300 users / 5 admins that's ~2 calls instead of ~300.

## Changes

- Add `_fetch_admin_auth_ids()`: resolves the `admin` role id, pages through its
  members (with rate-limit retry), returns a set of Auth0 user ids.
- `_process_single_user()`: `is_admin = auth0_id in context.admin_auth_ids`
- `sync_users_to_db()`: fetches admin members once before the user loop.
- Remove the now-dead `_fetch_user_roles_with_retry()`, `import random`,
  `BASE_DELAY`/`MAX_DELAY`, and the unused `max_role_fetch_retries` /
  `user_processing_delay` params.
- Update the two sync tests that asserted per-user role fetching.

Closes #516