### PR TITLE
Adds date / time data type

### DIFF
--- a/docs/TABLE_CHART_REACT.md
+++ b/docs/TABLE_CHART_REACT.md
@@ -11,6 +11,10 @@ The React Table Chart provides:
 - Find & Replace functionality
 - Cross-chart highlighting/selection
 
+### Date columns (`is_date`)
+
+Numeric columns with `is_date: true` store **days since Unix epoch** as `double`. Table cells, Find, Replace, and cell edit use ISO `YYYY-MM-DD` via `getValue` / date-aware string helpers. Sorting uses the raw day numbers (chronological), not lexicographic string order. Row filtering comes from DataStore filters (e.g. Selection Dialog range filters on the same column).
+
 ## File Structure
 
 | File | Purpose |

--- a/docs/extradocs/datasource.md
+++ b/docs/extradocs/datasource.md
@@ -44,7 +44,10 @@ integer/double columns. In the former the colors array is mapped to the values a
 * **editable** - specifies a column can be edited.
 
 * **is_url** - the column contains url links (unique and text columns)
-* **is_url** - the column contains url links (unique and text columns)
+
+* **is_date** - when `true` on an `integer`/`double`/`int32` column, values are calendar dates stored as **days since Unix epoch (UTC)**. Charts use the numeric values for continuous spacing and filters. Display formatting as `YYYY-MM-DD` is applied via `getValue`, continuous axis ticks, color-legend ticks, and Selection Dialog range inputs. Timezone-aware timestamps are converted to UTC at ingest (which can shift the calendar day); values with a time-of-day may be stored as fractional days (display rounds to the nearest day).
+
+* **date_unit** - for `is_date` columns; currently always `"days"`.
 
 * **minMax** - for integer and double columns, the minimum/maximum values in an array of length 2
 

--- a/docs/jsdocs/extradocs/datasource.md
+++ b/docs/jsdocs/extradocs/datasource.md
@@ -44,7 +44,10 @@ integer/double columns. In the former the colors array is mapped to the values a
 * **editable** - specifies a column can be edited.
 
 * **is_url** - the column contains url links (unique and text columns)
-* **is_url** - the column contains url links (unique and text columns)
+
+* **is_date** - when `true` on an `integer`/`double`/`int32` column, values are calendar dates stored as **days since Unix epoch (UTC)**. Charts use the numeric values for continuous spacing and filters. Display formatting as `YYYY-MM-DD` is applied via `getValue`, continuous axis ticks, color-legend ticks, and Selection Dialog range inputs. Timezone-aware timestamps are converted to UTC at ingest (which can shift the calendar day); values with a time-of-day may be stored as fractional days (display rounds to the nearest day).
+
+* **date_unit** - for `is_date` columns; currently always `"days"`.
 
 * **minMax** - for integer and double columns, the minimum/maximum values in an array of length 2
 

--- a/python/mdvtools/mdvproject.py
+++ b/python/mdvtools/mdvproject.py
@@ -128,6 +128,8 @@ def convert_pandas_datetime_columns(
     out = dataframe
     for col_name in list(dataframe.columns):
         series = dataframe[col_name]
+        if not isinstance(series, pandas.Series):
+            continue
         converted: Optional[pandas.Series] = None
         if is_datetime64_any_dtype(series):
             converted = _pandas_series_to_day_doubles(series)
@@ -144,8 +146,12 @@ def convert_pandas_datetime_columns(
     return out, date_fields
 
 
-def apply_date_column_metadata(columns: list[dict], date_fields: set[str]) -> list[dict]:
+def apply_date_column_metadata(
+    columns: list[dict] | None, date_fields: set[str]
+) -> list[dict] | None:
     """Mark converted date fields as double + is_date metadata."""
+    if not columns:
+        return columns
     for col in columns:
         field = col.get("field") or col.get("name")
         if field in date_fields:

--- a/python/mdvtools/mdvproject.py
+++ b/python/mdvtools/mdvproject.py
@@ -21,7 +21,7 @@ import scipy.sparse
 from werkzeug.utils import secure_filename
 from shutil import copytree, ignore_patterns, copyfile
 from typing import Optional, NewType, List, Union, Any, cast
-from pandas.api.types import is_bool_dtype
+from pandas.api.types import is_bool_dtype, is_datetime64_any_dtype
 import polars as pl
 # from mdvtools.charts.view import View 
 import time
@@ -92,6 +92,76 @@ numpy_dtypes = {
     "int32": numpy.int32,
     # unique created in fly (depends on string length)
 }
+
+_UNIX_EPOCH_UTC = pandas.Timestamp("1970-01-01", tz="UTC")
+_SECONDS_PER_DAY = 86400.0
+
+
+def _pandas_series_to_day_doubles(series: pandas.Series) -> pandas.Series:
+    """Convert a datetime-like pandas Series to float days since Unix epoch (UTC)."""
+    ts = pandas.to_datetime(series, utc=True, errors="coerce")
+    days = (ts - _UNIX_EPOCH_UTC).dt.total_seconds() / _SECONDS_PER_DAY
+    return days.astype("float64")
+
+
+def _object_column_looks_like_dates(series: pandas.Series, sample_size: int = 50) -> bool:
+    """Heuristic: uniformly parseable ISO-like strings in a sample of non-null values."""
+    sample = series.dropna()
+    if sample.empty:
+        return False
+    sample = sample.head(sample_size)
+    parsed = pandas.to_datetime(sample, utc=True, errors="coerce", format="mixed")
+    return bool(parsed.notna().mean() >= 0.8)
+
+
+def convert_pandas_datetime_columns(
+    dataframe: pandas.DataFrame,
+    *,
+    parse_object_dates: bool = True,
+) -> tuple[pandas.DataFrame, set[str]]:
+    """
+    Convert datetime columns (and optionally date-like object columns) to float64
+    days since Unix epoch. Returns the (possibly copied) dataframe and the set of
+    field names that were converted.
+    """
+    date_fields: set[str] = set()
+    out = dataframe
+    for col_name in list(dataframe.columns):
+        series = dataframe[col_name]
+        converted: Optional[pandas.Series] = None
+        if is_datetime64_any_dtype(series):
+            converted = _pandas_series_to_day_doubles(series)
+        elif parse_object_dates and (
+            series.dtype == object or str(series.dtype) == "string"
+        ):
+            if _object_column_looks_like_dates(series):
+                converted = _pandas_series_to_day_doubles(series)
+        if converted is not None:
+            if out is dataframe:
+                out = dataframe.copy()
+            out[col_name] = converted
+            date_fields.add(col_name)
+    return out, date_fields
+
+
+def apply_date_column_metadata(columns: list[dict], date_fields: set[str]) -> list[dict]:
+    """Mark converted date fields as double + is_date metadata."""
+    for col in columns:
+        field = col.get("field") or col.get("name")
+        if field in date_fields:
+            col["datatype"] = "double"
+            col["is_date"] = True
+            col["date_unit"] = "days"
+    return columns
+
+
+def map_polars_datetime_to_day_doubles(series: "pl.Series") -> "pl.Series":
+    """Convert Polars Date/Datetime to float days since Unix epoch (UTC)."""
+    # Cast to datetime[ms, UTC] then to epoch ms, then divide.
+    as_dt = series.cast(pl.Datetime("ms", "UTC"), strict=False)
+    ms = as_dt.dt.epoch(time_unit="ms")
+    days = ms / (86400.0 * 1000.0)
+    return days.cast(pl.Float64)
 
 
 class MDVProject:
@@ -1337,9 +1407,12 @@ class MDVProject:
         try:
             if isinstance(dataframe, str):
                 dataframe = pandas.read_csv(dataframe, sep=separator)
+
+            dataframe, date_fields = convert_pandas_datetime_columns(dataframe)
             
             # Get columns to add
             columns = get_column_info(columns, dataframe, supplied_columns_only)
+            columns = apply_date_column_metadata(columns, date_fields)
             
             # Check if the datasource already exists
             try:
@@ -1485,7 +1558,9 @@ class MDVProject:
 
             # Get columns to add using polars-compatible function.
             # Pass num_rows to avoid recalculating it for LazyFrames.
+            date_fields = get_polars_date_fields(dataframe)
             columns = get_column_info_polars(columns, dataframe, supplied_columns_only, num_rows)
+            columns = apply_date_column_metadata(columns, date_fields)
 
             has_existing_datasources = len(self.datasources) > 0
             
@@ -1543,6 +1618,19 @@ class MDVProject:
                         polars_series = dataframe.select(col["field"]).collect().get_columns()[0]
                     else:
                         polars_series = dataframe[col["field"]]
+
+                    # Only convert Date/Datetime dtypes. Already-numeric day doubles
+                    # (e.g. re-import with is_date metadata) must not be remapped —
+                    # casting floats as datetime epoch-ms would destroy values.
+                    if _is_polars_datetime_dtype(polars_series.dtype):
+                        polars_series = map_polars_datetime_to_day_doubles(polars_series)
+                        col["datatype"] = "double"
+                        col["is_date"] = True
+                        col["date_unit"] = "days"
+                    elif col.get("is_date"):
+                        col["datatype"] = "double"
+                        col["is_date"] = True
+                        col["date_unit"] = "days"
 
                     add_column_to_group_from_polars(col, polars_series, gr, num_rows, self.skip_column_clean)
                 except Exception as e:
@@ -2781,9 +2869,24 @@ def map_polars_to_mdv_type(polars_dtype):
         return "text"
     elif polars_dtype in [pl.Utf8, pl.String]:
         return "text"  # Default to text, might change to unique based on cardinality
+    elif _is_polars_datetime_dtype(polars_dtype):
+        return "double"
     else:
         # Default to text for any other types
         return "text"
+
+
+def _is_polars_datetime_dtype(polars_dtype) -> bool:
+    dtype_name = str(polars_dtype)
+    return dtype_name == "Date" or dtype_name.startswith("Datetime")
+
+
+def get_polars_date_fields(dataframe: "pl.DataFrame | pl.LazyFrame") -> set[str]:
+    return {
+        name
+        for name, dtype in dataframe.collect_schema().items()
+        if _is_polars_datetime_dtype(dtype)
+    }
 
 def add_column_to_group_from_polars(col_info, polars_series, h5_group, num_rows, skip_column_clean):
     """Add a column to HDF5 group using Polars Series data"""

--- a/python/mdvtools/tests/test_date_columns.py
+++ b/python/mdvtools/tests/test_date_columns.py
@@ -1,0 +1,106 @@
+"""Tests for datetime → days-since-epoch date column ingest."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import polars as pl
+import pytest
+
+from mdvtools.mdvproject import (
+    MDVProject,
+    apply_date_column_metadata,
+    convert_pandas_datetime_columns,
+    map_polars_datetime_to_day_doubles,
+)
+
+
+def test_convert_pandas_datetime_columns_sets_day_doubles():
+    df = pd.DataFrame(
+        {
+            "when": pd.to_datetime(
+                ["1970-01-01", "2020-01-01", None],
+                utc=True,
+            ),
+            "label": ["a", "b", "c"],
+        }
+    )
+    out, date_fields = convert_pandas_datetime_columns(df)
+    assert date_fields == {"when"}
+    assert out["when"].dtype == np.float64
+    assert out["when"].iloc[0] == pytest.approx(0.0)
+    assert out["when"].iloc[1] == pytest.approx(18262.0)
+    assert np.isnan(out["when"].iloc[2])
+    assert list(out["label"]) == ["a", "b", "c"]
+
+
+def test_convert_pandas_object_iso_dates():
+    df = pd.DataFrame({"d": ["2024-06-01", "2024-06-15", "2024-07-01"]})
+    out, date_fields = convert_pandas_datetime_columns(df)
+    assert date_fields == {"d"}
+    assert out["d"].iloc[0] < out["d"].iloc[1] < out["d"].iloc[2]
+    span = out["d"].iloc[2] - out["d"].iloc[0]
+    assert span == pytest.approx(30.0)
+
+
+def test_apply_date_column_metadata():
+    cols = [
+        {"field": "when", "datatype": "double"},
+        {"field": "x", "datatype": "double"},
+    ]
+    apply_date_column_metadata(cols, {"when"})
+    assert cols[0]["is_date"] is True
+    assert cols[0]["date_unit"] == "days"
+    assert "is_date" not in cols[1]
+
+
+def test_add_datasource_datetime_column(tmp_path):
+    project = MDVProject(str(tmp_path), delete_existing=True)
+    df = pd.DataFrame(
+        {
+            "when": pd.to_datetime(["2020-01-01", "2020-01-11", "2020-02-01"]),
+            "value": [1.0, 2.0, 3.0],
+        }
+    )
+    project.add_datasource("events", df, add_to_view=None)
+    meta = project.get_datasource_metadata("events")
+    when_col = next(c for c in meta["columns"] if c["field"] == "when")
+    assert when_col["datatype"] == "double"
+    assert when_col["is_date"] is True
+    assert when_col["date_unit"] == "days"
+    assert when_col["minMax"][1] - when_col["minMax"][0] == pytest.approx(31.0)
+
+
+def test_polars_datetime_to_day_doubles():
+    s = pl.Series("d", ["1970-01-01", "2020-01-01"]).str.to_date()
+    days = map_polars_datetime_to_day_doubles(s)
+    assert days[0] == pytest.approx(0.0)
+    assert days[1] == pytest.approx(18262.0)
+
+
+def test_polars_is_date_on_already_numeric_preserves_day_doubles(tmp_path):
+    """is_date metadata on Float64 day doubles must not re-run datetime conversion."""
+    project = MDVProject(str(tmp_path), delete_existing=True)
+    df = pl.DataFrame(
+        {
+            "when": [0.0, 18262.0, 18300.0],
+            "value": [1.0, 2.0, 3.0],
+        }
+    )
+    columns = [
+        {
+            "field": "when",
+            "name": "when",
+            "datatype": "double",
+            "is_date": True,
+            "date_unit": "days",
+        },
+        {"field": "value", "name": "value", "datatype": "double"},
+    ]
+    project.add_datasource_polars("events", df, columns=columns, add_to_view=None)
+    meta = project.get_datasource_metadata("events")
+    when_col = next(c for c in meta["columns"] if c["field"] == "when")
+    assert when_col["is_date"] is True
+    assert when_col["date_unit"] == "days"
+    assert when_col["minMax"][0] == pytest.approx(0.0)
+    assert when_col["minMax"][1] == pytest.approx(18300.0)

--- a/src/charts/BaseChart.ts
+++ b/src/charts/BaseChart.ts
@@ -16,6 +16,7 @@ import type { FieldSpec, FieldSpecs } from "@/lib/columnTypeHelpers";
 import getParamsGuiSpec from "./dialogs/utils/ParamsSettingGui";
 import tippy, {type Instance as TippyInstance} from "tippy.js";
 import 'tippy.js/dist/tippy.css';
+import { isDateColumn } from "@/lib/dateFormat";
 import { buildColorLegendSpec } from "@/react/legend/color_legend/buildColorLegendSpec";
 import type { ColorLegendSpec } from "@/react/legend/color_legend/types";
 import ColorLegend from "@/react/components/legend/ColorLegend";
@@ -569,9 +570,13 @@ class BaseChart<T extends BaseConfig> {
         if (!colorBy || typeof colorBy !== "string") {
             return null;
         }
+        const colorCol = this.dataStore.columnIndex[colorBy];
         const conf = {
             overideValues: {
-                colorLogScale: this.config.log_color_scale,
+                // Log color scales are not meaningful for calendar day numbers.
+                colorLogScale: isDateColumn(colorCol)
+                    ? false
+                    : this.config.log_color_scale,
             },
         };
         this._addTrimmedColor(colorBy, conf);

--- a/src/charts/SVGChart.js
+++ b/src/charts/SVGChart.js
@@ -5,6 +5,7 @@ import "d3-transition";
 import { easeLinear } from "d3-ease";
 import { axisLeft, axisBottom } from "d3-axis";
 import { cluster } from "d3-hierarchy";
+import { dateTickFormat } from "@/lib/dateFormat";
 
 class SVGChart extends BaseChart {
     constructor(dataStore, div, config, axisTypes = {}) {
@@ -101,6 +102,57 @@ class SVGChart extends BaseChart {
         };
     }
 
+    /**
+     * For continuous (linear) axes, prefer chart-owned `this.x` / `this.y` when present
+     * (WGL scatter), else `config.param[0|1]`.
+     * Returns the column if it is an `is_date` numeric column.
+     */
+    _getDateColumnForAxis(axis) {
+        let field;
+        if (axis === "x") {
+            field = this.x ?? this.config.param?.[0];
+        } else if (axis === "y") {
+            field = this.y ?? this.config.param?.[1];
+        } else {
+            return null;
+        }
+        if (!field || typeof field !== "string") {
+            return null;
+        }
+        const col =
+            this.dataStore.columnIndex[field] ??
+            this.dataStore.config?.columns?.find((c) => c.field === field);
+        if (!col) {
+            return null;
+        }
+        // Prefer explicit flag; also accept date_unit alone in case is_date was dropped.
+        if (col.is_date || col.date_unit === "days") {
+            return col;
+        }
+        return null;
+    }
+
+    /**
+     * Apply date tick formatting to a d3 axis generator when the bound column is a date.
+     * @param {"x"|"y"} axis
+     * @param {import("d3-axis").Axis<import("d3-scale").NumberValue>} axisCall
+     */
+    _applyDateTickFormat(axis, axisCall) {
+        if (!axisCall) {
+            return;
+        }
+        if (this._getDateColumnForAxis(axis)) {
+            axisCall.tickFormat((d) => dateTickFormat(Number(d)));
+        } else {
+            axisCall.tickFormat(null);
+        }
+    }
+
+    /** True when the scale is continuous (not band). */
+    _isLinearScale(scale) {
+        return Boolean(scale) && typeof scale.bandwidth !== "function";
+    }
+
     _getContentDimensions() {
         //this can end up with -ve width/height e.g. in the process of popping out,
         //or when gridstack does something weird on window resize.
@@ -164,6 +216,9 @@ class SVGChart extends BaseChart {
             if (this.x_scale) {
                 //PJT- TODO fix over-crowded ticks.
                 this.x_scale.range([0, dim.width]);
+                if (this._isLinearScale(this.x_scale) && this.x_axis_call) {
+                    this._applyDateTickFormat("x", this.x_axis_call);
+                }
                 this.x_axis_svg
                     .selectAll(".tick text")
                     .attr("font-family", "Helvetica");
@@ -206,6 +261,8 @@ class SVGChart extends BaseChart {
                     this.y_axis_call.tickFormat((d, i) => {
                         return i % ii === 0 ? d : "";
                     });
+                } else if (this._isLinearScale(this.y_scale)) {
+                    this._applyDateTickFormat("y", this.y_axis_call);
                 } else {
                     this.y_axis_call.tickFormat(null);
                 }

--- a/src/charts/WGLScatterPlot.js
+++ b/src/charts/WGLScatterPlot.js
@@ -510,24 +510,6 @@ class WGLScatterPlot extends WGLChart {
         this.y_scale.domain([-range.y_range[0], -range.y_range[1]]);
     }
 
-    updateAxis() {
-        super.updateAxis();
-        // Classic WGL scatters redraw axes often on pan/zoom; re-assert date tick
-        // labels so d3 does not fall back to numeric thousands separators.
-        if (this._isLinearScale(this.x_scale) && this.x_axis_call) {
-            this._applyDateTickFormat("x", this.x_axis_call);
-            this.x_axis_svg.call(this.x_axis_call);
-        }
-        if (
-            this._isLinearScale(this.y_scale) &&
-            this.y_axis_call &&
-            this._getDateColumnForAxis("y")
-        ) {
-            this._applyDateTickFormat("y", this.y_axis_call);
-            this.y_axis_svg.call(this.y_axis_call);
-        }
-    }
-
     _calculateRadius() {
         // const width = this.width?this.width:1;
         let max_x =

--- a/src/charts/WGLScatterPlot.js
+++ b/src/charts/WGLScatterPlot.js
@@ -267,26 +267,7 @@ class WGLScatterPlot extends WGLChart {
 
         this.x = this.config.param[0];
         this.y = this.config.param[1];
-        // Date tick labels are longer than day numbers — give axes a bit more room.
-        // Log scales are not meaningful for calendar days.
-        const xCol = this.dataStore.columnIndex[this.x];
-        const yCol = this.dataStore.columnIndex[this.y];
-        const xIsDate = xCol?.is_date || xCol?.date_unit === "days";
-        const yIsDate = yCol?.is_date || yCol?.date_unit === "days";
-        if (xIsDate && this.config.axis) {
-            this.config.axis.x_log_scale = false;
-            if (this.config.axis.x && (!this.config.axis.x.size || this.config.axis.x.size < 40)) {
-                this.config.axis.x.size = 40;
-                this.setAxisSize("x", 40);
-            }
-        }
-        if (yIsDate && this.config.axis) {
-            this.config.axis.y_log_scale = false;
-            if (this.config.axis.y && (!this.config.axis.y.size || this.config.axis.y.size < 45)) {
-                this.config.axis.y.size = 45;
-                this.setAxisSize("y", 45);
-            }
-        }
+        this._applyDateAxisDefaults();
         this.dim = this.getDimension();
        
         void this.setBackgroundFilter();
@@ -356,6 +337,7 @@ class WGLScatterPlot extends WGLChart {
 
         this.x = this.config.param[0];
         this.y = this.config.param[1];
+        this._applyDateAxisDefaults();
         this.dim = this.getDimension();
         this.minMaxX = this.dataStore.getMinMaxForColumn(this.x);
         this.minMaxY = this.dataStore.getMinMaxForColumn(this.y);
@@ -375,6 +357,32 @@ class WGLScatterPlot extends WGLChart {
         this.onDataFiltered();
         this.updateAxis();
         super.drawChart();
+    }
+
+    /**
+     * Date tick labels are longer than day numbers — give axes a bit more room.
+     * Log scales are not meaningful for calendar days.
+     * Re-applied when Settings change x/y columns (via drawChart).
+     */
+    _applyDateAxisDefaults() {
+        const xCol = this.dataStore.columnIndex[this.x];
+        const yCol = this.dataStore.columnIndex[this.y];
+        const xIsDate = xCol?.is_date || xCol?.date_unit === "days";
+        const yIsDate = yCol?.is_date || yCol?.date_unit === "days";
+        if (xIsDate && this.config.axis) {
+            this.config.axis.x_log_scale = false;
+            if (this.config.axis.x && (!this.config.axis.x.size || this.config.axis.x.size < 40)) {
+                this.config.axis.x.size = 40;
+                this.setAxisSize("x", 40);
+            }
+        }
+        if (yIsDate && this.config.axis) {
+            this.config.axis.y_log_scale = false;
+            if (this.config.axis.y && (!this.config.axis.y.size || this.config.axis.y.size < 45)) {
+                this.config.axis.y.size = 45;
+                this.setAxisSize("y", 45);
+            }
+        }
     }
 
     async setBackgroundFilter() {

--- a/src/charts/WGLScatterPlot.js
+++ b/src/charts/WGLScatterPlot.js
@@ -363,25 +363,59 @@ class WGLScatterPlot extends WGLChart {
      * Date tick labels are longer than day numbers — give axes a bit more room.
      * Log scales are not meaningful for calendar days.
      * Re-applied when Settings change x/y columns (via drawChart).
+     * Pre-date log-scale and size are cached per axis and restored when that
+     * column becomes numeric again.
      */
     _applyDateAxisDefaults() {
+        if (!this.config.axis) return;
         const xCol = this.dataStore.columnIndex[this.x];
         const yCol = this.dataStore.columnIndex[this.y];
         const xIsDate = xCol?.is_date || xCol?.date_unit === "days";
         const yIsDate = yCol?.is_date || yCol?.date_unit === "days";
-        if (xIsDate && this.config.axis) {
+        if (!this._dateAxisCache) this._dateAxisCache = {};
+
+        if (xIsDate) {
+            if (!this._dateAxisCache.x) {
+                this._dateAxisCache.x = {
+                    log_scale: this.config.axis.x_log_scale,
+                    size: this.config.axis.x?.size,
+                };
+            }
             this.config.axis.x_log_scale = false;
             if (this.config.axis.x && (!this.config.axis.x.size || this.config.axis.x.size < 40)) {
                 this.config.axis.x.size = 40;
                 this.setAxisSize("x", 40);
             }
+        } else if (this._dateAxisCache.x) {
+            const cached = this._dateAxisCache.x;
+            this.config.axis.x_log_scale = cached.log_scale;
+            if (cached.size != null && this.config.axis.x) {
+                this.config.axis.x.size = cached.size;
+                this.setAxisSize("x", cached.size);
+            }
+            this._dateAxisCache.x = null;
         }
-        if (yIsDate && this.config.axis) {
+
+        if (yIsDate) {
+            if (!this._dateAxisCache.y) {
+                this._dateAxisCache.y = {
+                    log_scale: this.config.axis.y_log_scale,
+                    size: this.config.axis.y?.size,
+                };
+            }
             this.config.axis.y_log_scale = false;
             if (this.config.axis.y && (!this.config.axis.y.size || this.config.axis.y.size < 45)) {
                 this.config.axis.y.size = 45;
                 this.setAxisSize("y", 45);
             }
+        } else if (this._dateAxisCache.y) {
+            const cached = this._dateAxisCache.y;
+            this.config.axis.y_log_scale = cached.log_scale;
+            if (cached.size != null && this.config.axis.y) {
+                this.config.axis.y.size = cached.size;
+                this.setAxisSize("y", cached.size);
+            }
+            this._dateAxisCache.y = null;
         }
     }
 

--- a/src/charts/WGLScatterPlot.js
+++ b/src/charts/WGLScatterPlot.js
@@ -267,6 +267,26 @@ class WGLScatterPlot extends WGLChart {
 
         this.x = this.config.param[0];
         this.y = this.config.param[1];
+        // Date tick labels are longer than day numbers — give axes a bit more room.
+        // Log scales are not meaningful for calendar days.
+        const xCol = this.dataStore.columnIndex[this.x];
+        const yCol = this.dataStore.columnIndex[this.y];
+        const xIsDate = xCol?.is_date || xCol?.date_unit === "days";
+        const yIsDate = yCol?.is_date || yCol?.date_unit === "days";
+        if (xIsDate && this.config.axis) {
+            this.config.axis.x_log_scale = false;
+            if (this.config.axis.x && (!this.config.axis.x.size || this.config.axis.x.size < 40)) {
+                this.config.axis.x.size = 40;
+                this.setAxisSize("x", 40);
+            }
+        }
+        if (yIsDate && this.config.axis) {
+            this.config.axis.y_log_scale = false;
+            if (this.config.axis.y && (!this.config.axis.y.size || this.config.axis.y.size < 45)) {
+                this.config.axis.y.size = 45;
+                this.setAxisSize("y", 45);
+            }
+        }
         this.dim = this.getDimension();
        
         void this.setBackgroundFilter();
@@ -480,6 +500,24 @@ class WGLScatterPlot extends WGLChart {
     _updateScale(range) {
         this.x_scale.domain([range.x_range[0], range.x_range[1]]);
         this.y_scale.domain([-range.y_range[0], -range.y_range[1]]);
+    }
+
+    updateAxis() {
+        super.updateAxis();
+        // Classic WGL scatters redraw axes often on pan/zoom; re-assert date tick
+        // labels so d3 does not fall back to numeric thousands separators.
+        if (this._isLinearScale(this.x_scale) && this.x_axis_call) {
+            this._applyDateTickFormat("x", this.x_axis_call);
+            this.x_axis_svg.call(this.x_axis_call);
+        }
+        if (
+            this._isLinearScale(this.y_scale) &&
+            this.y_axis_call &&
+            this._getDateColumnForAxis("y")
+        ) {
+            this._applyDateTickFormat("y", this.y_axis_call);
+            this.y_axis_svg.call(this.y_axis_call);
+        }
     }
 
     _calculateRadius() {

--- a/src/charts/charts.d.ts
+++ b/src/charts/charts.d.ts
@@ -109,14 +109,25 @@ export type DataColumn<T extends DataType> = {
     /** the column's values will be displayed as links (text and unique columns only).
      * not sure if this is strictly boolean or can be undefined */
     is_url?: T extends CategoricalDataType ? boolean : never;
+    /**
+     * When true on a numeric column, values are days since Unix epoch (UTC) and
+     * display/filter/axis formatting should treat them as calendar dates.
+     */
+    is_date?: T extends NumberDataType ? boolean : never;
+    /** Storage unit for `is_date` columns; currently always `"days"`. */
+    date_unit?: T extends NumberDataType ? "days" : never;
     /** the min max values in the column's values (integer/double only) */
     minMax: T extends NumberDataType ? [number, number] : never;
     /** an object describing the 0.05,0.01 and 0,001 qunatile ranges (integer/double only) */
     quantiles: T extends NumberDataType ? Quantiles : never;
     /** if `true` then the store will keep a record that this column has been added and is not permanently stored in the backend */
     dirty?: boolean;
-    /** return the value corresponding to a given row index `i`. If the data is categorical, this will be the appropriate value from `values` */
-    getValue: (i: number) => T extends CategoricalDataType ? string : number;
+    /**
+     * Return the value for row index `i`.
+     * Categorical columns return category strings; `is_date` numerics return ISO `YYYY-MM-DD`;
+     * other numerics return numbers (or `"missing"` for NaN).
+     */
+    getValue: (i: number) => string | number;
     stringLength: T extends "unique" ? number : never;
     delimiter?: T extends "multitext" ? string : never;
     subgroup?: SubgroupName; //not attempting to descriminate the other sg properties being related to this for now

--- a/src/charts/schemas/DataSourceSchema.ts
+++ b/src/charts/schemas/DataSourceSchema.ts
@@ -14,6 +14,8 @@ export const DataSourceColumnSchema = z.object({
     editable: z.boolean().optional().describe("Whether users can edit values in this column"),
     deleted: z.boolean().optional().describe("Whether the column has been soft-deleted and removed from user-facing column lists"),
     is_url: z.boolean().optional().describe("Whether this column contains URL links (for unique and text columns)"),
+    is_date: z.boolean().optional().describe("Whether this numeric column stores calendar dates as days since Unix epoch"),
+    date_unit: z.literal("days").optional().describe("Unit for is_date columns; always days since Unix epoch (UTC)"),
     minMax: z.tuple([z.number(), z.number()]).optional().describe("For numeric columns: [minimum, maximum] values for optimization"),
     quantiles: z.object({
         "0.05": z.tuple([z.number(), z.number()]).describe("5th and 95th percentiles"),

--- a/src/datastore/DataStore.js
+++ b/src/datastore/DataStore.js
@@ -13,6 +13,7 @@ import { quantileSorted } from "d3-array";
 import { makeObservable, observable, action } from "mobx";
 import { isColumnNumeric, isColumnText } from "../utilities/Utilities";
 import { isDatatypeNumeric } from "@/lib/utils";
+import { formatDateDays, isDateColumn } from "@/lib/dateFormat";
 import {
     getMultitextCapacity,
     getMultitextDelimiter,
@@ -532,6 +533,8 @@ class DataStore {
                 ) {
                     if (Number.isNaN(v)) {
                         v = "missing";
+                    } else if (isDateColumn(col)) {
+                        v = formatDateDays(v);
                     }
                 }
                 //multitext displayed as comma delimited values

--- a/src/lib/dateFormat.ts
+++ b/src/lib/dateFormat.ts
@@ -1,0 +1,62 @@
+import type { DataColumn, DataType, NumberDataType } from "@/charts/charts";
+
+const MS_PER_DAY = 86_400_000;
+
+/** True when a column stores calendar dates as days since Unix epoch. */
+export function isDateColumn(
+    col: Pick<DataColumn<DataType>, "is_date" | "date_unit" | "datatype"> | null | undefined,
+): boolean {
+    return col?.is_date === true || col?.date_unit === "days";
+}
+
+/**
+ * Format a day-number (days since Unix epoch, UTC) as `YYYY-MM-DD`.
+ * Returns `"missing"` for non-finite values.
+ */
+export function formatDateDays(dayNumber: number): string {
+    if (!Number.isFinite(dayNumber)) {
+        return "missing";
+    }
+    const date = new Date(Math.round(dayNumber) * MS_PER_DAY);
+    const y = date.getUTCFullYear();
+    const m = String(date.getUTCMonth() + 1).padStart(2, "0");
+    const d = String(date.getUTCDate()).padStart(2, "0");
+    return `${y}-${m}-${d}`;
+}
+
+/**
+ * Parse a strict ISO calendar date (`YYYY-MM-DD`) to days since Unix epoch
+ * (UTC midnight). Returns `null` if invalid. Bare numbers and loose Date.parse
+ * forms are rejected so values like `"18262"` are not treated as years.
+ */
+export function parseDateDays(iso: string): number | null {
+    const trimmed = iso.trim();
+    if (!trimmed) {
+        return null;
+    }
+    const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(trimmed);
+    if (!m) {
+        return null;
+    }
+    const year = Number(m[1]);
+    const month = Number(m[2]);
+    const day = Number(m[3]);
+    const ms = Date.UTC(year, month - 1, day);
+    // Reject impossible calendar dates (e.g. 2020-02-31 → Mar 2).
+    const date = new Date(ms);
+    if (
+        date.getUTCFullYear() !== year ||
+        date.getUTCMonth() + 1 !== month ||
+        date.getUTCDate() !== day
+    ) {
+        return null;
+    }
+    return Math.round(ms / MS_PER_DAY);
+}
+
+/** Tick formatter for continuous axes bound to an `is_date` column. */
+export function dateTickFormat(value: number): string {
+    return formatDateDays(value);
+}
+
+export type DateAwareNumberColumn = DataColumn<NumberDataType>;

--- a/src/react/components/AxisComponent.tsx
+++ b/src/react/components/AxisComponent.tsx
@@ -5,6 +5,7 @@ import { useChartSize, useParamColumns } from "../hooks";
 import { useLayoutEffect, useMemo, useState, type PropsWithChildren } from "react";
 import * as Axis from "@visx/axis";
 import * as Scale from "@visx/scale";
+import { dateTickFormat, isDateColumn } from "@/lib/dateFormat";
 
 type AxisComponentProps = {
     config: ScatterPlotConfig2D | ScatterPlotConfig3D
@@ -91,6 +92,12 @@ export default observer(function AxisComponent({ config, unproject, children }: 
     const is2d = dimension === "2d";
     const [width, height] = useChartSize();
     const { scaleX, scaleY, margin, chartWidth, chartHeight } = useSynchronizedScales({ config, unproject });
+    const xTickFormat = isDateColumn(cx)
+        ? (value: number | { valueOf(): number }) => dateTickFormat(Number(value))
+        : undefined;
+    const yTickFormat = isDateColumn(cy)
+        ? (value: number | { valueOf(): number }) => dateTickFormat(Number(value))
+        : undefined;
     
     const deckStyle = useMemo(() => ({
         position: "absolute",
@@ -113,6 +120,7 @@ export default observer(function AxisComponent({ config, unproject, children }: 
                     scale={scaleX}
                     stroke={"var(--text_color)"}
                     tickStroke={"var(--text_color)"}
+                    tickFormat={xTickFormat}
                     tickLabelProps={() => ({
                         fill: "var(--text_color)",
                         fontSize: config.axis.x.tickfont,
@@ -133,6 +141,7 @@ export default observer(function AxisComponent({ config, unproject, children }: 
                     scale={scaleY}
                     stroke={"var(--text_color)"}
                     tickStroke={"var(--text_color)"}
+                    tickFormat={yTickFormat}
                     tickLabelProps={() => ({
                         fill: "var(--text_color)",
                         fontSize: config.axis.y.tickfont,

--- a/src/react/components/HistogramWidget.tsx
+++ b/src/react/components/HistogramWidget.tsx
@@ -8,6 +8,7 @@ import {
     type BrushXScaleType,
     type Range,
 } from "@/react/components/histogram/useBrushX";
+import { formatDateDays } from "@/lib/dateFormat";
 
 export type HistogramScaleType = BrushXScaleType;
 export type HistogramBrushConfig = BrushXConfig;
@@ -50,9 +51,25 @@ type HistogramWidgetProps = {
     scaleControls?: HistogramScaleControls;
     onVisibleOnce?: () => void;
     rootMargin?: string;
+    /** When true, brush range chip formats day numbers as YYYY-MM-DD. */
+    isDate?: boolean;
 };
 
-const formatBrushValue = d3.format(".4~g");
+const formatNumericBrushValue = d3.format(".4~g");
+
+/** Brush chip text for a numeric or calendar-date histogram range. */
+export function formatHistogramBrushRange(
+    start: number,
+    end: number,
+    isDate = false,
+): string {
+    const lo = start <= end ? start : end;
+    const hi = start <= end ? end : start;
+    if (isDate) {
+        return `${formatDateDays(lo)} - ${formatDateDays(hi)}`;
+    }
+    return `${formatNumericBrushValue(lo)} - ${formatNumericBrushValue(hi)}`;
+}
 
 export default function HistogramWidget({
     layers,
@@ -67,6 +84,7 @@ export default function HistogramWidget({
     scaleControls,
     onVisibleOnce,
     rootMargin = "0px 0px 100px 0px",
+    isDate = false,
 }: HistogramWidgetProps) {
     const containerRef = useRef<HTMLDivElement>(null);
     const ref = useRef<SVGSVGElement>(null);
@@ -166,11 +184,8 @@ export default function HistogramWidget({
 
     const brushValueLabel = useMemo(() => {
         if (!brush?.value) return null;
-        const [start, end] = brush.value[0] <= brush.value[1]
-            ? brush.value
-            : [brush.value[1], brush.value[0]];
-        return `${formatBrushValue(start)} - ${formatBrushValue(end)}`;
-    }, [brush?.value]);
+        return formatHistogramBrushRange(brush.value[0], brush.value[1], isDate);
+    }, [brush?.value, isDate]);
 
     return (
         <div className="relative w-full" ref={containerRef}>
@@ -188,13 +203,15 @@ export default function HistogramWidget({
             ) : null}
             {scaleControls ? (
                 <div className="pointer-events-none absolute right-1 top-1 z-10 flex items-center gap-1 text-[10px] opacity-75">
-                    <button
-                        type="button"
-                        className="pointer-events-auto rounded border border-[hsl(var(--border))] bg-[hsl(var(--background)/0.9)] px-1 py-0 text-[9px] text-[hsl(var(--foreground))] shadow-sm"
-                        onClick={scaleControls.onToggleX}
-                    >
-                        X:{scaleControls.xLabel}
-                    </button>
+                    {!isDate ? (
+                        <button
+                            type="button"
+                            className="pointer-events-auto rounded border border-[hsl(var(--border))] bg-[hsl(var(--background)/0.9)] px-1 py-0 text-[9px] text-[hsl(var(--foreground))] shadow-sm"
+                            onClick={scaleControls.onToggleX}
+                        >
+                            X:{scaleControls.xLabel}
+                        </button>
+                    ) : null}
                     <button
                         type="button"
                         className="pointer-events-auto rounded border border-[hsl(var(--border))] bg-[hsl(var(--background)/0.9)] px-1 py-0 text-[9px] text-[hsl(var(--foreground))] shadow-sm"

--- a/src/react/components/SelectionDialogComponent.tsx
+++ b/src/react/components/SelectionDialogComponent.tsx
@@ -530,6 +530,7 @@ const Histogram = observer((props: RangeProps) => {
             xScaleType={resolvedXScale}
             yScaleType={resolvedYScale}
             brush={brush}
+            isDate={props.isDate}
             scaleControls={{
                 xLabel: xScaleMode === "auto" ? resolvedXScale : xScaleMode,
                 yLabel: yScaleMode === "auto" ? resolvedYScale : yScaleMode,

--- a/src/react/components/SelectionDialogComponent.tsx
+++ b/src/react/components/SelectionDialogComponent.tsx
@@ -24,6 +24,7 @@ import {
     resolveAutoHistogramXScaleFromHistogram,
     resolveAutoHistogramYScale,
 } from "@/lib/utils";
+import { formatDateDays, isDateColumn, parseDateDays } from "@/lib/dateFormat";
 import ErrorComponentReactWrapper from "./ErrorComponentReactWrapper";
 import {
     DndContext,
@@ -352,12 +353,13 @@ function useRangeFilter(column: DataColumn<NumberDataType>) {
     const isInteger = column.datatype.match(/int/);
     const { minMax } = column;
     const step = useMemo(() => {
+        if (isDateColumn(column)) return 1;
         if (isInteger) return 1;
         // not sure this is totally correct - but there was a problem with very small ranges
         // this should be better...
         const small = Math.abs(minMax[1] - minMax[0]);
         return small < 0.001 ? small/1000 : 0.001;
-    }, [isInteger, minMax]);
+    }, [isInteger, minMax, column]);
     const [debouncedValue] = useDebounce(value, 10);
      useEffect(() =>{
         filter.setNoClear(conf.noClearFilters);
@@ -442,6 +444,8 @@ type RangeProps = ReturnType<typeof useRangeFilter> & {
     // probably want to review how these are specified / controlled
     histoWidth: number, //number of bins
     histoHeight: number, //height of the histogram
+    /** Calendar-date columns should stay on a linear day axis. */
+    isDate?: boolean,
 };
 const toggleScaleMode = (
     mode: ScaleMode,
@@ -467,8 +471,13 @@ const Histogram = observer((props: RangeProps) => {
     const filteredData = filteredHistogram.length > 0 ? filteredHistogram : emptyHistogram;
     const highlightedData = highlightedHistogram.length > 0 ? highlightedHistogram : emptyHistogram;
     const resolvedXScale = useMemo(
-        () => xScaleMode === "auto" ? resolveAutoHistogramXScaleFromHistogram(props.minMax, backgroundData) : xScaleMode,
-        [backgroundData, props.minMax, xScaleMode],
+        () => {
+            if (props.isDate) return "linear";
+            return xScaleMode === "auto"
+                ? resolveAutoHistogramXScaleFromHistogram(props.minMax, backgroundData)
+                : xScaleMode;
+        },
+        [backgroundData, props.isDate, props.minMax, xScaleMode],
     );
     const resolvedYScale = useMemo(
         () => (yScaleMode === "auto" ? resolveAutoHistogramYScale(backgroundData) : yScaleMode),
@@ -554,6 +563,7 @@ const NumberComponent = observer(({ column }: Props<NumberDataType>) => {
     const rangeProps = useRangeFilter(column);
     const { value, step } = rangeProps;
     const [min, max] = column.minMax;
+    const dateMode = isDateColumn(column);
     const setValue = useCallback<set2d>((newValue) => {
         if (newValue) {
             // constrain with min, max and step
@@ -566,20 +576,50 @@ const NumberComponent = observer(({ column }: Props<NumberDataType>) => {
     }, [filters, column.field, min, max, step]);
     const low = value ? value[0] : min;
     const high = value ? value[1] : max;
+    const onDateChange = useCallback((which: "low" | "high", text: string) => {
+        const parsed = parseDateDays(text);
+        if (parsed == null) {
+            return;
+        }
+        if (which === "low") {
+            setValue([parsed, high]);
+        } else {
+            setValue([low, parsed]);
+        }
+    }, [setValue, low, high]);
     return (
         <div>
-            <Histogram {...rangeProps} setValue={setValue} minMax={column.minMax} histoWidth={99} histoHeight={100} />
+            <Histogram {...rangeProps} setValue={setValue} minMax={column.minMax} histoWidth={99} histoHeight={100} isDate={dateMode} />
             <div>
-                <TextField size="small" className="max-w-20" type="number"
-                    variant="standard"
-                    value={low}
-                    onChange={(e) => setValue([Number(e.target.value), high])}
-                />
-                <TextField size="small" className="max-w-20 float-right" type="number"
-                    variant="standard"
-                    value={high}
-                    onChange={(e) => setValue([low, Number(e.target.value)])} 
-                />
+                {dateMode ? (
+                    <>
+                        <TextField size="small" className="max-w-28"
+                            variant="standard"
+                            type="date"
+                            value={formatDateDays(low)}
+                            onChange={(e) => onDateChange("low", e.target.value)}
+                        />
+                        <TextField size="small" className="max-w-28 float-right"
+                            variant="standard"
+                            type="date"
+                            value={formatDateDays(high)}
+                            onChange={(e) => onDateChange("high", e.target.value)}
+                        />
+                    </>
+                ) : (
+                    <>
+                        <TextField size="small" className="max-w-20" type="number"
+                            variant="standard"
+                            value={low}
+                            onChange={(e) => setValue([Number(e.target.value), high])}
+                        />
+                        <TextField size="small" className="max-w-20 float-right" type="number"
+                            variant="standard"
+                            value={high}
+                            onChange={(e) => setValue([low, Number(e.target.value)])} 
+                        />
+                    </>
+                )}
             </div>
         </div>
     );

--- a/src/react/components/legend/ColorLegend.tsx
+++ b/src/react/components/legend/ColorLegend.tsx
@@ -152,6 +152,7 @@ export default function ColorLegend({
             getContinuousLegendContainerHeight(spec.range, {
                 width,
                 hasLabel: Boolean(spec.label),
+                isDate: spec.isDate,
             });
         el.style.width = `${width}px`;
         el.style.height = `${height}px`;
@@ -185,6 +186,7 @@ export default function ColorLegend({
                 height={spec.height}
                 activeRange={activeContinuousRange}
                 onRangeChange={onContinuousRangeChange}
+                isDate={spec.isDate}
             />
         </div>
     );

--- a/src/react/components/legend/LegendContinuousSvg.tsx
+++ b/src/react/components/legend/LegendContinuousSvg.tsx
@@ -40,6 +40,7 @@ export default function LegendContinuousSvg({
     height = DEFAULT_CONTINUOUS_LEGEND_HEIGHT,
     activeRange = null,
     onRangeChange,
+    isDate = false,
 }: LegendContinuousSvgProps) {
     // SVG ids are document-global, and legends may be rendered through separate React roots.
     const gradientIdRef = useRef<string>(createLegendGradientId());
@@ -106,7 +107,7 @@ export default function LegendContinuousSvg({
             .domain([range[0], range[1]])
             .range([0, layout.axisWidth]);
         const axis = axisBottom(scale)
-            .tickFormat(formatContinuousTick)
+            .tickFormat((d) => formatContinuousTick(d, isDate))
             .ticks(layout.tickCount);
 
         const selection = select(axisG);
@@ -121,7 +122,7 @@ export default function LegendContinuousSvg({
         return () => {
             selection.selectAll("*").remove();
         };
-    }, [layout.axisWidth, layout.tickCount, range]);
+    }, [layout.axisWidth, layout.tickCount, range, isDate]);
 
     return (
         <svg

--- a/src/react/legend/color_legend/buildColorLegendSpec.ts
+++ b/src/react/legend/color_legend/buildColorLegendSpec.ts
@@ -1,4 +1,5 @@
 import type DataStore from "@/datastore/DataStore";
+import { isDateColumn } from "@/lib/dateFormat";
 import { isColumnNumeric, isColumnText } from "@/utilities/Utilities";
 import type {
     ColorLegendBuildConfig,
@@ -48,6 +49,7 @@ export function buildColorLegendSpec(
             column,
             colors,
             range,
+            isDate: isDateColumn(c),
         };
     }
 

--- a/src/react/legend/color_legend/types.ts
+++ b/src/react/legend/color_legend/types.ts
@@ -26,6 +26,8 @@ export type ColorLegendContinuousSpec = {
     range: [number, number];
     width?: number;
     height?: number;
+    /** When true, axis ticks format as YYYY-MM-DD (days since Unix epoch). */
+    isDate?: boolean;
 };
 
 export type ColorLegendSpec =

--- a/src/react/legend/shared/legendTypes.ts
+++ b/src/react/legend/shared/legendTypes.ts
@@ -22,6 +22,8 @@ export type LegendContinuousSvgProps = {
     height?: number;
     activeRange?: [number, number] | null;
     onRangeChange?: (range: [number, number] | null) => void;
+    /** When true, axis ticks format as YYYY-MM-DD (days since Unix epoch). */
+    isDate?: boolean;
 };
 
 export type ContinuousLegendLayout = {

--- a/src/react/legend/shared/legendUtils.ts
+++ b/src/react/legend/shared/legendUtils.ts
@@ -1,4 +1,5 @@
 import { scaleLinear } from "d3-scale";
+import { dateTickFormat } from "@/lib/dateFormat";
 import {
     CONTINUOUS_HORIZONTAL_PADDING,
     CONTINUOUS_MIN_LAYOUT_WIDTH,
@@ -71,10 +72,13 @@ export function formatLegendLabel(
     };
 }
 
-export function formatContinuousTick(value: unknown): string {
+export function formatContinuousTick(value: unknown, isDate = false): string {
     const num = Number(value);
     if (!Number.isFinite(num)) {
         return String(value);
+    }
+    if (isDate) {
+        return dateTickFormat(num);
     }
     if (Math.abs(num) >= 10000 || (Math.abs(num) > 0 && Math.abs(num) < 0.01)) {
         return num.toExponential(1).replace("+", "");
@@ -141,6 +145,7 @@ const CONTINUOUS_LEGEND_MIN_HEIGHT = 64;
 export type ContinuousLegendHeightOptions = {
     width?: number;
     hasLabel?: boolean;
+    isDate?: boolean;
 };
 
 export function getContinuousLegendContainerHeight(
@@ -149,6 +154,7 @@ export function getContinuousLegendContainerHeight(
 ): number {
     const width = options.width ?? DEFAULT_CONTINUOUS_LEGEND_WIDTH;
     const hasLabel = options.hasLabel ?? true;
+    const isDate = options.isDate ?? false;
     const layout = getContinuousLegendLayout(width, hasLabel);
 
     const scale = scaleLinear()
@@ -160,7 +166,7 @@ export function getContinuousLegendContainerHeight(
     for (const tick of ticks) {
         longestTickWidth = Math.max(
             longestTickWidth,
-            measureLegendLabelWidth(formatContinuousTick(tick)),
+            measureLegendLabelWidth(formatContinuousTick(tick, isDate)),
         );
     }
 

--- a/src/react/utils/valueReplacementUtil.ts
+++ b/src/react/utils/valueReplacementUtil.ts
@@ -1,5 +1,10 @@
 import type { DataType, LoadedDataColumn } from "@/charts/charts";
 import {
+    formatDateDays,
+    isDateColumn,
+    parseDateDays,
+} from "@/lib/dateFormat";
+import {
     getMultitextCapacity,
     getMultitextDelimiter,
     getMultitextJoinDelimiter,
@@ -197,6 +202,9 @@ export const getCellValueAsString = (column: LoadedDataColumn<DataType>, dataInd
         const value = data[dataIndex];
 
         if (value === undefined || value === null || Number.isNaN(value)) return "";
+        if (isDateColumn(column)) {
+            return formatDateDays(value);
+        }
         return String(value);
     }
 
@@ -279,9 +287,26 @@ export const setCellValueFromString = (
 
     // numeric
     if (datatype === "double" || datatype === "int32" || datatype === "integer") {
-        const numValue = Number.parseFloat(newValue);
-        if (!Number.isFinite(numValue)) {
-            throw new Error(`Invalid number value "${newValue}" for ${datatype} column: ${column.field}`);
+        let numValue: number;
+        if (isDateColumn(column)) {
+            // Prefer YYYY-MM-DD; otherwise accept a finite day-number string.
+            // Avoid parseDateDays' Date.parse fallback, which treats "18262" as a year.
+            const parsedDate = /^\d{4}-\d{2}-\d{2}$/.test(newValue.trim())
+                ? parseDateDays(newValue)
+                : null;
+            numValue = parsedDate ?? Number.parseFloat(newValue);
+            if (!Number.isFinite(numValue)) {
+                throw new Error(
+                    `Invalid date value "${newValue}" for date column: ${column.field}`,
+                );
+            }
+        } else {
+            numValue = Number.parseFloat(newValue);
+            if (!Number.isFinite(numValue)) {
+                throw new Error(
+                    `Invalid number value "${newValue}" for ${datatype} column: ${column.field}`,
+                );
+            }
         }
 
         data[dataIndex] = numValue;

--- a/src/tests/dateAxisDefaults.spec.ts
+++ b/src/tests/dateAxisDefaults.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test, vi } from "vitest";
+import WGLScatterPlot from "@/charts/WGLScatterPlot.js";
+
+function makeStub(overrides: {
+    x: string;
+    y: string;
+    columns: Record<string, { is_date?: boolean; date_unit?: string }>;
+    axis: {
+        x?: { size?: number };
+        y?: { size?: number };
+        x_log_scale?: boolean;
+        y_log_scale?: boolean;
+    };
+}) {
+    const stub = {
+        x: overrides.x,
+        y: overrides.y,
+        dataStore: { columnIndex: overrides.columns },
+        config: { axis: overrides.axis },
+        _dateAxisCache: undefined as
+            | {
+                  x?: { log_scale?: boolean; size?: number } | null;
+                  y?: { log_scale?: boolean; size?: number } | null;
+              }
+            | undefined,
+        setAxisSize: vi.fn(function (
+            this: { config: { axis: Record<string, { size?: number }> } },
+            axis: "x" | "y",
+            size: number,
+        ) {
+            this.config.axis[axis].size = size;
+        }),
+    };
+    return stub;
+}
+
+describe("_applyDateAxisDefaults date↔numeric restore", () => {
+    test("date-to-numeric switch restores log scale and original axis size", () => {
+        const stub = makeStub({
+            x: "qc_date",
+            y: "n_genes",
+            columns: {
+                qc_date: { is_date: true },
+                n_genes: {},
+                score: {},
+            },
+            axis: {
+                x: { size: 30 },
+                y: { size: 45 },
+                x_log_scale: true,
+                y_log_scale: false,
+            },
+        });
+
+        WGLScatterPlot.prototype._applyDateAxisDefaults.call(stub);
+
+        expect(stub.config.axis.x_log_scale).toBe(false);
+        expect(stub.config.axis.x?.size).toBe(40);
+        expect(stub.setAxisSize).toHaveBeenCalledWith("x", 40);
+
+        stub.x = "score";
+        WGLScatterPlot.prototype._applyDateAxisDefaults.call(stub);
+
+        expect(stub.config.axis.x_log_scale).toBe(true);
+        expect(stub.config.axis.x?.size).toBe(30);
+        expect(stub.setAxisSize).toHaveBeenCalledWith("x", 30);
+    });
+});

--- a/src/tests/dateAxisTicks.spec.ts
+++ b/src/tests/dateAxisTicks.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "vitest";
+import { dateTickFormat, formatDateDays } from "@/lib/dateFormat";
+
+describe("date axis tick labels", () => {
+    test("formats typical qc_date day ticks as ISO dates", () => {
+        // Values visible on the MICRON-scanr-sim-psf scatter axis before formatting.
+        expect(dateTickFormat(20100)).toBe("2025-01-12");
+        expect(dateTickFormat(20150)).toBe("2025-03-03");
+        expect(dateTickFormat(20454)).toBe(formatDateDays(20454));
+        expect(dateTickFormat(20454)).toBe("2026-01-01");
+    });
+
+    test("d3 NumberValue-like objects coerce correctly", () => {
+        const asNumberValue = { valueOf: () => 20089 };
+        expect(dateTickFormat(Number(asNumberValue))).toBe("2025-01-01");
+    });
+});

--- a/src/tests/dateColumnDisplay.spec.ts
+++ b/src/tests/dateColumnDisplay.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "vitest";
+import { formatDateDays } from "@/lib/dateFormat";
+
+/**
+ * Mirrors DataStore.getValue numeric+is_date branch without constructing a full DataStore
+ * (Worker / config typing noise in unit tests).
+ */
+function getDateDisplayValue(raw: number, isDate: boolean): string | number {
+    if (Number.isNaN(raw)) {
+        return "missing";
+    }
+    if (isDate) {
+        return formatDateDays(raw);
+    }
+    return raw;
+}
+
+describe("date column display / sort contract", () => {
+    test("is_date columns display ISO dates while raw days stay numeric", () => {
+        const raw = new Float32Array([0, 18262, Number.NaN]);
+        expect(getDateDisplayValue(raw[0], true)).toBe("1970-01-01");
+        expect(getDateDisplayValue(raw[1], true)).toBe("2020-01-01");
+        expect(getDateDisplayValue(raw[2], true)).toBe("missing");
+        expect(raw[0]).toBe(0);
+        expect(raw[1]).toBe(18262);
+    });
+
+    test("numeric sort of day doubles is chronological", () => {
+        const days = new Float32Array([18262, 0, 100]);
+        const indices = new Uint32Array([0, 1, 2]);
+        indices.sort((a, b) => {
+            const comparison = days[a] < days[b] ? -1 : days[a] > days[b] ? 1 : 0;
+            return comparison;
+        });
+        expect(Array.from(indices)).toEqual([1, 2, 0]);
+    });
+});

--- a/src/tests/dateFormat.spec.ts
+++ b/src/tests/dateFormat.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "vitest";
+import {
+    dateTickFormat,
+    formatDateDays,
+    isDateColumn,
+    parseDateDays,
+} from "@/lib/dateFormat";
+
+describe("dateFormat", () => {
+    test("formatDateDays formats UTC epoch days as YYYY-MM-DD", () => {
+        expect(formatDateDays(0)).toBe("1970-01-01");
+        // 2020-01-01 is 18262 days after 1970-01-01
+        expect(formatDateDays(18262)).toBe("2020-01-01");
+    });
+
+    test("formatDateDays returns missing for non-finite", () => {
+        expect(formatDateDays(Number.NaN)).toBe("missing");
+        expect(formatDateDays(Number.POSITIVE_INFINITY)).toBe("missing");
+    });
+
+    test("parseDateDays parses YYYY-MM-DD to days", () => {
+        expect(parseDateDays("1970-01-01")).toBe(0);
+        expect(parseDateDays("2020-01-01")).toBe(18262);
+        expect(parseDateDays("not-a-date")).toBeNull();
+        expect(parseDateDays("")).toBeNull();
+        expect(parseDateDays("18262")).toBeNull();
+        expect(parseDateDays("2020-02-31")).toBeNull();
+    });
+
+    test("round-trip format and parse", () => {
+        for (const days of [0, 1, 10000, 20000]) {
+            expect(parseDateDays(formatDateDays(days))).toBe(days);
+        }
+    });
+
+    test("isDateColumn and dateTickFormat", () => {
+        expect(isDateColumn({ is_date: true, datatype: "double" })).toBe(true);
+        expect(isDateColumn({ is_date: false, datatype: "double" })).toBe(false);
+        expect(isDateColumn(null)).toBe(false);
+        expect(dateTickFormat(0)).toBe("1970-01-01");
+    });
+});

--- a/src/tests/histogramBrushRange.spec.ts
+++ b/src/tests/histogramBrushRange.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "vitest";
+import { formatHistogramBrushRange } from "@/react/components/HistogramWidget";
+
+describe("formatHistogramBrushRange", () => {
+    test("formats numeric ranges with compact g notation", () => {
+        expect(formatHistogramBrushRange(0.5, 1.25)).toBe("0.5 - 1.25");
+        expect(formatHistogramBrushRange(20150, 20320)).toBe("2.015e+4 - 2.032e+4");
+    });
+
+    test("formats date day ranges as YYYY-MM-DD", () => {
+        // 2025-02-28 and 2025-08-23 as days since Unix epoch
+        expect(formatHistogramBrushRange(20147, 20323, true)).toBe(
+            "2025-02-28 - 2025-08-23",
+        );
+    });
+
+    test("orders date range ends low-to-high", () => {
+        expect(formatHistogramBrushRange(20323, 20147, true)).toBe(
+            "2025-02-28 - 2025-08-23",
+        );
+    });
+});

--- a/src/tests/react/legend/legendUtils.test.ts
+++ b/src/tests/react/legend/legendUtils.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import {
+    formatContinuousTick,
     formatLegendLabel,
     getContinuousLegendContainerHeight,
     getContinuousLegendLayout,
@@ -63,5 +64,10 @@ describe("legendUtils", () => {
                 hasLabel: true,
             }),
         );
+    });
+
+    test("formatContinuousTick formats date columns as YYYY-MM-DD", () => {
+        expect(formatContinuousTick(18262, true)).toBe("2020-01-01");
+        expect(formatContinuousTick(20000, false)).toBe("2.0e4");
     });
 });

--- a/src/tests/table_react/utils/valueReplacementUtils.test.tsx
+++ b/src/tests/table_react/utils/valueReplacementUtils.test.tsx
@@ -1,5 +1,6 @@
 import type { DataType, LoadedDataColumn } from "@/charts/charts";
 import {
+    getCellValueAsString,
     replaceMatches,
     replaceValueInString,
     setCellValueFromString,
@@ -106,6 +107,50 @@ describe("valueReplacementUtils", () => {
 
                 expect(() => setCellValueFromString(column, 0, "")).toThrowError(
                     `Invalid number value "" for ${column.datatype} column: ${column.field}`,
+                );
+            });
+        });
+
+        describe("date column", () => {
+            test("reads and writes ISO dates as day doubles", () => {
+                column = {
+                    field: "when",
+                    data: [18262, 0],
+                    datatype: "double",
+                    is_date: true,
+                    date_unit: "days",
+                } as any;
+
+                expect(getCellValueAsString(column, 0)).toBe("2020-01-01");
+                setCellValueFromString(column, 0, "2020-01-11");
+                expect(column.data[0]).toBe(18272);
+                expect(getCellValueAsString(column, 0)).toBe("2020-01-11");
+            });
+
+            test("accepts raw day numbers when writing", () => {
+                column = {
+                    field: "when",
+                    data: [0],
+                    datatype: "double",
+                    is_date: true,
+                    date_unit: "days",
+                } as any;
+
+                setCellValueFromString(column, 0, "18262");
+                expect(column.data[0]).toBe(18262);
+            });
+
+            test("throw error for invalid date value", () => {
+                column = {
+                    field: "when",
+                    data: [0],
+                    datatype: "double",
+                    is_date: true,
+                    date_unit: "days",
+                } as any;
+
+                expect(() => setCellValueFromString(column, 0, "not-a-date")).toThrowError(
+                    `Invalid date value "not-a-date" for date column: ${column.field}`,
                 );
             });
         });

--- a/src/utilities/Color.js
+++ b/src/utilities/Color.js
@@ -7,6 +7,7 @@ import {
 import { select } from "d3-selection";
 import { scaleLinear } from "d3-scale";
 import { axisBottom } from "d3-axis";
+import { dateTickFormat } from "@/lib/dateFormat";
 import { getRandomString } from "./Utilities";
 
 /**
@@ -238,8 +239,12 @@ function getColorBar(colors, config = {}) {
             .domain([c.range[0], c.range[1]])
             .range([0, width - 20]);
         const axis = axisBottom(scale)
-            .tickFormat((v, i) =>
-                v >= 10000 ? Number.parseFloat(v).toPrecision(2) : v,
+            .tickFormat((v) =>
+                c.is_date || c.date_unit === "days"
+                    ? dateTickFormat(Number(v))
+                    : Number(v) >= 10000
+                      ? Number.parseFloat(String(v)).toPrecision(2)
+                      : v,
             )
             .ticks(Math.ceil(width / 20));
 

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -40,10 +40,11 @@ const enableBundleAnalysis =
 /** Same rules as main's per-build assetFileNames, plus fonts under assets/ (Rolldown emits url(./font) next to assets/mdv.css). */
 function flaskAssetFileNames(assetInfo: { name?: string }): string {
     const name = assetInfo.name ?? '';
-    if (name.includes('index.css')) return 'assets/mdv.css';
-    if (name === 'mdv.css') return 'assets/mdv.css';
+    // project_bootstrap / desktop_index import ./all_css → emitted as all_css.css
+    if (name.includes('index.css') || name === 'all_css.css' || name === 'mdv.css' || name === 'desktop_index.css') {
+        return 'assets/mdv.css';
+    }
     if (name === 'catalog.css') return 'assets/catalog.css';
-    if (name === 'desktop_index.css') return 'assets/mdv.css';
     if (process.env.VITE_ENTRYPOINT) {
         const { name: entryBase } = path.parse(process.env.VITE_ENTRYPOINT);
         if (name === `${entryBase}.css`) return 'assets/mdv.css';


### PR DESCRIPTION
Adds real date-column support end to end. Datetimes ingested from pandas/polars are stored as numeric days since the Unix epoch, tagged with is_date, and shown as YYYY-MM-DD in tables, tooltips, axes, color legends, Selection Dialog filters, and Find/Replace — while charts and filters keep using the underlying day numbers so sorting and brushing stay chronological.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added date-column support end-to-end for pandas and polars ingestion.
  * Date values now display as `YYYY-MM-DD` across tables, axes, legends, filters, and histogram/brush labels.
  * Improved interactions for date columns, including chronological sorting and date-aware filtering/range stepping.
  * Axis and legend tick formatting now render calendar dates; date modes disable log scaling and enforce minimum axis sizing where applicable.
* **Documentation**
  * Expanded documentation for date column configuration (`is_date`, `date_unit`) and behavior.
* **Bug Fixes**
  * Improved CSS asset mapping for additional stylesheet names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->