### PR TITLE
Add onboard.sh and deploy_bia.sh for the bia sqlite instances

### DIFF
--- a/deploy_bia.sh
+++ b/deploy_bia.sh
@@ -1,0 +1,325 @@
+#!/usr/bin/env bash
+#
+# deploy_bia.sh - build the sqlite image locally and put it on the bia instances.
+#
+# Runs from a local machine over one multiplexed SSH connection, so you type
+# your password once.
+#
+# Why this exists: the manual sequence fails silently in two ways.
+#
+# The tag moves but the containers stay on the old image. `docker compose
+# images` then shows <none> against a stale ID and nothing reports an error, so
+# a deploy that changed nothing looks like a deploy that worked. This script
+# refuses to report success unless every container is running the image ID it
+# just loaded.
+#
+# An arm64 image takes all three instances down with an exec format error. The
+# architecture is checked here before anything is transferred, and again on bia
+# after the load.
+#
+# Not to be confused with ./deploy.sh, which does named deployments with
+# generated compose overrides and is unrelated to bia.
+
+set -euo pipefail
+
+COMPOSE_FILE=${MDV_COMPOSE_FILE:-/bia/admin_space/sqlite/docker-compose.sqlite-multi.yml}
+DEFAULT_SERVICES="mdv_sqlite_1 mdv_sqlite_2 mdv_sqlite_3"
+IMAGE=mdvadmin/mdv:sqlite
+PLATFORM=linux/amd64
+ARCH=amd64
+TARBALL=mdv-sqlite-amd64.tar.gz
+
+prog=$(basename "$0")
+here=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+
+die() { printf '%s: error: %s\n' "$prog" "$*" >&2; exit 1; }
+info() { printf '==> %s\n' "$*"; }
+warn() { printf 'warning: %s\n' "$*" >&2; }
+
+usage() {
+    cat <<EOF
+Usage: $prog [-B] [-k] <user@host> [service ...]
+
+Build $IMAGE for $PLATFORM, transfer it to bia, load it, recreate the named
+services, and prove the containers actually picked up the new image.
+
+Arguments:
+  user@host   ssh target, for example mshaikh@bia.cmd.ox.ac.uk
+  service     services to recreate (default: $DEFAULT_SERVICES)
+
+  Only the named services are recreated, so mdv_public is never swept up.
+
+Options:
+  -B  skip the build and reuse the $IMAGE already in the local docker
+  -k  keep the image tarball on both machines instead of deleting it
+  -h  show this help
+
+Environment:
+  MDV_COMPOSE_FILE  compose file on the server
+                    (default: $COMPOSE_FILE)
+
+Examples:
+  $prog mshaikh@bia.cmd.ox.ac.uk
+  $prog mshaikh@bia.cmd.ox.ac.uk mdv_sqlite_1
+  $prog -B mshaikh@bia.cmd.ox.ac.uk mdv_sqlite_1 mdv_sqlite_2
+EOF
+}
+
+skip_build=0
+keep=0
+while getopts ':Bkh' opt; do
+    case "$opt" in
+        B) skip_build=1 ;;
+        k) keep=1 ;;
+        h) usage; exit 0 ;;
+        :) die "option -$OPTARG needs an argument" ;;
+        \?) die "unknown option -$OPTARG (try -h)" ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+[ $# -ge 1 ] || { usage >&2; exit 2; }
+
+target=$1
+shift
+services=${*:-$DEFAULT_SERVICES}
+
+case "$target" in
+    ?*@?*) ;;
+    *) die "target must look like user@host, got '$target'" ;;
+esac
+
+for svc in $services; do
+    case "$svc" in
+        mdv_public) die "refusing to recreate mdv_public" ;;
+        *[!A-Za-z0-9._-]*) die "invalid service name: '$svc'" ;;
+    esac
+done
+
+command -v docker >/dev/null || die "docker is not installed"
+docker info >/dev/null 2>&1 || die "the docker daemon is not running"
+command -v rsync >/dev/null || die "rsync is not installed"
+
+tarball="${TMPDIR:-/tmp}/$TARBALL"
+sock=$(mktemp -u "${TMPDIR:-/tmp}/mdv-ssh-XXXXXX")
+
+cleanup() {
+    if [ "$keep" -eq 0 ] && [ -f "$tarball" ]; then
+        rm -f "$tarball"
+    fi
+    [ -S "$sock" ] && ssh -S "$sock" -O exit "$target" >/dev/null 2>&1
+    return 0
+}
+trap cleanup EXIT
+
+# --- build -----------------------------------------------------------------
+
+if [ "$skip_build" -eq 0 ]; then
+    info "building $IMAGE for $PLATFORM (this takes a while)"
+    docker build --platform "$PLATFORM" -t "$IMAGE" "$here" \
+        || die "the build failed"
+else
+    info "skipping the build, using the local $IMAGE"
+    docker image inspect "$IMAGE" >/dev/null 2>&1 \
+        || die "$IMAGE is not in the local docker, so -B has nothing to reuse"
+fi
+
+# An arm64 image starts, then dies with an exec format error, and it takes
+# every instance down with it. Catch it before spending time on a 2GB transfer.
+built_arch=$(docker image inspect --format '{{.Architecture}}' "$IMAGE")
+[ "$built_arch" = "$ARCH" ] || die "$IMAGE is $built_arch, not $ARCH.
+Rebuild it with:  docker build --platform $PLATFORM -t $IMAGE ."
+
+built_id=$(docker image inspect --format '{{.Id}}' "$IMAGE")
+info "built $ARCH image ${built_id#sha256:}"
+
+# --- save ------------------------------------------------------------------
+
+info "saving and compressing to $tarball"
+docker save "$IMAGE" | gzip > "$tarball" || die "docker save failed"
+
+local_sum=$(shasum -a 256 "$tarball" | cut -d' ' -f1)
+info "$(du -h "$tarball" | cut -f1), sha256 ${local_sum:0:16}..."
+
+# --- connect ---------------------------------------------------------------
+
+info "connecting to $target"
+ssh -f -N -M -S "$sock" -o ControlPersist=60 "$target" \
+    || die "could not open an ssh connection to $target"
+
+remote() { ssh -S "$sock" "$target" "$@"; }
+
+remote "command -v docker >/dev/null" || die "docker is not available on $target"
+remote "test -f '$COMPOSE_FILE'" \
+    || die "no compose file at $COMPOSE_FILE on $target
+Point somewhere else with:  MDV_COMPOSE_FILE=... $prog $target"
+
+# --- transfer --------------------------------------------------------------
+
+# --partial --inplace so an interrupted 2GB transfer resumes rather than
+# starting over. The tarball lands in the home directory; docker load does not
+# care where the file sits, and the compose directory may not be writable.
+info "transferring to $target:~/$TARBALL"
+rsync -avP --partial --inplace -e "ssh -S $sock" "$tarball" "$target:$TARBALL" \
+    || die "the transfer failed"
+
+remote_sum=$(remote "sha256sum '$TARBALL' | cut -d' ' -f1")
+if [ "$local_sum" != "$remote_sum" ]; then
+    die "checksum mismatch after transfer.
+  local   $local_sum
+  remote  $remote_sum
+Delete ~/$TARBALL on $target and run this again."
+fi
+info "checksum matches"
+
+# --- record what the containers run now ------------------------------------
+
+info "recording the current image of each service"
+before=$(remote bash -s -- "$COMPOSE_FILE" $services <<'REMOTE'
+set -euo pipefail
+compose=$1; shift
+cd "$(dirname "$compose")"
+for svc in "$@"; do
+    # || true because compose exits non-zero on an unknown service, and under
+    # set -e that would kill the block before the fallback below runs.
+    cid=$(docker compose -f "$compose" ps -q "$svc" 2>/dev/null | head -1 || true)
+    # Fall back to the container name, which is how the bia compose file names
+    # these, in case the compose project name is not derived from the directory.
+    [ -n "$cid" ] || cid=$(docker ps --filter "name=^${svc}$" --format '{{.ID}}' | head -1)
+    if [ -n "$cid" ]; then
+        echo "$svc=$(docker inspect -f '{{.Image}}' "$cid")"
+    else
+        echo "$svc="
+    fi
+done
+REMOTE
+) || die "could not inspect the running services on $target"
+
+printf '%s\n' "$before" | sed 's/^/    /'
+
+# --- load ------------------------------------------------------------------
+
+info "loading the image on $target"
+loaded_id=$(remote bash -s -- "$TARBALL" "$IMAGE" "$ARCH" <<'REMOTE'
+set -euo pipefail
+tarball=$1; image=$2; want_arch=$3
+
+gunzip -c "$tarball" | docker load >&2
+
+arch=$(docker image inspect --format '{{.Architecture}}' "$image")
+if [ "$arch" != "$want_arch" ]; then
+    echo "loaded image is $arch, not $want_arch" >&2
+    exit 1
+fi
+docker image inspect --format '{{.Id}}' "$image"
+REMOTE
+) || die "docker load failed on $target"
+
+info "loaded ${loaded_id#sha256:}"
+
+if [ "$loaded_id" != "$built_id" ]; then
+    warn "the image ID on $target does not match the one built here.
+  built   $built_id
+  loaded  $loaded_id
+This is expected only if something else rebuilt or retagged $IMAGE."
+fi
+
+# --- recreate --------------------------------------------------------------
+
+# The compose file sets pull_policy: never, so the load above is what makes
+# this possible. Only the named services are passed, so nothing else restarts.
+info "recreating: $services"
+remote bash -s -- "$COMPOSE_FILE" $services <<'REMOTE'
+set -euo pipefail
+compose=$1; shift
+cd "$(dirname "$compose")"
+docker compose -f "$compose" up -d --force-recreate "$@"
+REMOTE
+
+# --- prove the containers actually moved -----------------------------------
+
+info "checking that the containers picked up the new image"
+after=$(remote bash -s -- "$COMPOSE_FILE" $services <<'REMOTE'
+set -euo pipefail
+compose=$1; shift
+cd "$(dirname "$compose")"
+for svc in "$@"; do
+    # || true because compose exits non-zero on an unknown service, and under
+    # set -e that would kill the block before the fallback below runs.
+    cid=$(docker compose -f "$compose" ps -q "$svc" 2>/dev/null | head -1 || true)
+    # Fall back to the container name, which is how the bia compose file names
+    # these, in case the compose project name is not derived from the directory.
+    [ -n "$cid" ] || cid=$(docker ps --filter "name=^${svc}$" --format '{{.ID}}' | head -1)
+    if [ -n "$cid" ]; then
+        echo "$svc=$(docker inspect -f '{{.Image}}' "$cid")"
+    else
+        echo "$svc="
+    fi
+done
+REMOTE
+) || die "could not inspect the running services on $target"
+
+stale=""
+for svc in $services; do
+    running=$(printf '%s\n' "$after" | sed -n "s/^${svc}=//p")
+    was=$(printf '%s\n' "$before" | sed -n "s/^${svc}=//p")
+    if [ -z "$running" ]; then
+        stale="$stale $svc(not running)"
+    elif [ "$running" != "$loaded_id" ]; then
+        stale="$stale $svc"
+    fi
+    printf '    %-16s %s -> %s\n' "$svc" "${was:-none}" "${running:-none}" \
+        | sed 's/sha256://g'
+done
+
+if [ -n "$stale" ]; then
+    die "these services are not running the image just loaded:$stale
+The tag moved but the containers did not. Check for a failed start with:
+  ssh $target docker compose -f $COMPOSE_FILE ps"
+fi
+info "every service is on ${loaded_id#sha256:}"
+
+# --- check the startup sync ------------------------------------------------
+
+# RUN_AUTH0_SYNC_ON_START going missing is silent: the container comes up fine
+# and the caches quietly go stale.
+info "checking the Auth0 startup sync"
+sync_report=$(remote bash -s -- "$COMPOSE_FILE" $services <<'REMOTE'
+set -euo pipefail
+compose=$1; shift
+cd "$(dirname "$compose")"
+for svc in "$@"; do
+    # || true because compose exits non-zero on an unknown service, and under
+    # set -e that would kill the block before the fallback below runs.
+    cid=$(docker compose -f "$compose" ps -q "$svc" 2>/dev/null | head -1 || true)
+    # Fall back to the container name, which is how the bia compose file names
+    # these, in case the compose project name is not derived from the directory.
+    [ -n "$cid" ] || cid=$(docker ps --filter "name=^${svc}$" --format '{{.ID}}' | head -1)
+    [ -n "$cid" ] || { echo "$svc: not running"; continue; }
+    flag=$(docker exec "$cid" printenv RUN_AUTH0_SYNC_ON_START 2>/dev/null || true)
+    line=$(docker logs "$cid" 2>&1 \
+        | grep -iE "sync on startup|syncing users|sync complete|sync failed" \
+        | tail -1 || true)
+    echo "$svc: RUN_AUTH0_SYNC_ON_START=${flag:-unset} ${line:+| $line}"
+done
+REMOTE
+) || warn "could not read the sync state"
+
+printf '%s\n' "$sync_report" | sed 's/^/    /'
+
+case "$sync_report" in
+    *"RUN_AUTH0_SYNC_ON_START=unset"*)
+        warn "the startup sync flag is not set on at least one service.
+It lives in the .env.sqlite_N files next to $COMPOSE_FILE. Without it the user
+caches go stale and new Auth0 users never appear." ;;
+esac
+
+# --- tidy up ---------------------------------------------------------------
+
+if [ "$keep" -eq 0 ]; then
+    remote "rm -f '$TARBALL'" || warn "could not remove ~/$TARBALL on $target"
+else
+    info "kept $tarball and $target:~/$TARBALL"
+fi
+
+printf '\n%s deployed to %s on %s.\n' "$IMAGE" "$services" "$target"

--- a/deploy_bia.sh
+++ b/deploy_bia.sh
@@ -130,8 +130,13 @@ built_arch=$(docker image inspect --format '{{.Architecture}}' "$IMAGE")
 [ "$built_arch" = "$ARCH" ] || die "$IMAGE is $built_arch, not $ARCH.
 Rebuild it with:  docker build --platform $PLATFORM -t $IMAGE ."
 
+# Local and remote image IDs are not comparable, so this one is printed for
+# the record and never checked against the ID bia reports. Docker Desktop's
+# containerd image store reports the OCI image index digest as .Id, while a
+# classic daemon reports the image config digest. Both describe the same image
+# and the two digests are always different.
 built_id=$(docker image inspect --format '{{.Id}}' "$IMAGE")
-info "built $ARCH image ${built_id#sha256:}"
+info "local $ARCH image ${built_id#sha256:}"
 
 # --- save ------------------------------------------------------------------
 
@@ -230,17 +235,28 @@ docker image inspect --format '{{.Id}}' "$image"
 REMOTE
 ) || die "docker load failed on $target"
 
-info "loaded ${loaded_id#sha256:}"
+info "loaded on $target as ${loaded_id#sha256:}"
 
-if [ "$loaded_id" != "$built_id" ]; then
-    die "the image now tagged $IMAGE on $target is not the one built here.
-  built   $built_id
-  loaded  $loaded_id
-docker load preserves the image ID, so these differ only if something retagged
-$IMAGE on $target between the load and this check. The final check compares the
-containers against the loaded ID, so carrying on would deploy that other image
-and then call it a success. Nothing has been recreated. Find out what moved the
-tag, then run this again."
+# That the tarball arrived intact is already established by the checksum above,
+# and every check from here on compares against the ID bia gave the image it
+# just loaded, so the local ID is not needed again.
+
+# Deploying an image bia already has is a normal use of -B, but the run changes
+# nothing and the final check would pass in a way that reads like a fresh
+# deploy. Say so instead.
+unchanged=yes
+for svc in $services; do
+    was=$(printf '%s\n' "$before" | sed -n "s/^${svc}=//p")
+    if [ "$was" != "$loaded_id" ]; then
+        unchanged=""
+        break
+    fi
+done
+if [ -n "$unchanged" ]; then
+    warn "every named service is already running this image, so this deploy
+moves nothing. The containers below are recreated on the image they were
+already on. If you expected new code, the local $IMAGE is stale: drop -B and
+let it rebuild."
 fi
 
 # --- recreate --------------------------------------------------------------

--- a/deploy_bia.sh
+++ b/deploy_bia.sh
@@ -147,10 +147,25 @@ info "connecting to $target"
 ssh -f -N -M -S "$sock" -o ControlPersist=60 "$target" \
     || die "could not open an ssh connection to $target"
 
-remote() { ssh -S "$sock" "$target" "$@"; }
+# ssh joins the command arguments it is given into one string and hands that
+# string to the remote login shell, so anything left unquoted here is shell
+# syntax on bia rather than data. MDV_COMPOSE_FILE comes from the environment
+# and reaches several remote blocks, so it is quoted like everything else.
+shquote() {
+    local arg quoted=""
+    for arg in "$@"; do
+        quoted="$quoted '${arg//\'/\'\\\'\'}'"
+    done
+    printf '%s' "${quoted# }"
+}
 
-remote "command -v docker >/dev/null" || die "docker is not available on $target"
-remote "test -f '$COMPOSE_FILE'" \
+# Takes a command and its arguments, never a shell snippet. Anything needing a
+# pipeline or a redirection goes through an explicit sh -c with its own quoting.
+remote() { ssh -S "$sock" "$target" "$(shquote "$@")"; }
+
+remote sh -c 'command -v docker >/dev/null' \
+    || die "docker is not available on $target"
+remote test -f "$COMPOSE_FILE" \
     || die "no compose file at $COMPOSE_FILE on $target
 Point somewhere else with:  MDV_COMPOSE_FILE=... $prog $target"
 
@@ -163,7 +178,7 @@ info "transferring to $target:~/$TARBALL"
 rsync -avP --partial --inplace -e "ssh -S $sock" "$tarball" "$target:$TARBALL" \
     || die "the transfer failed"
 
-remote_sum=$(remote "sha256sum '$TARBALL' | cut -d' ' -f1")
+remote_sum=$(remote sh -c 'sha256sum "$1" | cut -d" " -f1' sh "$TARBALL")
 if [ "$local_sum" != "$remote_sum" ]; then
     die "checksum mismatch after transfer.
   local   $local_sum
@@ -218,10 +233,14 @@ REMOTE
 info "loaded ${loaded_id#sha256:}"
 
 if [ "$loaded_id" != "$built_id" ]; then
-    warn "the image ID on $target does not match the one built here.
+    die "the image now tagged $IMAGE on $target is not the one built here.
   built   $built_id
   loaded  $loaded_id
-This is expected only if something else rebuilt or retagged $IMAGE."
+docker load preserves the image ID, so these differ only if something retagged
+$IMAGE on $target between the load and this check. The final check compares the
+containers against the loaded ID, so carrying on would deploy that other image
+and then call it a success. Nothing has been recreated. Find out what moved the
+tag, then run this again."
 fi
 
 # --- recreate --------------------------------------------------------------
@@ -317,7 +336,7 @@ esac
 # --- tidy up ---------------------------------------------------------------
 
 if [ "$keep" -eq 0 ]; then
-    remote "rm -f '$TARBALL'" || warn "could not remove ~/$TARBALL on $target"
+    remote rm -f "$TARBALL" || warn "could not remove ~/$TARBALL on $target"
 else
     info "kept $tarball and $target:~/$TARBALL"
 fi

--- a/onboard.sh
+++ b/onboard.sh
@@ -6,15 +6,7 @@
 # goes over one multiplexed SSH connection and you type your password once.
 #
 # Why this exists: the tenant and connection are read out of the running
-# container rather than from a local config. A user created in the wrong Auth0
-# connection looks correct in the dashboard and never appears in the instance,
-# because the sync only pulls identities matching AUTH0_DB_CONNECTION and login
-# matches on auth_id rather than email. That mistake is easy to make by hand and
-# hard to spot afterwards.
-#
-# Automates sections 4 to 10 of the runbook
-# "Adding a user to a bia sqlite MDV instance".
-#
+# container rather than from a local config.
 # The three instances are independent. Run this once per instance.
 
 set -euo pipefail
@@ -321,14 +313,33 @@ grant_out=$(remote bash -s -- \
 set -euo pipefail
 id=$1; app_dir=$2; script=$3; email=$4; project=$5; permission=$6
 
+# The image installs its dependencies into a uv-managed venv under $app_dir and
+# starts the app with `uv run`. Plain `python` on PATH is the base image's
+# interpreter, which cannot import h5py, so mdvtools fails to import before
+# argparse ever sees the subcommand. Pick an interpreter that can import the
+# package rather than assuming which one that is.
+python_bin=$(docker exec -i "$id" sh -c '
+for py in "$0/.venv/bin/python" "$0/.venv/bin/python3" python3 python; do
+    if "$py" -c "import mdvtools" >/dev/null 2>&1; then
+        printf "%s" "$py"
+        exit 0
+    fi
+done
+exit 1' "$app_dir") || {
+    echo "nothing in $id can import mdvtools." >&2
+    echo "Looked for $app_dir/.venv/bin/python, then python3 and python on PATH." >&2
+    echo "List what is there with:  docker exec $id ls $app_dir/.venv/bin" >&2
+    exit 1
+}
+
 if [ -n "$project" ]; then
     docker exec -i "$id" sh -c \
-        'cd "$0" && python "$1" assign --email "$2" --project "$3" --permission "$4"' \
-        "$app_dir" "$script" "$email" "$project" "$permission"
+        'cd "$0" && "$1" "$2" assign --email "$3" --project "$4" --permission "$5"' \
+        "$app_dir" "$python_bin" "$script" "$email" "$project" "$permission"
 else
     docker exec -i "$id" sh -c \
-        'cd "$0" && python "$1" sync' \
-        "$app_dir" "$script"
+        'cd "$0" && "$1" "$2" sync' \
+        "$app_dir" "$python_bin" "$script"
 fi
 REMOTE
 )

--- a/onboard.sh
+++ b/onboard.sh
@@ -104,6 +104,18 @@ if [ -n "$project" ]; then
     esac
 fi
 
+# `$prog host service someone@x.ac.uk owner` reads owner as the project name and
+# leaves the permission at its default, which is not what anyone means by it.
+if [ $# -lt 5 ] && [ -n "$project" ]; then
+    case "$project" in
+        view|edit|owner)
+            die "'$project' is a permission, but it is in the project position.
+The order is:  $prog <user@host> <service> <email> [project] [permission]
+You may mean:  $prog $target $service $email <project> $project
+If a project really is called '$project', name the permission as well." ;;
+    esac
+fi
+
 # Credentials come from the environment so they are never written to the repo.
 [ -n "${M2M_CLIENT_ID:-}" ] || die "set M2M_CLIENT_ID, the Auth0 machine-to-machine client id"
 [ -n "${M2M_CLIENT_SECRET:-}" ] || die "set M2M_CLIENT_SECRET, the machine-to-machine secret"
@@ -318,14 +330,18 @@ id=$1; app_dir=$2; script=$3; email=$4; project=$5; permission=$6
 # interpreter, which cannot import h5py, so mdvtools fails to import before
 # argparse ever sees the subcommand. Pick an interpreter that can import the
 # package rather than assuming which one that is.
-python_bin=$(docker exec -i "$id" sh -c '
+# No -i, and stdin from /dev/null. These blocks reach bia as the script of a
+# `bash -s`, which reads them from stdin, and `docker exec -i` drains whatever
+# stdin still holds. An -i here swallows the rest of this block, so the commands
+# below never run and the block exits 0 having done nothing.
+python_bin=$(docker exec "$id" sh -c '
 for py in "$0/.venv/bin/python" "$0/.venv/bin/python3" python3 python; do
     if "$py" -c "import mdvtools" >/dev/null 2>&1; then
         printf "%s" "$py"
         exit 0
     fi
 done
-exit 1' "$app_dir") || {
+exit 1' "$app_dir" </dev/null) || {
     echo "nothing in $id can import mdvtools." >&2
     echo "Looked for $app_dir/.venv/bin/python, then python3 and python on PATH." >&2
     echo "List what is there with:  docker exec $id ls $app_dir/.venv/bin" >&2
@@ -333,13 +349,13 @@ exit 1' "$app_dir") || {
 }
 
 if [ -n "$project" ]; then
-    docker exec -i "$id" sh -c \
+    docker exec "$id" sh -c \
         'cd "$0" && "$1" "$2" assign --email "$3" --project "$4" --permission "$5"' \
-        "$app_dir" "$python_bin" "$script" "$email" "$project" "$permission"
+        "$app_dir" "$python_bin" "$script" "$email" "$project" "$permission" </dev/null
 else
-    docker exec -i "$id" sh -c \
+    docker exec "$id" sh -c \
         'cd "$0" && "$1" "$2" sync' \
-        "$app_dir" "$python_bin" "$script"
+        "$app_dir" "$python_bin" "$script" </dev/null
 fi
 REMOTE
 )
@@ -367,7 +383,7 @@ rows=$(remote bash -s -- "$container_id" "$email" "$db_path" "$auth_id" <<'REMOT
 set -euo pipefail
 id=$1; email=$2; db_path=$3; auth_id=$4
 
-docker exec -i "$id" python3 -c '
+docker exec "$id" python3 -c '
 import sqlite3, sys
 email, db_path, want_auth_id = sys.argv[1], sys.argv[2], sys.argv[3]
 c = sqlite3.connect(db_path)
@@ -386,7 +402,7 @@ if want_auth_id:
 print("PROJECTS=%d" % len(projects))
 for row in projects:
     print("  project:", row)
-' "$email" "$db_path" "$auth_id"
+' "$email" "$db_path" "$auth_id" </dev/null
 REMOTE
 ) || die "could not read the database on $service"
 

--- a/onboard.sh
+++ b/onboard.sh
@@ -1,0 +1,380 @@
+#!/usr/bin/env bash
+#
+# onboard.sh - add a user to a bia sqlite MDV instance.
+#
+# Runs from a local machine. The containers run on bia, so every container step
+# goes over one multiplexed SSH connection and you type your password once.
+#
+# Why this exists: the tenant and connection are read out of the running
+# container rather than from a local config. A user created in the wrong Auth0
+# connection looks correct in the dashboard and never appears in the instance,
+# because the sync only pulls identities matching AUTH0_DB_CONNECTION and login
+# matches on auth_id rather than email. That mistake is easy to make by hand and
+# hard to spot afterwards.
+#
+# Automates sections 4 to 10 of the runbook
+# "Adding a user to a bia sqlite MDV instance".
+#
+# The three instances are independent. Run this once per instance.
+
+set -euo pipefail
+
+COMPOSE_SERVICES="mdv_sqlite_1 mdv_sqlite_2 mdv_sqlite_3"
+DB_PATH_DEFAULT=/app/mdv/mdv.sqlite3
+APP_DIR=/app/python
+PERMS_SCRIPT=mdvtools/scripts/manage_project_permissions.py
+
+prog=$(basename "$0")
+here=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+
+die() { printf '%s: error: %s\n' "$prog" "$*" >&2; exit 1; }
+info() { printf '==> %s\n' "$*"; }
+warn() { printf 'warning: %s\n' "$*" >&2; }
+
+usage() {
+    cat <<EOF
+Usage: $prog [-y] <user@host> <service> <email> [project] [permission]
+
+Add a user to a bia sqlite MDV instance: create the Auth0 account, sync it into
+the instance database, optionally grant project access, then read the rows back.
+
+Arguments:
+  user@host    ssh target, for example mshaikh@bia.cmd.ox.ac.uk
+  service      instance to onboard onto ($COMPOSE_SERVICES)
+  email        the person's email address
+  project      project to grant access to; omitted means sync only
+  permission   view, edit or owner (default: view)
+
+Options:
+  -y  do not ask for confirmation before touching Auth0
+  -h  show this help
+
+Environment:
+  M2M_CLIENT_ID      Auth0 machine-to-machine client id
+  M2M_CLIENT_SECRET  its secret
+
+  The M2M application needs read:users and create:users on the Management API.
+  Credentials come from the environment so they are never written to the repo.
+
+Examples:
+  $prog mshaikh@bia.cmd.ox.ac.uk mdv_sqlite_1 furquan.nawab@well.ox.ac.uk
+  $prog mshaikh@bia.cmd.ox.ac.uk mdv_sqlite_1 a.person@well.ox.ac.uk cg edit
+EOF
+}
+
+assume_yes=0
+while getopts ':yh' opt; do
+    case "$opt" in
+        y) assume_yes=1 ;;
+        h) usage; exit 0 ;;
+        :) die "option -$OPTARG needs an argument" ;;
+        \?) die "unknown option -$OPTARG (try -h)" ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+if [ $# -lt 3 ] || [ $# -gt 5 ]; then
+    usage >&2
+    exit 2
+fi
+
+target=$1
+service=$2
+email=$3
+project=${4:-}
+permission=${5:-view}
+
+# --- validate the arguments ------------------------------------------------
+
+case "$target" in
+    ?*@?*) ;;
+    *) die "target must look like user@host, got '$target'" ;;
+esac
+
+case "$email" in
+    ?*@?*.?*) ;;
+    *) die "'$email' does not look like an email address" ;;
+esac
+
+case "$permission" in
+    view|edit|owner) ;;
+    *) die "permission must be view, edit or owner, got '$permission'" ;;
+esac
+
+if [ -n "$project" ]; then
+    case "$project" in
+        *[!A-Za-z0-9._-]*) die "invalid project name: '$project'" ;;
+    esac
+fi
+
+# Credentials come from the environment so they are never written to the repo.
+[ -n "${M2M_CLIENT_ID:-}" ] || die "set M2M_CLIENT_ID, the Auth0 machine-to-machine client id"
+[ -n "${M2M_CLIENT_SECRET:-}" ] || die "set M2M_CLIENT_SECRET, the machine-to-machine secret"
+
+# --- find the local pieces we need -----------------------------------------
+
+# auth_invitation only needs `requests` and the Auth0 Management API over
+# HTTPS, so it runs here rather than on bia.
+invitation="$here/python/mdvtools/auth/auth_invitation"
+[ -f "$invitation" ] || die "cannot find auth_invitation at $invitation
+Run this script from its place in the MDV repo."
+
+if [ -x "$here/python/.venv/bin/python" ]; then
+    python="$here/python/.venv/bin/python"
+elif command -v python3 >/dev/null 2>&1; then
+    python=python3
+else
+    die "no python3 on PATH and no venv at python/.venv"
+fi
+
+"$python" -c 'import requests' 2>/dev/null \
+    || die "$python cannot import requests, which auth_invitation needs.
+Install it with:  $python -m pip install requests"
+
+# --- open one ssh connection -----------------------------------------------
+
+# A single multiplexed connection means the password is typed once rather than
+# once per command. BatchMode is deliberately left off so password auth works.
+sock=$(mktemp -u "${TMPDIR:-/tmp}/mdv-ssh-XXXXXX")
+cfg=""
+
+cleanup() {
+    [ -n "$cfg" ] && rm -f "$cfg"
+    [ -S "$sock" ] && ssh -S "$sock" -O exit "$target" >/dev/null 2>&1
+    return 0
+}
+trap cleanup EXIT
+
+info "connecting to $target"
+ssh -f -N -M -S "$sock" -o ControlPersist=60 "$target" \
+    || die "could not open an ssh connection to $target"
+
+remote() { ssh -S "$sock" "$target" "$@"; }
+
+# --- read the tenant and connection out of the container -------------------
+
+info "reading the Auth0 tenant and connection from $service"
+
+container_env=$(remote bash -s -- "$service" <<'REMOTE'
+set -euo pipefail
+service=$1
+
+id=$(docker ps --filter "name=^${service}$" --format '{{.ID}}' | head -1)
+if [ -z "$id" ]; then
+    echo "no running container named $service" >&2
+    docker ps --format '  {{.Names}}' >&2
+    exit 1
+fi
+echo "ID=$id"
+
+# printenv first, then the mounted config, which is where these live when the
+# compose file does not pass them as environment variables.
+for var in AUTH0_DOMAIN AUTH0_DB_CONNECTION MDV_API_ROOT SQLITE_DB_PATH; do
+    value=$(docker exec "$id" printenv "$var" 2>/dev/null || true)
+    if [ -z "$value" ]; then
+        value=$(docker exec "$id" python3 -c '
+import json, os, sys
+want = sys.argv[1].replace("_", "").lower()
+try:
+    cfg = json.load(open(os.environ.get("MDV_USER_CONFIG_PATH", "/config/user_config.json")))
+except Exception:
+    sys.exit(0)
+def walk(node):
+    if isinstance(node, dict):
+        for k, v in node.items():
+            if isinstance(v, str) and k.replace("_", "").lower() == want:
+                return v
+            found = walk(v)
+            if found:
+                return found
+    elif isinstance(node, list):
+        for item in node:
+            found = walk(item)
+            if found:
+                return found
+print(walk(cfg) or "")
+' "$var" 2>/dev/null || true)
+    fi
+    echo "${var}=${value}"
+done
+REMOTE
+) || die "could not read the container environment on $target"
+
+container_id=$(printf '%s\n' "$container_env" | sed -n 's/^ID=//p')
+domain=$(printf '%s\n' "$container_env" | sed -n 's/^AUTH0_DOMAIN=//p')
+connection=$(printf '%s\n' "$container_env" | sed -n 's/^AUTH0_DB_CONNECTION=//p')
+api_root=$(printf '%s\n' "$container_env" | sed -n 's/^MDV_API_ROOT=//p')
+db_path=$(printf '%s\n' "$container_env" | sed -n 's/^SQLITE_DB_PATH=//p')
+db_path=${db_path:-$DB_PATH_DEFAULT}
+
+[ -n "$domain" ] || die "$service does not expose AUTH0_DOMAIN.
+Check it by hand:  ssh $target docker exec $container_id printenv | grep -i auth0"
+[ -n "$connection" ] || die "$service does not expose AUTH0_DB_CONNECTION.
+An account created in the wrong connection never reaches this instance, so this
+script will not guess. Check it by hand:
+  ssh $target docker exec $container_id cat /config/user_config.json | grep -i auth0"
+
+# --- confirm before touching Auth0 -----------------------------------------
+
+if [ -n "$project" ]; then
+    access_desc="$project ($permission)"
+else
+    access_desc="sync only, no project access"
+fi
+
+cat <<EOF
+
+  instance    $service on $target
+  container   $container_id
+  tenant      $domain
+  connection  $connection
+  user        $email
+  access      $access_desc
+
+EOF
+
+if [ "$assume_yes" -eq 0 ] && [ -t 0 ]; then
+    printf 'Create this user in Auth0? [y/N] '
+    read -r reply </dev/tty || reply=""
+    case "$reply" in
+        [yY]|[yY][eE][sS]) ;;
+        *) die "cancelled" ;;
+    esac
+fi
+
+# --- create the Auth0 account ----------------------------------------------
+
+# mktemp creates the file 0600, so the secret is never world-readable, and the
+# EXIT trap removes it whichever way the script ends.
+cfg=$(mktemp)
+cat > "$cfg" <<EOF
+domain=$domain
+client_id=$M2M_CLIENT_ID
+client_secret=$M2M_CLIENT_SECRET
+connection=$connection
+
+$email
+EOF
+
+info "creating $email in connection '$connection'"
+
+# auth_invitation catches per-user errors, prints them and still exits 0, so
+# its exit code is not evidence that the account exists. Check the output too,
+# and treat the database read-back at the end as the real proof.
+invitation_out=$("$python" "$invitation" "$cfg" 2>&1) || {
+    printf '%s\n' "$invitation_out" >&2
+    die "auth_invitation failed"
+}
+printf '%s\n' "$invitation_out"
+
+case "$invitation_out" in
+    *"Failed to process"*)
+        die "auth_invitation could not create $email, see the message above" ;;
+esac
+
+# --- sync the user into the instance, and grant access ---------------------
+
+if [ -n "$project" ]; then
+    info "granting $permission on '$project' to $email"
+else
+    info "syncing users from Auth0 into $service"
+fi
+
+set +e
+grant_out=$(remote bash -s -- \
+    "$container_id" "$APP_DIR" "$PERMS_SCRIPT" "$email" "$project" "$permission" <<'REMOTE' 2>&1
+set -euo pipefail
+id=$1; app_dir=$2; script=$3; email=$4; project=$5; permission=$6
+
+if [ -n "$project" ]; then
+    docker exec -i "$id" sh -c \
+        'cd "$0" && python "$1" assign --email "$2" --project "$3" --permission "$4"' \
+        "$app_dir" "$script" "$email" "$project" "$permission"
+else
+    docker exec -i "$id" sh -c \
+        'cd "$0" && python "$1" sync' \
+        "$app_dir" "$script"
+fi
+REMOTE
+)
+grant_status=$?
+set -e
+
+printf '%s\n' "$grant_out"
+
+if [ "$grant_status" -ne 0 ]; then
+    case "$grant_out" in
+        *"invalid choice: 'sync'"*)
+            die "the image running $service predates the 'sync' subcommand of
+$PERMS_SCRIPT, which exists on the sqlite branches but not on main.
+Rebuild and redeploy the image with ./deploy_bia.sh $target $service, or pass a
+project so the 'assign' path is used instead." ;;
+    esac
+    die "granting access failed on $service (exit $grant_status)"
+fi
+
+# --- read the rows back ----------------------------------------------------
+
+info "reading the database rows back"
+
+rows=$(remote bash -s -- "$container_id" "$email" "$db_path" <<'REMOTE'
+set -euo pipefail
+id=$1; email=$2; db_path=$3
+
+docker exec -i "$id" python3 -c '
+import sqlite3, sys
+email, db_path = sys.argv[1], sys.argv[2]
+c = sqlite3.connect(db_path)
+users = c.execute(
+    "select id,email,auth_id,is_admin from users where email=?", (email,)
+).fetchall()
+projects = c.execute(
+    "select user_id,project_id,can_read,can_write,is_owner from user_projects "
+    "where user_id in (select id from users where email=?)", (email,)
+).fetchall()
+print("USERS=%d" % len(users))
+for row in users:
+    print("  user:", row)
+print("PROJECTS=%d" % len(projects))
+for row in projects:
+    print("  project:", row)
+' "$email" "$db_path"
+REMOTE
+) || die "could not read the database on $service"
+
+printf '%s\n' "$rows"
+
+user_count=$(printf '%s\n' "$rows" | sed -n 's/^USERS=//p')
+project_count=$(printf '%s\n' "$rows" | sed -n 's/^PROJECTS=//p')
+
+if [ "${user_count:-0}" -eq 0 ]; then
+    die "$email is not in the users table on $service.
+The account exists in Auth0 but the sync did not pick it up, which usually means
+it landed in a different connection. Compare the user's Identities in the Auth0
+dashboard against '$connection'."
+fi
+
+if [ -n "$project" ] && [ "${project_count:-0}" -eq 0 ]; then
+    die "$email has no user_projects rows, so the catalog will be empty."
+fi
+
+if [ -z "$project" ] && [ "${project_count:-0}" -eq 0 ]; then
+    warn "$email has no project access yet, so their catalog will be empty.
+Grant some with:  $prog $target $service $email <project> view"
+fi
+
+# --- what the operator still has to do -------------------------------------
+
+printf '\n%s is on %s.\n' "$email" "$service"
+
+if [ -n "$api_root" ]; then
+    host=${target#*@}
+    printf 'Instance URL: https://%s%s\n' "$host" "$api_root"
+fi
+
+cat <<EOF
+
+auth_invitation sets a random password and sends nothing, so tell them to reset
+it from the sign-in page, or set one in the Auth0 dashboard and pass it on out
+of band. Nothing is emailed automatically.
+EOF

--- a/onboard.sh
+++ b/onboard.sh
@@ -188,44 +188,28 @@ if [ -z "$id" ]; then
 fi
 echo "ID=$id"
 
-# printenv first, then the config files, in the order the app itself reads
-# them: mdv_server_app.load_config takes os.getenv(NAME) or config.get(NAME)
-# from dbutils/config.json. MDV_USER_CONFIG_PATH is tried as well because a
-# deployment may mount a config there, though the stock image ships neither
-# /config nor that variable.
+# printenv first, then the application's own config.json, which is what
+# mdv_server_app.load_config does: os.getenv(NAME) or config.get(NAME) against
+# the top level of that file. Only the two Auth0 settings get that fallback.
+# The app reads MDV_API_ROOT and SQLITE_DB_PATH from the environment alone, so
+# a value found in a file would not be the value the app is running with, and
+# reporting it would defeat the point of reading the tenant off the container.
 for var in AUTH0_DOMAIN AUTH0_DB_CONNECTION MDV_API_ROOT SQLITE_DB_PATH; do
     value=$(docker exec "$id" printenv "$var" 2>/dev/null || true)
     if [ -z "$value" ]; then
-        value=$(docker exec "$id" python3 -c '
-import json, os, sys
-want = sys.argv[1].replace("_", "").lower()
-paths = [
-    os.environ.get("MDV_USER_CONFIG_PATH", "/config/user_config.json"),
-    os.path.join(sys.argv[2], "mdvtools", "dbutils", "config.json"),
-]
-def walk(node):
-    if isinstance(node, dict):
-        for k, v in node.items():
-            if isinstance(v, str) and k.replace("_", "").lower() == want:
-                return v
-            found = walk(v)
-            if found:
-                return found
-    elif isinstance(node, list):
-        for item in node:
-            found = walk(item)
-            if found:
-                return found
-for path in paths:
-    try:
-        cfg = json.load(open(path))
-    except Exception:
-        continue
-    found = walk(cfg)
-    if found:
-        print(found)
-        break
-' "$var" "$app_dir" 2>/dev/null || true)
+        case "$var" in
+            AUTH0_DOMAIN|AUTH0_DB_CONNECTION)
+                value=$(docker exec "$id" python3 -c '
+import json, sys
+try:
+    cfg = json.load(open(sys.argv[2]))
+except Exception:
+    sys.exit(0)
+found = cfg.get(sys.argv[1])
+if isinstance(found, str):
+    print(found)
+' "$var" "$app_dir/mdvtools/dbutils/config.json" </dev/null 2>/dev/null || true) ;;
+        esac
     fi
     echo "${var}=${value}"
 done
@@ -239,12 +223,19 @@ api_root=$(printf '%s\n' "$container_env" | sed -n 's/^MDV_API_ROOT=//p')
 db_path=$(printf '%s\n' "$container_env" | sed -n 's/^SQLITE_DB_PATH=//p')
 db_path=${db_path:-$DB_PATH_DEFAULT}
 
+# Both come from the environment or the top level of the app's config.json, and
+# nowhere else. A value nested inside either would not be one the app reads, so
+# an empty result here means the setting is genuinely absent.
+config_json=$APP_DIR/mdvtools/dbutils/config.json
 [ -n "$domain" ] || die "$service does not expose AUTH0_DOMAIN.
-Check it by hand:  ssh $target docker exec $container_id printenv | grep -i auth0"
+Check it by hand:
+  ssh $target docker exec $container_id printenv | grep -i auth0
+  ssh $target docker exec $container_id cat $config_json"
 [ -n "$connection" ] || die "$service does not expose AUTH0_DB_CONNECTION.
 An account created in the wrong connection never reaches this instance, so this
 script will not guess. Check it by hand:
-  ssh $target docker exec $container_id cat /config/user_config.json | grep -i auth0"
+  ssh $target docker exec $container_id printenv | grep -i auth0
+  ssh $target docker exec $container_id cat $config_json"
 
 # --- confirm before touching Auth0 -----------------------------------------
 

--- a/onboard.sh
+++ b/onboard.sh
@@ -91,6 +91,11 @@ case "$target" in
     *) die "target must look like user@host, got '$target'" ;;
 esac
 
+case " $COMPOSE_SERVICES " in
+    *" $service "*) ;;
+    *) die "unknown service '$service'; expected one of: $COMPOSE_SERVICES" ;;
+esac
+
 case "$email" in
     ?*@?*.?*) ;;
     *) die "'$email' does not look like an email address" ;;
@@ -149,15 +154,27 @@ info "connecting to $target"
 ssh -f -N -M -S "$sock" -o ControlPersist=60 "$target" \
     || die "could not open an ssh connection to $target"
 
-remote() { ssh -S "$sock" "$target" "$@"; }
+# ssh joins the command arguments it is given into one string and hands that
+# string to the remote login shell, so anything left unquoted here is shell
+# syntax on bia rather than data. Quoting each argument means an email address
+# or a service name reaches the remote block as the value it is.
+shquote() {
+    local arg quoted=""
+    for arg in "$@"; do
+        quoted="$quoted '${arg//\'/\'\\\'\'}'"
+    done
+    printf '%s' "${quoted# }"
+}
+
+remote() { ssh -S "$sock" "$target" "$(shquote "$@")"; }
 
 # --- read the tenant and connection out of the container -------------------
 
 info "reading the Auth0 tenant and connection from $service"
 
-container_env=$(remote bash -s -- "$service" <<'REMOTE'
+container_env=$(remote bash -s -- "$service" "$APP_DIR" <<'REMOTE'
 set -euo pipefail
-service=$1
+service=$1; app_dir=$2
 
 id=$(docker ps --filter "name=^${service}$" --format '{{.ID}}' | head -1)
 if [ -z "$id" ]; then
@@ -167,18 +184,21 @@ if [ -z "$id" ]; then
 fi
 echo "ID=$id"
 
-# printenv first, then the mounted config, which is where these live when the
-# compose file does not pass them as environment variables.
+# printenv first, then the config files, in the order the app itself reads
+# them: mdv_server_app.load_config takes os.getenv(NAME) or config.get(NAME)
+# from dbutils/config.json. MDV_USER_CONFIG_PATH is tried as well because a
+# deployment may mount a config there, though the stock image ships neither
+# /config nor that variable.
 for var in AUTH0_DOMAIN AUTH0_DB_CONNECTION MDV_API_ROOT SQLITE_DB_PATH; do
     value=$(docker exec "$id" printenv "$var" 2>/dev/null || true)
     if [ -z "$value" ]; then
         value=$(docker exec "$id" python3 -c '
 import json, os, sys
 want = sys.argv[1].replace("_", "").lower()
-try:
-    cfg = json.load(open(os.environ.get("MDV_USER_CONFIG_PATH", "/config/user_config.json")))
-except Exception:
-    sys.exit(0)
+paths = [
+    os.environ.get("MDV_USER_CONFIG_PATH", "/config/user_config.json"),
+    os.path.join(sys.argv[2], "mdvtools", "dbutils", "config.json"),
+]
 def walk(node):
     if isinstance(node, dict):
         for k, v in node.items():
@@ -192,8 +212,16 @@ def walk(node):
             found = walk(item)
             if found:
                 return found
-print(walk(cfg) or "")
-' "$var" 2>/dev/null || true)
+for path in paths:
+    try:
+        cfg = json.load(open(path))
+    except Exception:
+        continue
+    found = walk(cfg)
+    if found:
+        print(found)
+        break
+' "$var" "$app_dir" 2>/dev/null || true)
     fi
     echo "${var}=${value}"
 done
@@ -272,6 +300,13 @@ case "$invitation_out" in
         die "auth_invitation could not create $email, see the message above" ;;
 esac
 
+# auth_invitation prints the new Auth0 id when it creates an account, and prints
+# nothing identifying when one already exists in this connection. Where we have
+# the id, the read-back below matches on it rather than on the email alone, so a
+# stale row for the same address cannot stand in for the identity just created.
+auth_id=$(printf '%s\n' "$invitation_out" \
+    | sed -n 's/^Created user .* with id //p' | tail -1)
+
 # --- sync the user into the instance, and grant access ---------------------
 
 if [ -n "$project" ]; then
@@ -317,13 +352,13 @@ fi
 
 info "reading the database rows back"
 
-rows=$(remote bash -s -- "$container_id" "$email" "$db_path" <<'REMOTE'
+rows=$(remote bash -s -- "$container_id" "$email" "$db_path" "$auth_id" <<'REMOTE'
 set -euo pipefail
-id=$1; email=$2; db_path=$3
+id=$1; email=$2; db_path=$3; auth_id=$4
 
 docker exec -i "$id" python3 -c '
 import sqlite3, sys
-email, db_path = sys.argv[1], sys.argv[2]
+email, db_path, want_auth_id = sys.argv[1], sys.argv[2], sys.argv[3]
 c = sqlite3.connect(db_path)
 users = c.execute(
     "select id,email,auth_id,is_admin from users where email=?", (email,)
@@ -335,10 +370,12 @@ projects = c.execute(
 print("USERS=%d" % len(users))
 for row in users:
     print("  user:", row)
+if want_auth_id:
+    print("MATCHED=%d" % sum(1 for row in users if row[2] == want_auth_id))
 print("PROJECTS=%d" % len(projects))
 for row in projects:
     print("  project:", row)
-' "$email" "$db_path"
+' "$email" "$db_path" "$auth_id"
 REMOTE
 ) || die "could not read the database on $service"
 
@@ -346,12 +383,20 @@ printf '%s\n' "$rows"
 
 user_count=$(printf '%s\n' "$rows" | sed -n 's/^USERS=//p')
 project_count=$(printf '%s\n' "$rows" | sed -n 's/^PROJECTS=//p')
+matched_count=$(printf '%s\n' "$rows" | sed -n 's/^MATCHED=//p')
 
 if [ "${user_count:-0}" -eq 0 ]; then
     die "$email is not in the users table on $service.
 The account exists in Auth0 but the sync did not pick it up, which usually means
 it landed in a different connection. Compare the user's Identities in the Auth0
 dashboard against '$connection'."
+fi
+
+if [ -n "$auth_id" ] && [ "${matched_count:-0}" -eq 0 ]; then
+    die "$email is in the users table on $service, but no row carries the Auth0
+id just created ($auth_id). The rows above belong to an older identity, and
+login matches on auth_id rather than email, so this person still cannot sign in.
+Compare their Identities in the Auth0 dashboard against '$connection'."
 fi
 
 if [ -n "$project" ] && [ "${project_count:-0}" -eq 0 ]; then


### PR DESCRIPTION
These scripts automate them two repeated operations that we do on `bia`. 

Both run from a local machine. The containers run on bia, so each opens one multiplexed SSH connection. The SSH target is the first argument rather than a hardcoded user, so anyone with bia access can run them. Nothing is installed on bia.

## onboard.sh

```
onboard.sh <user@host> <service> <email> [project] [permission]
```

It reads `AUTH0_DOMAIN` and `AUTH0_DB_CONNECTION` out of the running container rather than from a local config, falling back to the mounted `user_config.json`. That is the point of the script: a user created in the wrong Auth0 connection looks correct in the dashboard and never appears in the instance, because the sync only pulls identities matching the connection and login matches on `auth_id` rather than email.

`auth_invitation` runs locally, since it only needs `requests` and the Management API over HTTPS. It wraps each user in a try/except, prints `Failed to process` and still exits 0, so the script checks its output rather than trusting the exit code, and treats the `users` and `user_projects` read-back at the end as the real proof.

The M2M credentials come from `M2M_CLIENT_ID` and `M2M_CLIENT_SECRET` in the environment. The temporary config holding the secret is created 0600 by `mktemp` and removed by an EXIT trap.

`manage_project_permissions.py::sync` exists on the sqlite branches but not on main. The script calls it inside the container, so it works against the deployed image. It fails gracefully by raising an error if `sync` function isn't found. 

## deploy_bia.sh

```
deploy_bia.sh [-B] [-k] <user@host> [service ...]
```

Build, save, transfer, checksum, load, recreate, verify.

Only the named services are recreated, defaulting to the three sqlite instances, so `mdv_public` is never swept up. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated deployment for BIA SQLite services, including architecture validation, image transfer, selective service updates, and post-deployment verification.
  - Added deployment options to skip image builds, retain artifacts, and display help.
  - Added onboarding validation for supported services and improved configuration discovery.
  - Added confirmation that newly created accounts synchronize correctly.

- **Bug Fixes**
  - Improved handling and diagnostics for invalid inputs, deployment failures, missing configuration, and unsuccessful account synchronization.
  - Improved reliability when granting permissions and reading account information during onboarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->