### PR TITLE
Fix parquet-wasm 404 in production builds

### DIFF
--- a/python/mdvtools/auth/authutils.py
+++ b/python/mdvtools/auth/authutils.py
@@ -147,8 +147,7 @@ def register_before_request_auth(app):
         '/static',
         '/flask/assets',
         '/flask/img',
-        '/flask/vendor',
-        '/static/vendor',
+        '/flask/vendor/',
     ]
 
     @app.before_request

--- a/python/mdvtools/auth/authutils.py
+++ b/python/mdvtools/auth/authutils.py
@@ -146,7 +146,9 @@ def register_before_request_auth(app):
         '/flask/js/',
         '/static',
         '/flask/assets',
-        '/flask/img'
+        '/flask/img',
+        '/flask/vendor',
+        '/static/vendor',
     ]
 
     @app.before_request

--- a/src/tests/build/bundleAssetReferences.test.ts
+++ b/src/tests/build/bundleAssetReferences.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Guards the class of bug where a bundled chunk keeps a literal runtime path to a file
+ * the build never emitted, so the app 404s in production while dev works fine (the dev
+ * server serves the dependency's own tree from node_modules).
+ *
+ * The live instance is @spatialdata/core's parquet-wasm loader: it imports
+ * `../vendor/parquet-wasm/parquet_wasm.js` under `@vite-ignore`, which opts the path out
+ * of resolution, so nothing is emitted for it and `copySpatialdataParquetWasm` in
+ * `vite.config.mts` has to copy the files in. Deleting that plugin fails this test.
+ *
+ * Deliberately not an assertion about parquet-wasm specifically: once upstream stops
+ * hiding the import, Vite emits the loader as a normal hashed asset, the `../vendor/…`
+ * reference disappears, and this test keeps passing without an edit. It does mean the
+ * test passes vacuously if nothing escapes its own directory — that is the healthy state.
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { describe, expect, test } from "vitest";
+
+const repoRoot = path.resolve(__dirname, "../../..");
+
+/** Every outDir the build scripts in package.json write to. */
+const BUILD_OUT_DIRS = ["vite-dist", "dist/flask", "python/mdvtools/static"];
+
+/** Rolldown chunk output only — not `examples/` (publicDir) or the copied vendor tree. */
+const CHUNK_DIRS = ["assets", "js"];
+
+/**
+ * Paths escaping the chunk's own directory. Same-directory references are emitted by the
+ * bundler and are hashed, so they cannot dangle; `../` is how an unresolved package-relative
+ * path survives into the output.
+ */
+const ESCAPING_PATH = /["'`](\.\.\/[^"'`\n]*?\.(?:js|mjs|wasm))["'`]/g;
+
+/**
+ * Only references landing inside the build tree are things the server would serve. Anything
+ * resolving above it is a string that never becomes a request — Rolldown's CommonJS interop
+ * registers modules under keys like `"../../node_modules/…/main.js"`, which are inert.
+ */
+function isServedFromBuild(target: string, buildDir: string): boolean {
+    const relative = path.relative(buildDir, target);
+    return relative !== "" && !relative.startsWith("..") && !path.isAbsolute(relative);
+}
+
+function jsFilesIn(dir: string): string[] {
+    if (!fs.existsSync(dir)) return [];
+    return fs
+        .readdirSync(dir, { recursive: true, encoding: "utf8" })
+        .filter((entry) => entry.endsWith(".js") || entry.endsWith(".mjs"))
+        .map((entry) => path.join(dir, entry));
+}
+
+function danglingReferences(buildDir: string): string[] {
+    const dangling: string[] = [];
+    for (const chunkDir of CHUNK_DIRS) {
+        for (const file of jsFilesIn(path.join(buildDir, chunkDir))) {
+            const source = fs.readFileSync(file, "utf8");
+            for (const [, reference] of source.matchAll(ESCAPING_PATH)) {
+                const target = path.resolve(path.dirname(file), reference);
+                if (isServedFromBuild(target, buildDir) && !fs.existsSync(target)) {
+                    dangling.push(`${path.relative(buildDir, file)} → ${reference}`);
+                }
+            }
+        }
+    }
+    return dangling;
+}
+
+const builtDirs = BUILD_OUT_DIRS.map((dir) => path.join(repoRoot, dir)).filter((dir) =>
+    fs.existsSync(path.join(dir, "assets")),
+);
+
+describe("build output asset references", () => {
+    // CI builds immediately before running vitest, so finding nothing there means the
+    // check silently stopped gating — worse than a failure. Locally a build is optional.
+    test.runIf(process.env.CI)("a production build is present to check", () => {
+        expect(builtDirs, `no build output found in ${BUILD_OUT_DIRS.join(", ")}`).not.toHaveLength(0);
+    });
+
+    test.skipIf(builtDirs.length === 0)("no chunk references a file the build did not emit", () => {
+        const dangling = builtDirs.flatMap((dir) =>
+            danglingReferences(dir).map((entry) => `${path.relative(repoRoot, dir)}/${entry}`),
+        );
+        const detail = `built chunks point at files missing from the output (rebuild if a listed\nbuild is just stale):\n${dangling.join("\n")}`;
+        expect(dangling, detail).toEqual([]);
+    });
+});

--- a/src/tests/build/bundleAssetReferences.test.ts
+++ b/src/tests/build/bundleAssetReferences.test.ts
@@ -20,9 +20,22 @@ import { describe, expect, test } from "vitest";
 const repoRoot = path.resolve(__dirname, "../../..");
 
 /** Every outDir the build scripts in package.json write to. */
-const BUILD_OUT_DIRS = ["vite-dist", "dist/flask", "python/mdvtools/static"];
+const BUILD_OUT_DIRS = [
+    "vite-dist",
+    "dist",
+    "dist/flask",
+    "dist/mdv",
+    "python/mdvtools/static",
+    "python/dist_hotfix/flask",
+];
 
-/** Rolldown chunk output only — not `examples/` (publicDir) or the copied vendor tree. */
+/**
+ * Rolldown chunk output only — not the build root, `examples/` (publicDir) or the copied
+ * vendor tree. Excluding the root is not just about noise: a `../` reference from there
+ * escapes the build tree by definition, so `isServedFromBuild` rejects it and scanning the
+ * root cannot flag anything. Root entries (`production` emits `mdv-<version>.js`) would need
+ * a different rule to be worth reading.
+ */
 const CHUNK_DIRS = ["assets", "js"];
 
 /**
@@ -47,7 +60,8 @@ function jsFilesIn(dir: string): string[] {
     return fs
         .readdirSync(dir, { recursive: true, encoding: "utf8" })
         .filter((entry) => entry.endsWith(".js") || entry.endsWith(".mjs"))
-        .map((entry) => path.join(dir, entry));
+        .map((entry) => path.join(dir, entry))
+        .filter((file) => fs.statSync(file).isFile());
 }
 
 function danglingReferences(buildDir: string): string[] {

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -1,4 +1,5 @@
 import { execSync } from "node:child_process";
+import { createRequire } from "node:module";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -7,7 +8,7 @@ import { babel as rollupBabel } from "@rollup/plugin-babel";
 // import vitePluginSocketIO from 'vite-plugin-socket.io';
 import react, { reactCompilerPreset } from "@vitejs/plugin-react";
 import { visualizer } from "rollup-plugin-visualizer";
-import { type ProxyOptions, type UserConfig, defineConfig } from "vite";
+import { type Plugin, type ProxyOptions, type UserConfig, defineConfig } from "vite";
 import glsl from "vite-plugin-glsl";
 
 const configDir = path.dirname(fileURLToPath(import.meta.url));
@@ -81,6 +82,56 @@ function workerFormat(): "es" | "iife" {
 }
 
 const spatialdataFsAllow = linkedSpatialdataRoots();
+
+/**
+ * Works around an upstream bug: @spatialdata/core loads parquet-wasm with
+ * `await import(/* @vite-ignore *\/ "../vendor/parquet-wasm/parquet_wasm.js")`, and
+ * `@vite-ignore` opts that path out of resolution, so nothing is emitted to satisfy
+ * the literal path left in the chunk. Chunks live in `assets/`, so the browser asks
+ * for `{staticRoot}/vendor/parquet-wasm/…` and gets a 404 — dev only survives because
+ * Vite serves core's vendor tree straight from node_modules.
+ *
+ * Core's own points-worker loader shows the fix: it uses `new URL(…, import.meta.url)`,
+ * which Vite emits as an asset, and its stray `@vite-ignore` is inert because the
+ * comment only suppresses dynamic-import analysis. Deleting the comment in core's
+ * `src/parquetWasmLoader.ts` is enough to make this plugin unnecessary — but check the
+ * output before removing it: the wasm then falls through `flaskAssetFileNames` to an
+ * unhashed `img/parquet_wasm_bg.wasm` while the points-worker bundle emits a second
+ * hashed copy, doubling 6.6MB. Today both chunks share the one directory copied here.
+ */
+function copySpatialdataParquetWasm(): Plugin {
+    const require = createRequire(import.meta.url);
+    let outDir = path.resolve(configDir, "dist");
+
+    return {
+        name: "copy-spatialdata-parquet-wasm",
+        apply: "build",
+        configResolved(config) {
+            outDir = path.resolve(config.root, config.build.outDir);
+        },
+        closeBundle: {
+            order: "post",
+            handler() {
+                let coreRoot: string;
+                try {
+                    const coreEntry = require.resolve("@spatialdata/core");
+                    coreRoot = path.dirname(path.dirname(coreEntry));
+                } catch {
+                    console.warn("[copy-spatialdata-parquet-wasm] @spatialdata/core not installed; skipping");
+                    return;
+                }
+                const src = path.join(coreRoot, "vendor/parquet-wasm");
+                if (!fs.existsSync(src)) {
+                    console.warn(`[copy-spatialdata-parquet-wasm] missing ${src}; skipping`);
+                    return;
+                }
+                const dest = path.join(outDir, "vendor/parquet-wasm");
+                fs.mkdirSync(path.dirname(dest), { recursive: true });
+                fs.cpSync(src, dest, { recursive: true });
+            },
+        },
+    };
+}
 
 // zarrita needed a polyfill for Buffer - seems like a bug
 // seems ok without as long we don't use ZipFileStore (marked experimental anyway)
@@ -269,6 +320,7 @@ export default defineConfig(async (): Promise<UserConfig> => {
             },
         },
         plugins: [
+            copySpatialdataParquetWasm(),
             glsl(),
             rollupBabel({
                 babelHelpers: "bundled",


### PR DESCRIPTION
## Summary
SpatialData shapes failed to load in built deployments with `Failed to fetch dynamically imported module: …/flask/vendor/parquet-wasm/parquet_wasm.js`, while dev worked fine.

@spatialdata/core loads parquet-wasm with `await import(/* @vite-ignore */ "../vendor/parquet-wasm/parquet_wasm.js")`. The `@vite-ignore` opts that path out of resolution, so Vite emits nothing for it and the literal path survives into the chunk. Chunks live in `assets/`, so the browser requests `{staticRoot}/vendor/parquet-wasm/…` and 404s. Dev only worked because the dev server serves core's vendor tree straight from node_modules. zarrextra's codec-worker is unaffected because it uses `new URL(…, import.meta.url)`, which Vite emits as a real asset.

## Changes
- `vite.config.mts`: build plugin copying core's `vendor/parquet-wasm/` into the output beside `assets/`, so both the main-thread and points-worker chunks resolve against one shared copy.
- `python/mdvtools/auth/authutils.py`: whitelist `/flask/vendor` and `/static/vendor`, so the assets aren't redirected to login when auth is enabled.
`src/tests/build/bundleAssetReferences.test.ts`: asserts no built chunk references a file the build didn't emit. Hangs off the existing ts_ci job, which already builds before running vitest.

## Upstream
The real fix belongs in core's `src/parquetWasmLoader.ts`. Deleting the @vite-ignore is verified sufficient — Vite then bundles the loader and emits the wasm. It isn't a clean drop-in for MDV as-is, though: the wasm falls through flaskAssetFileNames to an unhashed img/parquet_wasm_bg.wasm while the worker bundle emits a second hashed copy, taking 6.6 MB to 13 MB. A package export for the loader would avoid that. The plugin comment records this so the workaround can be removed deliberately.

## Test plan
- Confirmed the guarded reference exists in the CI build (`vite-dist`), so the test isn't passing vacuously.
- Moving the copied vendor/ aside fails the test, naming both offending chunks; restoring it passes.
- Full suite green (60 files, 433 tests); `tsgo` and biome clean.
`/flask/vendor/parquet-wasm/parquet_wasm{.js,_bg.wasm}` both return 200 from the running server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed browser loading for spatial data features by ensuring required WebAssembly assets are included in production builds.
  * Updated authentication enforcement for vendor assets, including improved handling of Flask vendor paths and protected static vendor resources.

* **Tests**
  * Added build validation to detect missing files referenced by generated browser bundles, helping prevent runtime asset-loading failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->