### PR TITLE
Make unwritable projects visible instead of silently read-only

### DIFF
--- a/python/mdvtools/auth/authutils.py
+++ b/python/mdvtools/auth/authutils.py
@@ -268,6 +268,7 @@ def update_cache(user_id=None, project_id=None, user_data=None, project_data=Non
             if existing_project:
                 # Project exists in cache, update only the changed fields
                 existing_project["name"] = project_data.get("name", existing_project["name"])
+                existing_project["path"] = project_data.get("path", existing_project.get("path"))
                 existing_project["lastModified"] = project_data.get("lastModified", existing_project["lastModified"])
                 existing_project["thumbnail"] = project_data.get("thumbnail", existing_project["thumbnail"])
                 logger.info(f"Updated project {project_id} in active projects cache.")
@@ -276,6 +277,7 @@ def update_cache(user_id=None, project_id=None, user_data=None, project_data=Non
                 project_entry = {
                     "id": project_data["id"],
                     "name": project_data["name"],
+                    "path": project_data.get("path"),
                     "lastModified": project_data["lastModified"],
                     "thumbnail": project_data["thumbnail"]
                 }

--- a/python/mdvtools/dbutils/dbservice.py
+++ b/python/mdvtools/dbutils/dbservice.py
@@ -66,6 +66,7 @@ class ProjectService:
             list[dict]: List of project dictionaries, each containing:
                 - id (int): Project ID
                 - name (str): Project name
+                - path (str): Project directory path for internal server checks
                 - lastModified (str): Formatted update timestamp (YYYY-MM-DD HH:MM:SS)
                 - thumbnail (str|None): First available viewImage from project views
                 - readme (str|None): Project README content if available
@@ -107,6 +108,7 @@ class ProjectService:
                 {
                     "id": p.id,
                     "name": p.name,
+                    "path": p.path,
                     "lastModified": p.update_timestamp.strftime('%Y-%m-%d %H:%M:%S'),
                     "thumbnail": get_project_thumbnail(p.path),
                     "readme": get_readme_file(p.path),

--- a/python/mdvtools/dbutils/project_manager_extension.py
+++ b/python/mdvtools/dbutils/project_manager_extension.py
@@ -119,6 +119,7 @@ class ProjectManagerExtension(MDVProjectServerExtension):
                             project_data={
                                 "id": new_project.id,
                                 "name": new_project.name,
+                                "path": new_project.path,
                                 "lastModified": new_project.update_timestamp.strftime("%Y-%m-%d %H:%M:%S"),
                                 "thumbnail": thumbnail,
                                 "owner": [owner_email]
@@ -253,6 +254,7 @@ class ProjectManagerExtension(MDVProjectServerExtension):
                             project_data={
                                 "id": new_project.id,
                                 "name": new_project.name,
+                                "path": new_project.path,
                                 "lastModified": new_project.update_timestamp.strftime("%Y-%m-%d %H:%M:%S"),
                                 "thumbnail": thumbnail,
                                 "owners": [owner_email]

--- a/python/mdvtools/dbutils/routes.py
+++ b/python/mdvtools/dbutils/routes.py
@@ -1,6 +1,7 @@
 import os
 from typing import Any
 from mdvtools.logging_config import get_logger
+from mdvtools.mdvproject import get_unwritable_project_paths
 logger = get_logger(__name__)
 
 # Module-level constants and functions that can be imported
@@ -8,13 +9,32 @@ REQUIRED_FILES = {"views.json", "state.json", "datasources.json"}
 
 
 def register_routes(app, ENABLE_AUTH):
-    from flask import abort, jsonify, session, redirect, url_for, render_template, send_file
+    """Register routes with the Flask app."""
+    from flask import abort, jsonify, session, render_template, send_file
     from mdvtools.auth.authutils import active_projects_cache, user_project_cache, all_users_cache, cache_user_projects
     from mdvtools.dbutils.mdv_server_app import serve_projects_from_filesystem
     from mdvtools.dbutils.dbmodels import User
     from mdvtools.dbutils.dbservice import ProjectService, UserProjectService
-    
-    """Register routes with the Flask app."""
+
+    def project_is_writable(project_data: dict[str, Any]) -> bool:
+        project_path = project_data.get("path")
+        if not project_path:
+            logger.warning(
+                "Cannot determine filesystem writability for project %s because "
+                "its path is missing from the project cache",
+                project_data.get("id"),
+            )
+            return False
+        try:
+            return not get_unwritable_project_paths(project_path)
+        except Exception:
+            logger.exception(
+                "Cannot determine filesystem writability for project %s at '%s'",
+                project_data.get("id"),
+                project_path,
+            )
+            return False
+
     logger.info("Registering routes...")
     # Note: Project management routes (create, import, export, delete, rename, access, share)
     # are now handled by the ProjectManagerExtension
@@ -113,6 +133,7 @@ def register_routes(app, ENABLE_AUTH):
             try:
                 # Serve the projects after checking authentication and admin privileges
                 created_ids = serve_projects_from_filesystem(app, app.config["projects_base_dir"])
+                unwritable_projects = []
 
                 # Keep rescanned projects consistent with Auth0 startup sync:
                 # every administrator owns every newly discovered project.
@@ -129,20 +150,30 @@ def register_routes(app, ENABLE_AUTH):
                         cache_user_projects()
                     except Exception as perm_e:
                         logger.exception(f"Error assigning permissions for new projects {created_ids}: {perm_e}")
+
+                for project_id in created_ids:
+                    project = ProjectService.get_project_by_id(project_id)
+                    if project is None:
+                        continue
+                    project_data = {
+                        "id": project.id,
+                        "name": project.name,
+                        "path": project.path,
+                    }
+                    if not project_is_writable(project_data):
+                        unwritable_projects.append({
+                            "id": project.id,
+                            "name": project.name,
+                        })
             except Exception as e:
                 # Handle potential errors while serving the projects
                 logger.exception(f"Error while serving the projects: {e}")
                 abort(500, description="Error while serving the projects.")
 
-            # If everything goes well, redirect to the 'index' page
-            # Check for MDV_API_ROOT environment variable
-            mdv_api_root = os.getenv('MDV_API_ROOT')
-            if mdv_api_root:
-                logger.info(f"Redirecting to MDV_API_ROOT: {mdv_api_root}")
-                return redirect(mdv_api_root)
-            else:
-                logger.info("MDV_API_ROOT not set, redirecting to index")
-                return redirect(url_for("index"))
+            return jsonify({
+                "created_project_ids": created_ids,
+                "unwritable_projects": unwritable_projects,
+            })
         
         def get_project_owners(project_id):
             owners = []
@@ -195,6 +226,7 @@ def register_routes(app, ENABLE_AUTH):
                             "permissions": user_projects[p["id"]],
                             "owner": get_project_owners(p["id"]),
                             "readme": p.get("readme"),
+                            "writable": project_is_writable(p),
                         }
                         for p in active_projects
                         if p["id"] in allowed_project_ids
@@ -210,6 +242,7 @@ def register_routes(app, ENABLE_AUTH):
                             "permissions": None,
                             "owner": [],
                             "readme": p.get("readme"),
+                            "writable": project_is_writable(p),
                         }
                         for p in active_projects
                     ]

--- a/python/mdvtools/dbutils/test/unit/test_mdv_server_app.py
+++ b/python/mdvtools/dbutils/test/unit/test_mdv_server_app.py
@@ -4,6 +4,7 @@ import os
 import tempfile
 import shutil
 import json
+from types import SimpleNamespace
 from sqlalchemy.exc import OperationalError
 from flask import Flask
 from mdvtools.dbutils.mdv_server_app import (
@@ -672,16 +673,57 @@ class TestServeProjectsFromFilesystem(unittest.TestCase):
 
 
 class TestRescanProjectPermissions(unittest.TestCase):
+    @patch(
+        "mdvtools.dbutils.mdv_server_app.serve_projects_from_filesystem",
+        return_value=[10],
+    )
+    @patch("mdvtools.dbutils.routes.get_unwritable_project_paths")
+    @patch("mdvtools.dbutils.dbservice.ProjectService.get_project_by_id")
+    def test_rescan_reports_registered_unwritable_projects(
+        self,
+        mock_get_project,
+        mock_unwritable_paths,
+        _mock_serve_projects,
+    ):
+        app = Flask(__name__)
+        app.config["projects_base_dir"] = "/tmp/mdv"
+        mock_get_project.return_value = SimpleNamespace(
+            id=10,
+            name="read-only-project",
+            path="/tmp/mdv/read-only-project",
+        )
+        mock_unwritable_paths.return_value = [
+            "/tmp/mdv/read-only-project/state.json",
+        ]
+        register_routes(app, ENABLE_AUTH=False)
+
+        response = app.test_client().get("/rescan_projects")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.get_json(),
+            {
+                "created_project_ids": [10],
+                "unwritable_projects": [
+                    {"id": 10, "name": "read-only-project"},
+                ],
+            },
+        )
+
     @patch("mdvtools.auth.authutils.cache_user_projects")
     @patch("mdvtools.dbutils.dbservice.UserProjectService.add_or_update_user_project")
     @patch(
         "mdvtools.dbutils.mdv_server_app.serve_projects_from_filesystem",
         return_value=[10, 11],
     )
+    @patch("mdvtools.dbutils.routes.get_unwritable_project_paths")
+    @patch("mdvtools.dbutils.dbservice.ProjectService.get_project_by_id")
     @patch("mdvtools.dbutils.dbmodels.User")
     def test_rescan_grants_every_admin_ownership(
         self,
         mock_user,
+        mock_get_project,
+        mock_unwritable_paths,
         mock_serve_projects,
         mock_add_user_project,
         mock_cache_user_projects,
@@ -693,6 +735,11 @@ class TestRescanProjectPermissions(unittest.TestCase):
             MagicMock(id=1),
             MagicMock(id=2),
         ]
+        mock_get_project.side_effect = [
+            SimpleNamespace(id=10, name="project-10", path="/tmp/mdv/project-10"),
+            SimpleNamespace(id=11, name="project-11", path="/tmp/mdv/project-11"),
+        ]
+        mock_unwritable_paths.return_value = []
         register_routes(app, ENABLE_AUTH=True)
 
         client = app.test_client()
@@ -701,7 +748,14 @@ class TestRescanProjectPermissions(unittest.TestCase):
 
         response = client.get("/rescan_projects")
 
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.get_json(),
+            {
+                "created_project_ids": [10, 11],
+                "unwritable_projects": [],
+            },
+        )
         mock_serve_projects.assert_called_once_with(app, "/tmp/mdv")
         mock_user.query.filter_by.assert_called_once_with(is_admin=True)
         self.assertEqual(
@@ -721,10 +775,14 @@ class TestRescanProjectPermissions(unittest.TestCase):
         "mdvtools.dbutils.mdv_server_app.serve_projects_from_filesystem",
         return_value=[],
     )
+    @patch("mdvtools.dbutils.routes.get_unwritable_project_paths")
+    @patch("mdvtools.dbutils.dbservice.ProjectService.get_project_by_id")
     @patch("mdvtools.dbutils.dbmodels.User")
     def test_rescan_without_new_projects_does_not_change_permissions(
         self,
         mock_user,
+        mock_get_project,
+        mock_unwritable_paths,
         _mock_serve_projects,
         mock_add_user_project,
         mock_cache_user_projects,
@@ -740,10 +798,52 @@ class TestRescanProjectPermissions(unittest.TestCase):
 
         response = client.get("/rescan_projects")
 
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.get_json(),
+            {
+                "created_project_ids": [],
+                "unwritable_projects": [],
+            },
+        )
         mock_user.query.filter_by.assert_not_called()
+        mock_get_project.assert_not_called()
+        mock_unwritable_paths.assert_not_called()
         mock_add_user_project.assert_not_called()
         mock_cache_user_projects.assert_not_called()
+
+
+class TestProjectListWritability(unittest.TestCase):
+    @patch("mdvtools.dbutils.routes.get_unwritable_project_paths")
+    @patch("mdvtools.dbutils.dbservice.ProjectService.get_active_projects")
+    def test_projects_reports_live_filesystem_writability(
+        self,
+        mock_get_active_projects,
+        mock_unwritable_paths,
+    ):
+        app = Flask(__name__)
+        mock_get_active_projects.return_value = [
+            {
+                "id": 10,
+                "name": "read-only-project",
+                "path": "/tmp/mdv/read-only-project",
+                "lastModified": "2026-09-03 12:00:00",
+                "thumbnail": None,
+                "readme": None,
+            },
+        ]
+        mock_unwritable_paths.return_value = [
+            "/tmp/mdv/read-only-project/state.json",
+        ]
+        register_routes(app, ENABLE_AUTH=False)
+
+        response = app.test_client().get("/projects")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.get_json()[0]["writable"])
+        mock_unwritable_paths.assert_called_once_with(
+            "/tmp/mdv/read-only-project",
+        )
 
 
 class TestCreateFlaskApp(unittest.TestCase):

--- a/python/mdvtools/mdvproject.py
+++ b/python/mdvtools/mdvproject.py
@@ -39,11 +39,16 @@ def get_unwritable_project_paths(project_dir: str) -> list[str]:
     """Return project paths the current process cannot modify as required."""
     statefile = join(project_dir, "state.json")
     viewsfile = join(project_dir, "views.json")
+    datasourcesfile = join(project_dir, "datasources.json")
     h5file = join(project_dir, "datafile.h5")
+    # MDVProject.__init__ creates the directory and these three files, so they
+    # are always present. The h5 file only exists once the project has data,
+    # which is why it is checked separately below.
     required_access = (
         (statefile, os.W_OK),
         (project_dir, os.W_OK | os.X_OK),
         (viewsfile, os.W_OK),
+        (datasourcesfile, os.W_OK),
     )
     unwritable = [
         path for path, mode in required_access if not os.access(path, mode)

--- a/python/mdvtools/mdvproject.py
+++ b/python/mdvtools/mdvproject.py
@@ -35,6 +35,24 @@ from mdvtools.project_protocols import RowsAsColumnsLinkSource
 logger = get_logger(__name__)
 
 
+def get_unwritable_project_paths(project_dir: str) -> list[str]:
+    """Return project paths the current process cannot modify as required."""
+    statefile = join(project_dir, "state.json")
+    viewsfile = join(project_dir, "views.json")
+    h5file = join(project_dir, "datafile.h5")
+    required_access = (
+        (statefile, os.W_OK),
+        (project_dir, os.W_OK | os.X_OK),
+        (viewsfile, os.W_OK),
+    )
+    unwritable = [
+        path for path, mode in required_access if not os.access(path, mode)
+    ]
+    if exists(h5file) and not os.access(h5file, os.W_OK):
+        unwritable.append(h5file)
+    return unwritable
+
+
 def _agent_debug_log(
     run_id: str,
     hypothesis_id: str,
@@ -211,23 +229,22 @@ class MDVProject:
                 o.write(json.dumps({"all_views": []}))
         self._lock = fasteners.InterProcessReaderWriterLock(join(dir, "lock"))
         self.backend_db = backend_db
+        self._writability_warning_logged = False
 
     @property
-    def writable(self):
+    def unwritable_paths(self):
         """
-        Determine whether the user running this process has write-permission on relevant files
+        List project paths the current process cannot modify as required.
+
         This is independent of any permissions set in db etc,
         but can be used to guard against inappropriate admin actions
         """
-        # check if project has a h5 file or write permissions, newly created project doesn't have a h5 file which blocks file upload
-        h5_writable_or_not_created = (not exists(self.h5file)) or os.access(self.h5file, os.W_OK)
-        return (
-            # belt and braces
-            os.access(self.statefile, os.W_OK)
-            and os.access(self.dir, os.W_OK | os.X_OK)
-            and os.access(self.viewsfile, os.W_OK)
-            and h5_writable_or_not_created
-        )
+        return get_unwritable_project_paths(self.dir)
+
+    @property
+    def writable(self):
+        """Whether the current process can modify all required project paths."""
+        return not self.unwritable_paths
 
     @property
     def datasources(self):
@@ -263,8 +280,15 @@ class MDVProject:
         save_json(self.statefile, value ,self.safe_file_save)
 
     def set_editable(self, edit=True):
-        if not self.writable:
-            logger.log(1, f"can't set_editable on '{self.dir}' because it's not writable")
+        unwritable_paths = self.unwritable_paths
+        if unwritable_paths:
+            logger.warning(
+                "Cannot set project '%s' editable state because the process lacks "
+                "write access to these paths (the project directory also requires "
+                "execute access): %s",
+                self.dir,
+                ", ".join(unwritable_paths),
+            )
             return
         c = self.state
         c["permission"] = "edit" if edit else "view"

--- a/python/mdvtools/server.py
+++ b/python/mdvtools/server.py
@@ -54,6 +54,27 @@ logger.info("server.py module loaded")
 routes = set()
 
 
+def _apply_project_writability(
+    project: MDVProject,
+    state: dict,
+    websocket_enabled: bool,
+) -> None:
+    unwritable_paths = project.unwritable_paths
+    if unwritable_paths:
+        if not project._writability_warning_logged:
+            logger.warning(
+                "[%s - '%s'] Serving project read-only because the process "
+                "lacks write access to these paths (the project directory also "
+                "requires execute access): %s",
+                project.id,
+                os.path.basename(project.dir),
+                ", ".join(unwritable_paths),
+            )
+            project._writability_warning_logged = True
+        state["permission"] = "view"
+    state["websocket"] = not unwritable_paths and websocket_enabled
+
+
 
 
 
@@ -201,11 +222,7 @@ def create_app(
                 try:
                     state = json.load(f)
                     # if we don't have write-permission, then we definitely shouldn't allow `permission: "edit"` to get to the frontend
-                    if not project.writable:
-                        log("overriding editable permission because state is not writable")
-                        state["permission"] = "view"
-                    # do we want this to always be true/not a flag we pass?
-                    state["websocket"] = project.writable and options.websocket
+                    _apply_project_writability(project, state, options.websocket)
                     # in future, we could iterate over a list of extensions.
                     # we should alter permissions based on the permission of the user...
                     for extension in options.extensions:

--- a/python/mdvtools/tests/test_project_writability.py
+++ b/python/mdvtools/tests/test_project_writability.py
@@ -1,0 +1,76 @@
+import logging
+import os
+
+from mdvtools.mdvproject import MDVProject
+from mdvtools.server import _apply_project_writability
+
+
+def test_unwritable_paths_names_every_failed_access_check(tmp_path, monkeypatch):
+    project = MDVProject(str(tmp_path / "project"))
+    with open(project.h5file, "wb"):
+        pass
+
+    blocked_paths = {
+        project.statefile,
+        project.dir,
+        project.viewsfile,
+        project.h5file,
+    }
+    monkeypatch.setattr(
+        os,
+        "access",
+        lambda path, _mode: path not in blocked_paths,
+    )
+
+    assert project.unwritable_paths == [
+        project.statefile,
+        project.dir,
+        project.viewsfile,
+        project.h5file,
+    ]
+    assert not project.writable
+
+
+def test_set_editable_warns_with_failed_paths(tmp_path, monkeypatch, caplog):
+    project = MDVProject(str(tmp_path / "project"))
+    monkeypatch.setattr(
+        MDVProject,
+        "unwritable_paths",
+        property(lambda self: [self.statefile, self.viewsfile]),
+    )
+    caplog.set_level(logging.WARNING, logger="mdvtools.mdvproject")
+
+    project.set_editable()
+
+    assert "Cannot set project" in caplog.text
+    assert project.statefile in caplog.text
+    assert project.viewsfile in caplog.text
+
+
+def test_state_writability_warns_once_and_serves_view_permission(
+    tmp_path,
+    monkeypatch,
+    caplog,
+):
+    project = MDVProject(str(tmp_path / "project"), id="7")
+    monkeypatch.setattr(
+        MDVProject,
+        "unwritable_paths",
+        property(lambda self: [self.statefile]),
+    )
+    caplog.set_level(logging.WARNING, logger="mdvtools.server")
+    first_state = {"permission": "edit"}
+    second_state = {"permission": "edit"}
+
+    _apply_project_writability(project, first_state, websocket_enabled=True)
+    _apply_project_writability(project, second_state, websocket_enabled=True)
+
+    assert first_state == {"permission": "view", "websocket": False}
+    assert second_state == {"permission": "view", "websocket": False}
+    warnings = [
+        record
+        for record in caplog.records
+        if "Serving project read-only" in record.getMessage()
+    ]
+    assert len(warnings) == 1
+    assert project.statefile in warnings[0].getMessage()

--- a/python/mdvtools/tests/test_project_writability.py
+++ b/python/mdvtools/tests/test_project_writability.py
@@ -14,6 +14,7 @@ def test_unwritable_paths_names_every_failed_access_check(tmp_path, monkeypatch)
         project.statefile,
         project.dir,
         project.viewsfile,
+        project.datasourcesfile,
         project.h5file,
     }
     monkeypatch.setattr(
@@ -26,8 +27,31 @@ def test_unwritable_paths_names_every_failed_access_check(tmp_path, monkeypatch)
         project.statefile,
         project.dir,
         project.viewsfile,
+        project.datasourcesfile,
         project.h5file,
     ]
+    assert not project.writable
+
+
+def test_unwritable_datasources_file_alone_makes_a_project_unwritable(
+    tmp_path,
+    monkeypatch,
+):
+    """A read-only datasources.json is enough to make the project unwritable.
+
+    The datasources setter writes that file, so a project the server called
+    editable on the strength of the other paths would fail partway through:
+    add_datasource writes datafile.h5 first and only then persists the
+    metadata, leaving the h5 file changed and datasources.json stale.
+    """
+    project = MDVProject(str(tmp_path / "project"))
+    monkeypatch.setattr(
+        os,
+        "access",
+        lambda path, _mode: path != project.datasourcesfile,
+    )
+
+    assert project.unwritable_paths == [project.datasourcesfile]
     assert not project.writable
 
 

--- a/src/catalog/Dashboard.tsx
+++ b/src/catalog/Dashboard.tsx
@@ -68,8 +68,10 @@ const Dashboard: React.FC = () => {
         projects,
         isLoading: projectsLoading,
         error,
+        rescanWarning,
         isErrorModalOpen,
         closeErrorModal,
+        clearRescanWarning,
         fetchProjects,
         createProject,
         deleteProject,
@@ -282,6 +284,15 @@ const Dashboard: React.FC = () => {
                             If your browser asks whether this site can communicate with local apps or devices, allow it for this preview:
                             the Netlify page is only the frontend, and project lists plus <code>/project/:id</code> data are loaded from your local MDV container.
                             No local data is sent to a remote server.
+                        </Alert>
+                    )}
+                    {rescanWarning && (
+                        <Alert
+                            severity="warning"
+                            onClose={clearRescanWarning}
+                            sx={{ mb: 3 }}
+                        >
+                            {rescanWarning}
                         </Alert>
                     )}
                     <Grid container spacing={3} sx={{ mb: 4 }}>

--- a/src/catalog/ProjectCard.tsx
+++ b/src/catalog/ProjectCard.tsx
@@ -8,12 +8,14 @@ import {
     Upload as UploadIcon,
     Settings,
     Share as ShareIcon,
+    WarningAmber,
 } from "@mui/icons-material";
 import {
     Card,
     CardContent,
     CardMedia,
     Checkbox,
+    Chip,
     Divider,
     IconButton,
     ListItemIcon,
@@ -46,6 +48,7 @@ export interface ProjectCardProps {
     numberOfStructures: string;
     numberOfImages: string;
     permissions: Permissions;
+    writable: boolean;
     onDelete: (id: string) => Promise<void>;
     onRename: (id: string, newName: string) => Promise<void>;
     onChangeType: (
@@ -67,6 +70,7 @@ const ProjectCard: React.FC<ProjectCardProps> = ({
     type,
     lastModified,
     permissions,
+    writable,
     onDelete,
     onRename,
     onChangeType,
@@ -211,6 +215,17 @@ const ProjectCard: React.FC<ProjectCardProps> = ({
                             {name}
                         </Typography>
                     </Tooltip>
+                    {!isPublicPage && !writable && (
+                        <Tooltip title="The MDV server cannot write this project's files. It will open read-only.">
+                            <Chip
+                                icon={<WarningAmber />}
+                                label="Server read-only"
+                                color="warning"
+                                size="small"
+                                sx={{ alignSelf: "flex-start", mb: 1 }}
+                            />
+                        </Tooltip>
+                    )}
                     {!isPublicPage && (
                         <Typography
                             variant="body2"

--- a/src/catalog/ProjectListView.tsx
+++ b/src/catalog/ProjectListView.tsx
@@ -6,7 +6,8 @@ import {
     LockPerson,
     MoreVert,
     Upload as UploadIcon,
-    Share as ShareIcon
+    Share as ShareIcon,
+    WarningAmber,
 } from "@mui/icons-material";
 import {
     Checkbox,
@@ -22,6 +23,7 @@ import {
     TableContainer,
     TableHead,
     TableRow,
+    Tooltip,
     Typography,
     useTheme,
 } from "@mui/material";
@@ -98,6 +100,7 @@ const ProjectListView = ({ projects, onDelete, onRename, onExport, onChangeType,
                             <TableCell>Owner</TableCell>
                             {!isPublicPage && <TableCell>Last Modified</TableCell>}
                             <TableCell>Type</TableCell>
+                            {!isPublicPage && <TableCell>Filesystem</TableCell>}
                             <TableCell align="right">Actions</TableCell>
                         </TableRow>
                     </TableHead>
@@ -135,6 +138,24 @@ const ProjectListView = ({ projects, onDelete, onRename, onExport, onChangeType,
                                 <TableCell>{project.owner ? project.owner.join(', ') : ''}</TableCell>
                                 {!isPublicPage && <TableCell>{project.lastModified}</TableCell>}
                                 <TableCell>{project.type}</TableCell>
+                                {!isPublicPage && (
+                                    <TableCell>
+                                        {project.writable ? (
+                                            "Writable"
+                                        ) : (
+                                            <Tooltip title="The MDV server cannot write this project's files. It will open read-only.">
+                                                <Typography
+                                                    component="span"
+                                                    color="warning.main"
+                                                    sx={{ display: "inline-flex", alignItems: "center", gap: 0.5 }}
+                                                >
+                                                    <WarningAmber fontSize="small" />
+                                                    Server read-only
+                                                </Typography>
+                                            </Tooltip>
+                                        )}
+                                    </TableCell>
+                                )}
                                 <TableCell align="right">
                                 {(hasReadme(project) || hasPermissions(project)) && 
                                     (

--- a/src/catalog/hooks/useProjects.ts
+++ b/src/catalog/hooks/useProjects.ts
@@ -9,10 +9,21 @@ import {
     restoreRecycledProjectResponseSchema,
 } from "../utils/projectSchemas";
 
+type RescannedProject = {
+    id: number;
+    name: string;
+};
+
+type RescanResponse = {
+    created_project_ids: number[];
+    unwritable_projects: RescannedProject[];
+};
+
 const useProjects = () => {
     const [projects, setProjects] = useState<Project[]>([]);
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
+    const [rescanWarning, setRescanWarning] = useState<string | null>(null);
     const [isErrorModalOpen, setIsErrorModalOpen] = useState(false);
     const [filter, setFilter] = useState("");
     const [sortBy, setSortBy] = useState<"lastModified" | "name">(
@@ -23,6 +34,10 @@ const useProjects = () => {
     const closeErrorModal = useCallback(() => {
         setIsErrorModalOpen(false);
         setError(null);
+    }, []);
+
+    const clearRescanWarning = useCallback(() => {
+        setRescanWarning(null);
     }, []);
 
     const handleError = useCallback((errorMessage: string) => {
@@ -59,6 +74,7 @@ const useProjects = () => {
                         : [],
                     numberOfStructures: item.numberOfStructures || "0",
                     numberOfImages: item.numberOfImages || "0",
+                    writable: item.writable !== false,
                     // Assigning all permissions as true if auth is not enabled
                     permissions: item?.permissions ? {
                                 read: item.permissions["can_read"],
@@ -123,6 +139,7 @@ const useProjects = () => {
                     collaborators: [],
                     numberOfStructures: "0",
                     numberOfImages: "0",
+                    writable: true,
                     permissions: {
                         read: true,
                         edit: true,
@@ -366,11 +383,20 @@ const useProjects = () => {
         async () => {
             setIsLoading(true);
             setError(null);
+            setRescanWarning(null);
 
             try {
                 const response = await apiFetch("rescan_projects");
                 if (response.ok) {
-                   console.log("Rescan successful");
+                   const result: RescanResponse = await response.json();
+                   if (result.unwritable_projects.length > 0) {
+                       const projectNames = result.unwritable_projects
+                           .map((project) => project.name)
+                           .join(", ");
+                       setRescanWarning(
+                           `Registered ${projectNames}, but the server cannot write the project files. These projects will open read-only.`,
+                       );
+                   }
                    // Refresh the project list so newly discovered projects appear (works with or without auth)
                    await fetchProjects();
                 } else {
@@ -530,6 +556,8 @@ const useProjects = () => {
         projects: filteredAndSortedProjects,
         isLoading,
         error,
+        rescanWarning,
+        clearRescanWarning,
         isErrorModalOpen,
         closeErrorModal,
         fetchProjects,

--- a/src/catalog/utils/projectUtils.ts
+++ b/src/catalog/utils/projectUtils.ts
@@ -18,6 +18,7 @@ export interface Project {
     numberOfStructures: string;
     numberOfImages: string;
     permissions: Permissions;
+    writable: boolean;
     thumbnail?: string;
     readme?: string;
 }

--- a/src/tests/catalog/ProjectCard.test.tsx
+++ b/src/tests/catalog/ProjectCard.test.tsx
@@ -1,0 +1,52 @@
+import ProjectCard, { type ProjectCardProps } from "@/catalog/ProjectCard";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("@/catalog/PermissionsContext", () => ({
+    default: () => ({
+        permissions: {
+            createProject: true,
+            importProject: true,
+            deleteProject: true,
+            renameProject: true,
+            changeProjectAccess: true,
+            exportProject: true,
+            shareProject: true,
+            editUserPermissions: true,
+            removeUserFromProject: true,
+        },
+        isPublicPage: false,
+    }),
+}));
+
+const commonProps: Omit<ProjectCardProps, "writable"> = {
+    id: "10",
+    name: "read-only-project",
+    type: "Editable",
+    lastModified: "2026-09-03 12:00:00",
+    createdAt: "",
+    owner: [],
+    collaborators: [],
+    numberOfStructures: "0",
+    numberOfImages: "0",
+    permissions: { read: true, edit: true, owner: true },
+    onDelete: vi.fn(async () => {}),
+    onRename: vi.fn(async () => {}),
+    onChangeType: vi.fn(async () => {}),
+    onAddCollaborator: vi.fn(),
+    onExport: vi.fn(async () => {}),
+};
+
+describe("ProjectCard filesystem writability", () => {
+    test("marks projects the server cannot write", () => {
+        render(<ProjectCard {...commonProps} writable={false} />);
+
+        expect(screen.getByText("Server read-only")).toBeDefined();
+    });
+
+    test("does not mark writable projects", () => {
+        render(<ProjectCard {...commonProps} writable />);
+
+        expect(screen.queryByText("Server read-only")).toBeNull();
+    });
+});

--- a/src/tests/catalog/useProjects.test.tsx
+++ b/src/tests/catalog/useProjects.test.tsx
@@ -1,0 +1,64 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const { apiFetchMock } = vi.hoisted(() => ({
+    apiFetchMock: vi.fn(),
+}));
+
+vi.mock("@/utils/mdvRouting", () => ({
+    apiFetch: apiFetchMock,
+    buildApiUrl: (path: string) => path,
+}));
+
+import useProjects from "@/catalog/hooks/useProjects";
+
+function jsonResponse(body: unknown) {
+    return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+    });
+}
+
+describe("useProjects writability", () => {
+    beforeEach(() => {
+        apiFetchMock.mockReset();
+    });
+
+    test("maps filesystem writability from the projects response", async () => {
+        apiFetchMock.mockResolvedValueOnce(
+            jsonResponse([
+                {
+                    id: 10,
+                    name: "read-only-project",
+                    writable: false,
+                },
+            ]),
+        );
+        const { result } = renderHook(() => useProjects());
+
+        await act(async () => {
+            await result.current.fetchProjects();
+        });
+
+        expect(result.current.projects[0].writable).toBe(false);
+    });
+
+    test("reports projects registered without write access", async () => {
+        apiFetchMock
+            .mockResolvedValueOnce(
+                jsonResponse({
+                    created_project_ids: [10],
+                    unwritable_projects: [{ id: 10, name: "read-only-project" }],
+                }),
+            )
+            .mockResolvedValueOnce(jsonResponse([]));
+        const { result } = renderHook(() => useProjects());
+
+        await act(async () => {
+            await result.current.rescanProjects();
+        });
+
+        expect(result.current.rescanWarning).toContain("read-only-project");
+        expect(result.current.rescanWarning).toContain("will open read-only");
+    });
+});


### PR DESCRIPTION
A project whose files the server cannot write is served read-only with no visible explanation. `state.json` still says `"permission": "edit"` and the database still has the project as editable, so the only trace is a single info-level log line buried in the boot output. Diagnosing this on our bia deployment took about a day.

The usual cause is copying a project into the `/app/mdv` volume as root. The container runs as uid 1000 and the image chowns `/app/mdv` to that user, but anything copied in afterwards keeps the ownership the copy gave it, so all four `os.access` checks in `MDVProject.writable` fail.

The override itself is right. If the process cannot write the files, showing edit controls would only move the failure to save time and produce an `EACCES`. The problem is that it happens silently.

## Log which project paths block write access

`MDVProject.writable` was a single boolean, so nothing said which of the four checks had failed. This adds an `unwritable_paths` property that names the failing paths and derives `writable` from it. The checks themselves are unchanged.

The `state.json` route now logs at warning level, names the project, and lists the paths it cannot write. It logs once per project rather than on every request. `set_editable` warns for the same reason instead of logging at level 1, which no standard handler emits. Every caller of `set_editable` is a boot, project creation or conversion path, so raising the level does not make the logs noisy.

## Surface unwritable projects in the catalog

`/projects` now returns a `writable` field, and projects the server cannot write are marked in both the card and the list view, so the state is visible without reading logs. Working out writability needs the project directory, so `path` is added to `get_all_projects` and to the two `update_cache` call sites that build project entries.

## One change reviewers should look at

`/rescan_projects` now returns JSON naming any project it registered but cannot write, so the dashboard can warn about it. This replaces the redirect the route used to return, so it is a change to the route contract.

The frontend hook is the only caller and it is updated here. The Playwright fixture calls the route but does not depend on the redirect, and the unit tests are updated. The `redirect` and `url_for` imports are no longer used and have been removed.

If you would rather keep that out of this PR, the first commit can go in alone and the catalog work can follow separately.

## Testing

45 Python tests pass, including a new `test_project_writability.py`, and 4 new frontend tests cover the card marker and the rescan warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Project listings now show whether each project’s files are writable.
  - Projects with restricted filesystem access open in read-only mode, with WebSocket editing disabled.
  - Read-only projects display warnings and explanations in project cards and listings.
  - Rescans report newly created projects and projects that cannot be written to.
  - Dismissible warnings appear when rescans detect restricted projects.
- **Bug Fixes**
  - Project filesystem paths are now retained during project registration and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->