### PR TITLE
add headers for range requests

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -93,7 +93,14 @@ Because the JavaScript uses WebWorkers and SharedArrayBuffers, the app must run 
 "Cross-Origin-Opener-Policy":"same-origin",
 "Cross-Origin-Embedder-Policy":"require-corp"
 ```
-The dev server and Flask helpers in this repository already add these headers. If your deployment uses a different web server or reverse proxy, it must send the same headers consistently for pages using MDV, and any cross-origin assets must be served in a way that remains compatible with `require-corp`/CORS. If your server already adds these headers then the `convert_to_static_page` function can be invoked with `include_sab_headers=False`, which will exclude the service worker. In this case the project does not have to be served over https.
+Binary columns, tracks, and SpatialData assets (parquet / OME-TIFF / zarr) also use HTTP Range requests. Cross-origin clients (for example SpatialData.js against a separate Flask or static origin, or the Vite dev server) need CORS to allow and expose those headers:
+```
+"Access-Control-Allow-Origin":"*",
+"Access-Control-Allow-Headers":"Content-Type, Range",
+"Access-Control-Expose-Headers":"Content-Range, Content-Length, Accept-Ranges",
+"Cross-Origin-Resource-Policy":"cross-origin"
+```
+The Vite dev server (`vite.config.mts`) and Flask helpers (`add_safe_headers` in `mdvtools/server_utils.py`) already add these headers. If your deployment uses a different web server or reverse proxy, it must send the same headers consistently for pages using MDV, and any cross-origin assets must be served in a way that remains compatible with `require-corp`/CORS. If your server already adds these headers then the `convert_to_static_page` function can be invoked with `include_sab_headers=False`, which will exclude the service worker. In this case the project does not have to be served over https.
 
 ### To convert CSV data for a simple file server
 
@@ -122,7 +129,10 @@ class CustomHandler(http.server.SimpleHTTPRequestHandler):
     def end_headers(self):
         self.send_header('Access-Control-Allow-Origin', '*')
         self.send_header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
-        self.send_header('Access-Control-Allow-Headers', 'Content-Type, responsetype')
+        # Range: binary columns, tracks, parquet / OME-TIFF / zarr (SpatialData.js)
+        self.send_header('Access-Control-Allow-Headers', 'Content-Type, Range, responsetype')
+        self.send_header('Access-Control-Expose-Headers', 'Content-Range, Content-Length, Accept-Ranges')
+        self.send_header('Access-Control-Max-Age', '86400')
         self.send_header('Cross-Origin-Opener-Policy', 'same-origin')
         self.send_header('Cross-Origin-Embedder-Policy', 'require-corp')
         self.send_header('Cross-Origin-Resource-Policy', 'cross-origin')
@@ -132,7 +142,9 @@ class CustomHandler(http.server.SimpleHTTPRequestHandler):
         self.send_response(200)
         self.send_header('Access-Control-Allow-Origin', '*')
         self.send_header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
-        self.send_header('Access-Control-Allow-Headers', 'Content-Type, responsetype')
+        self.send_header('Access-Control-Allow-Headers', 'Content-Type, Range, responsetype')
+        self.send_header('Access-Control-Expose-Headers', 'Content-Range, Content-Length, Accept-Ranges')
+        self.send_header('Access-Control-Max-Age', '86400')
         self.send_header('Cross-Origin-Opener-Policy', 'same-origin')
         self.send_header('Cross-Origin-Embedder-Policy', 'require-corp')
         self.send_header('Cross-Origin-Resource-Policy', 'cross-origin')

--- a/python/mdvtools/server_utils.py
+++ b/python/mdvtools/server_utils.py
@@ -48,7 +48,10 @@ def add_safe_headers(resp):
     resp.headers["Cross-Origin-Embedder-Policy"] = "require-corp"
     # headers required if serving endpoints for another server e,g dev server
     resp.headers["Access-Control-Allow-Origin"] = "*"
-    resp.headers["Access-Control-Allow-Headers"] = "Content-Type"
+    # range requests for parquet (& OME-TIFF/other things, but noticing issues with points parquet)
+    resp.headers["Access-Control-Allow-Headers"] = "Content-Type, Range"
+    resp.headers["Access-Control-Expose-Headers"] = "Content-Range, Content-Length, Accept-Ranges"
+    resp.headers["Access-Control-Max-Age"] = "86400"
     #required for vite dev
     resp.headers["Cross-Origin-Resource-Policy"] ="cross-origin"
     _set_shell_cache_headers(resp)

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -119,10 +119,12 @@ function getRollupOptions() {
 }
 
 // avoiding some repition by defining a proxyOptions object used for all proxied routes.
+// Flask already adds CORS + Range expose headers via add_safe_headers; keep changeOrigin so
+// cross-origin Range requests (parquet / OME-TIFF / zarr via spatialdata.js) work through the proxy.
 const proxyOptions = { target: flaskURL, changeOrigin: true };
 // ... and then this is a bit more concise than 
 const proxy = [
-    '^/(get_|images|tracks|save|chat).*', // these routes are proxied to flask server in 'single project' mode
+    '^/(get_|images|tracks|save|chat|spatial).*', // single-project Flask routes (incl. /spatial zarr etc.)
     '^/project/[^/]+/.+', // proxy nested project routes, but keep /project/:id for the Vite app shell
     '^/.*\\.(json|b|gz)$',
     '/projects',
@@ -175,11 +177,15 @@ export default defineConfig(async (): Promise<UserConfig> => {
     base: process.env.asset_base || (build === 'dev_pt' ? "/" : "./"),
     server: {
         headers: {
+            // Match python/mdvtools/server_utils.add_safe_headers (SharedArrayBuffer + Range CORS).
             "Cross-Origin-Embedder-Policy": "require-corp",
             "Cross-Origin-Opener-Policy": "same-origin",
+            "Cross-Origin-Resource-Policy": "cross-origin",
             "Access-Control-Allow-Origin": "*",
             "Access-Control-Allow-Methods": "GET",
-            "Access-Control-Allow-Headers": "X-Requested-With, content-type, Authorization",
+            "Access-Control-Allow-Headers": "Content-Type, Range, X-Requested-With, Authorization",
+            "Access-Control-Expose-Headers": "Content-Range, Content-Length, Accept-Ranges",
+            "Access-Control-Max-Age": "86400",
         },
         port,
         strictPort: true,


### PR DESCRIPTION
Expose headers to allow range-requests over CORS. Was helpful when debugging spatialdata.js points in particular.